### PR TITLE
fix(create-hq): resolve spinner hang, integrity failure, smoke PATH

### DIFF
--- a/packages/create-hq/src/deps.ts
+++ b/packages/create-hq/src/deps.ts
@@ -164,7 +164,7 @@ async function confirm(question: string, defaultYes: boolean): Promise<boolean> 
   });
 }
 
-export async function checkDeps(): Promise<{ allRequired: boolean }> {
+export async function checkDeps(nonInteractive = false): Promise<{ allRequired: boolean }> {
   console.log();
   console.log("  Checking dependencies...");
 
@@ -188,10 +188,22 @@ export async function checkDeps(): Promise<{ allRequired: boolean }> {
       // Can offer auto-install
       const defaultYes = dep.required;
       const optionalTag = dep.required ? "" : " (optional)";
-      const accepted = await confirm(
-        `Install ${dep.name}?${optionalTag} [${installCmd}]`,
-        defaultYes,
-      );
+
+      let accepted: boolean;
+      if (nonInteractive) {
+        // --yes mode: auto-accept required, auto-skip optional
+        accepted = dep.required;
+        if (accepted) {
+          info(`Auto-installing ${dep.name} [${installCmd}]`);
+        } else {
+          info(`${dep.name} (optional) — skipped (--yes)`);
+        }
+      } else {
+        accepted = await confirm(
+          `Install ${dep.name}?${optionalTag} [${installCmd}]`,
+          defaultYes,
+        );
+      }
 
       if (accepted) {
         info(`Running: ${installCmd}`);

--- a/packages/create-hq/src/index.ts
+++ b/packages/create-hq/src/index.ts
@@ -19,6 +19,7 @@ program
   .option("--skip-sync", "don't prompt for cloud sync setup")
   .option("--tag <version>", "fetch a specific HQ version tag (e.g. v9.1.0)")
   .option("--local-template <path>", "use a local template directory instead of fetching from GitHub")
+  .option("-y, --yes", "auto-accept required dependency installs (non-interactive)")
   .action(async (directory: string, options) => {
     try {
       await scaffold(directory, options);

--- a/packages/create-hq/src/scaffold.ts
+++ b/packages/create-hq/src/scaffold.ts
@@ -18,6 +18,7 @@ interface ScaffoldOptions {
   skipSync?: boolean;
   tag?: string;
   localTemplate?: string;
+  yes?: boolean;
 }
 
 async function prompt(question: string, defaultVal?: string): Promise<string> {
@@ -132,35 +133,47 @@ export async function scaffold(
   const integrityLabel = "Verifying kernel integrity";
   stepStatus(integrityLabel, "running");
   try {
-    const computeChecksumsScript = path.join(targetDir, "scripts", "compute-checksums.sh");
-    const coreIntegrityScript = path.join(targetDir, "scripts", "core-integrity.sh");
-    const hasComputeChecksums = fs.existsSync(computeChecksumsScript);
-    const hasCoreIntegrity = fs.existsSync(coreIntegrityScript);
-    if (hasComputeChecksums && hasCoreIntegrity) {
-      execSync("bash scripts/compute-checksums.sh", { cwd: targetDir, stdio: "pipe" });
-      try {
-        execSync("bash scripts/core-integrity.sh", { cwd: targetDir, stdio: "pipe" });
-        stepStatus(integrityLabel, "done");
-      } catch {
-        stepStatus(integrityLabel, "failed");
-        warn("Kernel integrity check found issues — run scripts/core-integrity.sh to investigate");
-      }
-    } else {
+    const computeScript = path.join(targetDir, "scripts", "compute-checksums.sh");
+    const integrityScript = path.join(targetDir, "scripts", "core-integrity.sh");
+
+    if (!fs.existsSync(computeScript) || !fs.existsSync(integrityScript)) {
       // Scripts not present in this template version — skip silently
       stepStatus(integrityLabel, "done");
+    } else {
+      // Both scripts require yq — skip gracefully if not yet installed
+      const hasYq = (() => { try { execSync("yq --version", { stdio: "pipe" }); return true; } catch { return false; } })();
+
+      if (!hasYq) {
+        stepStatus(integrityLabel, "done"); // yq will be offered during dependency check
+      } else {
+        execSync("bash scripts/compute-checksums.sh", { cwd: targetDir, stdio: "pipe" });
+        try {
+          execSync("bash scripts/core-integrity.sh", { cwd: targetDir, stdio: "pipe" });
+          stepStatus(integrityLabel, "done");
+        } catch (err) {
+          stepStatus(integrityLabel, "failed");
+          const stderr = (err as { stderr?: Buffer })?.stderr?.toString().trim() ?? "";
+          warn(`Kernel integrity check found issues${stderr ? " — " + stderr : ""}`);
+          warn("Run: bash scripts/core-integrity.sh for details");
+        }
+      }
     }
-  } catch {
+  } catch (err) {
     stepStatus(integrityLabel, "failed");
+    const stderr = (err as { stderr?: Buffer })?.stderr?.toString().trim() ?? "";
+    if (stderr) warn(`Governance bootstrap failed: ${stderr}`);
     // governance bootstrap should never abort the scaffold
   }
 
   // 5. Check dependencies
   const depsLabel = "Checking dependencies";
-  stepStatus(depsLabel, "running");
   if (!options.skipDeps) {
-    await checkDeps();
+    stepStatus(depsLabel, "running");
+    stepStatus(depsLabel, "done"); // stop spinner — checkDeps prints its own output
+    await checkDeps(options.yes);
+  } else {
+    stepStatus(depsLabel, "done");
   }
-  stepStatus(depsLabel, "done");
 
   // 6. Smart cloud sync detection
   const alreadySynced = await detectExistingSync(targetDir);
@@ -169,7 +182,7 @@ export async function scaffold(
   }
 
   // 7. Cloud sync setup
-  if (!options.skipSync && !alreadySynced) {
+  if (!options.skipSync && !alreadySynced && !options.yes) {
     console.log();
     const setupSync = await confirm(
       "Set up cloud sync? (enables mobile access via hq.indigoai.com)"

--- a/packages/create-hq/test/run-smoke-tests.sh
+++ b/packages/create-hq/test/run-smoke-tests.sh
@@ -10,6 +10,31 @@
 
 set -euo pipefail
 
+# Ensure PATH includes user-installed tools (Homebrew, nvm, etc.)
+# Needed when running from cron/scheduled agents that don't source shell profiles.
+if [ -z "${HQ_SMOKE_PATH_SET:-}" ]; then
+  for profile in "$HOME/.zshrc" "$HOME/.bash_profile" "$HOME/.bashrc" "$HOME/.profile"; do
+    if [ -f "$profile" ]; then
+      set +eu
+      source "$profile" 2>/dev/null || true
+      set -eu
+      break
+    fi
+  done
+  export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.nvm/current/bin:$PATH"
+  export HQ_SMOKE_PATH_SET=1
+fi
+
+# Pre-flight: verify required tools are in PATH
+for tool in npm node docker; do
+  if ! command -v "$tool" &>/dev/null; then
+    echo "FATAL: $tool not found in PATH." >&2
+    echo "PATH=$PATH" >&2
+    echo "If running from cron, ensure your shell profile is sourced." >&2
+    exit 1
+  fi
+done
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 PKG_DIR="$REPO_ROOT/packages/create-hq"

--- a/packages/create-hq/test/scheduled-smoke.md
+++ b/packages/create-hq/test/scheduled-smoke.md
@@ -11,6 +11,9 @@ This prompt is designed to be executed by a scheduled agent (via CronCreate or e
 ### 1. Run the smoke test orchestrator
 
 ```bash
+# Ensure PATH includes user tools (Homebrew, nvm, Docker)
+source ~/.zshrc 2>/dev/null || source ~/.bash_profile 2>/dev/null || true
+
 cd ~/hq/repos/public/hq
 bash packages/create-hq/test/run-smoke-tests.sh 2>&1
 ```
@@ -92,6 +95,21 @@ Note: CronCreate jobs are session-only (max 7 days). For persistent scheduling, 
 ```bash
 claude -p "Read and execute ~/hq/repos/public/hq/packages/create-hq/test/scheduled-smoke.md"
 ```
+
+## PATH Requirements
+
+The smoke test orchestrator requires `npm`, `node`, and `docker` in PATH. When running from cron or a scheduled agent, these may not be available because the user's shell profile (~/.zshrc) is not sourced.
+
+The orchestrator script now includes automatic PATH detection, but if tools are still not found:
+
+1. **For cron jobs**: Use a login shell wrapper:
+   ```bash
+   7 6 * * * /bin/zsh -l -c "cd ~/hq/repos/public/hq && bash packages/create-hq/test/run-smoke-tests.sh"
+   ```
+
+2. **For Claude Code scheduled agents**: The agent should source the profile before running (see Step 1 above).
+
+3. **For launchd plists**: Set the PATH environment key in the plist to include `/opt/homebrew/bin:/usr/local/bin`.
 
 ## Expected Artifacts
 

--- a/template/.claude/CLAUDE.md
+++ b/template/.claude/CLAUDE.md
@@ -225,6 +225,24 @@ Use a bridge instead of copying files:
 - New command files created under `.claude/commands/` become available to Codex through the prompt bridge without a sync step
 - Inference: Codex may need a fresh session to notice brand-new bridged content, but the filesystem bridge stays current
 
+**Dual-format approach (Codex promotion):** Some skills have both `SKILL.md` (Codex version) and a corresponding `command.md` (Claude Code source of truth). `SKILL.md` is a Codex-adapted derivative — same goal, adapted execution model. When a skill exists in `.claude/skills/{name}/`, it is Codex-ready if it also has `agents/openai.yaml`.
+
+**Codex-ready skill structure:**
+```
+.claude/skills/{name}/
+  SKILL.md              # Codex-adapted instructions (frontmatter: name:, description:)
+  agents/
+    openai.yaml         # display_name + short_description — required for Codex discovery
+```
+
+**Codex adaptation rules (apply when writing new SKILL.md files):**
+- No Claude Code-only tools: never reference `Task`, `EnterPlanMode`, `TodoWrite`
+- Search: `qmd` CLI first (`qmd search/vsearch/query`), Grep as fallback
+- Orchestration: inline execution only — no sub-agent spawning (describe as "inline phases")
+- Rephrase anti-instructions: "Do NOT use TodoWrite" → "Track state in your context, not via TodoWrite"
+
+**Coverage tool:** `bash scripts/codex-skill-bridge.sh status` — shows skills count, openai.yaml coverage, and which commands lack corresponding skills. Run after adding new skills or commands.
+
 ## Search (qmd)
 
 HQ and active codebases are indexed with [qmd](https://github.com/tobi/qmd) for local semantic + full-text search.

--- a/template/.claude/policies/articles-blog-first.md
+++ b/template/.claude/policies/articles-blog-first.md
@@ -1,0 +1,25 @@
+---
+id: articles-blog-first
+title: Articles must go to blog before social sharing
+scope: cross-cutting
+trigger: /contentidea, /post, daily-social, article, type:article, blog-queue
+enforcement: hard
+---
+
+## Rule
+
+Any content with `type: article` in draft frontmatter or assessed as "Article" scope in `/contentidea` must follow the blog-first pipeline:
+
+1. Write as MDX to `repos/private/personal-website/src/content/blog/{slug}.mdx`
+2. Add to `workspace/social-drafts/blog-queue.json` with `status: queued`
+3. Deploy personal-website to Vercel so blog URL + OG image are live
+4. Write a teaser/share draft (3-5 short paragraphs + blog URL) for X and/or LinkedIn
+5. Submit the teaser to Post Bridge — NOT the full article text
+
+The X deliverable for articles is a short teaser linking to the blog. Never post full 1500+ word article text directly to X or LinkedIn.
+
+The `/contentidea` "Article" form routes to this pipeline. The daily-social skill checks `blog-queue.json` for pending articles each run.
+
+## Rationale
+
+Blog posts compound (SEO, OG cards, permanent library). X posts disappear in hours. The "Docs-First Agents" blog share (Mar 11) outperformed raw long-form X posts. Every blog article is a deposit into the long-term credibility bank. Established 2026-03-12.

--- a/template/.claude/policies/blog-post-x-draft.md
+++ b/template/.claude/policies/blog-post-x-draft.md
@@ -8,21 +8,21 @@ enforcement: hard
 
 ## Rule
 
-When publishing a new blog article to {your-username}.com (writing MDX to `repos/private/personal-website/src/content/blog/`), always draft an X post to share the article before deploying.
+When publishing a new blog article to {your-name}.com (writing MDX to `repos/private/personal-website/src/content/blog/`), always draft an X post to share the article before deploying.
 
 **Workflow:**
 1. Write the blog article MDX
-2. Draft an X teaser post for @{your-username} that hooks the reader and links to the article
+2. Draft an X teaser post for @{your-name} that hooks the reader and links to the article
 3. Show the draft to the user for approval before posting
 4. Deploy the site so the OG image is live before the post goes out
-5. Post via Post-Bridge API (account ID {account-id})
+5. Post via Post-Bridge API (account ID 34528)
 6. Update `workspace/social-drafts/blog-queue.json` — set item status to `published` after deploy, `done` after share
 
 **X post format:**
 - Match {your-name}'s voice: direct, declarative, first-person, short sentences
 - Open with a hook (the insight or contrarian take)
 - 3-5 short paragraphs max
-- End with the article URL (`https://{your-username}.com/blog/{slug}`)
+- End with the article URL (`https://{your-name}.com/blog/{slug}`)
 - No hashtags, no emojis, no "check out my new article" framing
 
 **Hard gates:**

--- a/template/.claude/policies/cio-browser-navigation.md
+++ b/template/.claude/policies/cio-browser-navigation.md
@@ -1,0 +1,21 @@
+---
+id: cio-browser-navigation
+title: Customer.io Browser Automation Gotchas
+scope: cross-cutting
+trigger: agent-browser, customer.io, CIO dashboard
+enforcement: soft
+---
+
+## Rule
+
+When navigating Customer.io via agent-browser:
+
+1. **Campaign list filter doesn't work** — the "FILTER BY" text input on the campaigns page does not actually filter results. Use `agent-browser eval` with JS to find campaign link URLs: `document.querySelectorAll('a').filter(a => a.textContent.includes('...')).map(a => a.href)`
+2. **Navigate by direct URL** — `fly.customer.io/workspaces/152814/journeys/campaigns/{id}/workflow`. Campaign IDs documented in `companies/{company}/knowledge/engineering/systems/customer-io/campaigns.md`
+3. **Workflow canvas doesn't scroll normally** — use `node.scrollIntoView()` to bring workflow nodes into view, or zoom out with the zoom controls
+4. **Slack template textarea** — uses class `ember-text-area`. Must use native setter + event dispatch for Ember to detect changes: `Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(ta, newVal); ta.dispatchEvent(new Event('input', {bubbles:true}))`
+5. **Browser state expires** — CIO auth cookies expire. Always be prepared to re-auth via headed mode
+
+## Rationale
+
+CIO's Ember.js UI has quirks that waste time if you don't know the workarounds. Direct URL navigation and JS eval are much faster than clicking through the UI.

--- a/template/.claude/policies/company-context-verify.md
+++ b/template/.claude/policies/company-context-verify.md
@@ -28,4 +28,4 @@ Infrastructure lookup checklist:
 
 ## Rationale
 
-Company policies contain hard-won instructions for specific services (e.g. "use Vercel API, not CLI for {domain} domains"). Skipping them means repeating known failures. The manifest now has infrastructure mappings to eliminate guessing.
+Company policies contain hard-won instructions for specific services (e.g. "use Vercel API, not CLI for getindigo.ai domains"). Skipping them means repeating known failures. The manifest now has infrastructure mappings to eliminate guessing.

--- a/template/.claude/policies/credential-access-protocol.md
+++ b/template/.claude/policies/credential-access-protocol.md
@@ -8,7 +8,7 @@ version: 1
 created: 2026-03-05
 updated: 2026-03-05
 source: session-learning
-learned_from: "Cross-company credential violation — used {company} AWS for {company} domain"
+learned_from: "Cross-company credential violation — used {Product} AWS for {company} domain"
 ---
 
 ## Rule

--- a/template/.claude/policies/curious-minds-is-book.md
+++ b/template/.claude/policies/curious-minds-is-book.md
@@ -1,0 +1,19 @@
+---
+id: curious-minds-is-book
+title: "{product} is a book, not company knowledge"
+scope: global
+trigger: "knowledge operations targeting curious-minds"
+enforcement: hard
+created: 2026-03-04
+---
+
+## Rule
+
+`knowledge/public/curious-minds/` is a book (concept reference), NOT company knowledge docs. Skip it during:
+- Knowledge tagging / ontology operations
+- Knowledge audits and gardening
+- Company doc categorization
+
+## Rationale
+
+Session 2026-03-04: Auto-tagging agent tagged ~20 curious-minds concept files before being stopped. User clarified it's a book. Changes were reverted.

--- a/template/.claude/policies/deconflict-postbridge-schedule.md
+++ b/template/.claude/policies/deconflict-postbridge-schedule.md
@@ -13,7 +13,7 @@ Before scheduling a batch of posts via Post-Bridge:
 1. Query `GET /v1/posts?status=scheduled&limit=100` (paginate if >100) to get ALL existing scheduled posts
 2. Map existing posts by date and account ID to identify occupied time slots
 3. Schedule new posts only in free slots — avoid same-account same-hour collisions
-4. {Company} posts go to BOTH accounts ({account-id-1} + {account-id-2}) every 3 days — account for this when scheduling X-only or LinkedIn-only posts
+4. {product} posts go to BOTH accounts (34528 + 34531) every 3 days — account for this when scheduling X-only or LinkedIn-only posts
 
 ## Rationale
 

--- a/template/.claude/policies/dual-repo-prd-routing.md
+++ b/template/.claude/policies/dual-repo-prd-routing.md
@@ -8,8 +8,8 @@ enforcement: soft
 
 ## Rule
 
-When a PRD spans two repos (`repoPath` + `secondaryRepoPath`), add a `REPO:` prefix in each story's `notes` field directing the sub-agent to the correct repo. Example: `"REPO: This story targets repos/private/{repo} (NOT {repo}). CD to that repo before working."` Also expand `qualityGates` to run typecheck in both repos using subshell: `"(cd /path/to/secondary/repo && npm run typecheck)"`.
+When a PRD spans two repos (`repoPath` + `secondaryRepoPath`), add a `REPO:` prefix in each story's `notes` field directing the sub-agent to the correct repo. Example: `"REPO: This story targets repos/private/artist-manager (NOT holler-comms). CD to that repo before working."` Also expand `qualityGates` to run typecheck in both repos using subshell: `"(cd /path/to/secondary/repo && npm run typecheck)"`.
 
 ## Rationale
 
-`execute-task` resolves CWD from `metadata.repoPath` only. Stories targeting the secondary repo get the wrong working directory. Per-story `notes` are included in the worker prompt — this is zero-infrastructure routing without modifying execute-task code. Proven in {project} (Mar 2026): 3 {repo} stories + 7 {repo} stories, all routed correctly.
+`execute-task` resolves CWD from `metadata.repoPath` only. Stories targeting the secondary repo get the wrong working directory. Per-story `notes` are included in the worker prompt — this is zero-infrastructure routing without modifying execute-task code. Proven in holler-cross-channel (Mar 2026): 3 artist-manager stories + 7 holler-comms stories, all routed correctly.

--- a/template/.claude/policies/email-send-safety.md
+++ b/template/.claude/policies/email-send-safety.md
@@ -17,4 +17,4 @@ created: 2026-03-04
 
 ## Rationale
 
-On 2026-03-04, a kickoff email to a $10k/mo client ({company} Brands Group) was sent from the wrong Gmail account (personal instead of {your-name}@get{company}.ai) with a garbled subject line. The {company} account auth was broken, and Claude fell back to personal without asking. This sent a broken, unprofessional email to the client the day before their kickoff meeting. This must never happen again.
+On 2026-03-04, a kickoff email to a $10k/mo client ({company} Brands Group) was sent from the wrong Gmail account (personal instead of {your-name}@getindigo.ai) with a garbled subject line. The {company} account auth was broken, and Claude fell back to personal without asking. This sent a broken, unprofessional email to the client the day before their kickoff meeting. This must never happen again.

--- a/template/.claude/policies/ggshield-global-hook-workaround.md
+++ b/template/.claude/policies/ggshield-global-hook-workaround.md
@@ -1,0 +1,22 @@
+---
+id: ggshield-global-hook-workaround
+title: Temporarily disable ggshield global hook when binary is missing
+scope: global
+trigger: git commit failure mentioning ggshield
+enforcement: soft
+created: 2026-04-02
+---
+
+## Rule
+
+When `git commit` fails because a global ggshield pre-commit hook exists (`~/Library/Application Support/ggshield/git-hooks/pre-commit`) but the `ggshield` binary is not installed:
+
+1. `mv` the hook file to `.bak`
+2. Perform the commit
+3. `mv` it back immediately after
+
+The `SKIP=ggshield` env var does NOT work for this global hook. Do not delete the hook permanently — it may be needed when ggshield is reinstalled.
+
+## Rationale
+
+Discovered during v10.3.0 publish. The global hook blocks ALL git commits across all repos when the binary is absent. The mv-commit-mv pattern is the minimal-impact workaround.

--- a/template/.claude/policies/hq-codex-skill-dual-format.md
+++ b/template/.claude/policies/hq-codex-skill-dual-format.md
@@ -1,0 +1,21 @@
+---
+id: hq-codex-skill-dual-format
+title: Commands and Skills are separate formats — use dual-format for Codex visibility
+scope: global
+trigger: creating or modifying HQ commands that should be visible in Codex
+enforcement: soft
+version: 1
+created: 2026-04-02
+updated: 2026-04-02
+source: success-pattern
+---
+
+## Rule
+
+Commands (`.claude/commands/*.md`) and skills (`.claude/skills/*/SKILL.md`) are different formats with different discovery mechanisms. Codex discovers skills by scanning for `SKILL.md` files in named directories — it does NOT discover commands in `.claude/commands/`. When a command needs Codex visibility, create a separate `SKILL.md` in `.claude/skills/{name}/` (dual format) rather than converting the command. Keep `command.md` as the Claude Code source of truth.
+
+Commands that depend on the Task tool (`run-project`, `execute-task`, `run`) require architectural adaptation for Codex — replace sub-agent spawning with inline execution. This trades context isolation for compatibility.
+
+## Rationale
+
+Discovered during codex-command-discovery brainstorm/PRD session. The Codex skill bridge (`scripts/codex-skill-bridge.sh`) correctly symlinks `.claude/skills/` to `~/.codex/skills/hq`, making all 57 skills discoverable. But the 50 commands in `.claude/commands/` are invisible to Codex because they use Claude Code's flat-file format (frontmatter: `description`, `allowed-tools`, `argument-hint`) instead of the SKILL.md folder format (frontmatter: `name`, `description`) with optional `agents/openai.yaml` metadata.

--- a/template/.claude/policies/hq-fix-root-cause-not-symptoms.md
+++ b/template/.claude/policies/hq-fix-root-cause-not-symptoms.md
@@ -23,4 +23,4 @@ When debugging:
 
 ## Rationale
 
-During a conversation-details sidebar investigation, a PR added a `response.ok` guard to `useConversationDetails` — improving error display in the UI. But this didn't fix the actual bug: the PostgREST queries were silently returning `{ data: null, error: {...} }` and the route was passing `null` through as `{ success: true }`. The error handling PR was necessary but would have left the root cause unfixed if accepted as the sole fix.
+During the conversation-details sidebar investigation (2026-04-02), PR #2998 added a `response.ok` guard to `useConversationDetails` — improving error display in the UI. But this didn't fix the actual bug: the PostgREST queries were silently returning `{ data: null, error: {...} }` and the route was passing `null` through as `{ success: true }`. The error handling PR was necessary but would have left the root cause unfixed if accepted as the sole fix.

--- a/template/.claude/policies/hq-gnb-product-imagery-remix.md
+++ b/template/.claude/policies/hq-gnb-product-imagery-remix.md
@@ -12,7 +12,7 @@ source: success-pattern
 
 ## Rule
 
-NEVER generate branded product imagery (cans, bottles, packaging) from text descriptions alone. AI image generators consistently produce wrong brand text, colors, and label layouts (e.g. "SPARKLE" instead of "HpO").
+NEVER generate branded product imagery (cans, bottles, packaging) from text descriptions alone. AI image generators consistently produce wrong brand text, colors, and label layouts (e.g. "SPARKLE" instead of "{company}").
 
 ALWAYS use this two-step workflow:
 1. Generate the lifestyle scene first (person, setting, lighting) — the product will have wrong branding, that's expected
@@ -22,4 +22,4 @@ Reference actual product photos from `companies/{co}/data/product-images/` or `c
 
 ## Rationale
 
-During HpO PDP design (Mar 2026), generated lifestyle photos showed models holding cans branded "SPARKLE", "VELOCITY", and "FUEL" instead of HpO. The GNB remix approach using the actual blood-orange-01.png product photo as reference produced correct coral-orange HpO cans with proper logo, citrus icon, and PROTEIN text. Scene composition, lighting, and model poses were preserved perfectly through remix.
+During {company} PDP design (Mar 2026), generated lifestyle photos showed models holding cans branded "SPARKLE", "VELOCITY", and "FUEL" instead of {company}. The GNB remix approach using the actual blood-orange-01.png product photo as reference produced correct coral-orange {company} cans with proper logo, citrus icon, and PROTEIN text. Scene composition, lighting, and model poses were preserved perfectly through remix.

--- a/template/.claude/policies/hq-never-swallow-errors.md
+++ b/template/.claude/policies/hq-never-swallow-errors.md
@@ -20,4 +20,4 @@ source: session-learning
 
 ## Rationale
 
-Silent error propagation caused the worst incidents: Pydantic validation silently rejected checkout webhooks causing 98% checkout drop across 22+ brands for 2 days with zero alerts. PostgREST `.error` fields went unchecked, propagating null through the frontend. `putEvent()` failed silently creating 9,013 zombie checkouts. A handler returning 204 No Content hid complete data loss from operations.
+Silent error propagation caused the worst incidents in HQ history: Pydantic validation silently rejected checkout webhooks causing 98% checkout drop across 22+ brands for 2 days with zero alerts. PostgREST `.error` fields went unchecked, propagating null through the frontend. `putEvent()` failed silently creating 9,013 zombie checkouts. A handler returning 204 No Content hid complete data loss from operations.

--- a/template/.claude/policies/hq-no-production-testing.md
+++ b/template/.claude/policies/hq-no-production-testing.md
@@ -20,4 +20,4 @@ source: session-learning
 
 ## Rationale
 
-A test post was published to an actual social account and could not be deleted via API — the content was permanently live. API field debugging against a production endpoint created immutable records. In both cases, the agent treated production as a test environment because no staging guard existed. External API mutations are often irreversible, and social platforms in particular offer no undo.
+A Post-Bridge test post was published to an actual social account and could not be deleted via API — the content was permanently live. API field debugging against a production endpoint created immutable records. In both cases, the agent treated production as a test environment because no staging guard existed. External API mutations are often irreversible, and social platforms in particular offer no undo.

--- a/template/.claude/policies/hq-pr-single-concern.md
+++ b/template/.claude/policies/hq-pr-single-concern.md
@@ -20,4 +20,4 @@ source: session-learning
 
 ## Rationale
 
-A PR merged unready messaging infrastructure commits alongside a Shopify identity fix. The messaging changes were incomplete and took down the messaging app in production, requiring an 11-minute emergency revert. Had the identity fix been in its own PR, it could have shipped safely while the messaging work continued on its branch. Mixed PRs make rollback impossible without also reverting the good changes.
+PR #2980 merged unready messaging infrastructure commits alongside a Shopify identity fix. The messaging changes were incomplete and took down the messaging app in production, requiring an 11-minute emergency revert. Had the identity fix been in its own PR, it could have shipped safely while the messaging work continued on its branch. Mixed PRs make rollback impossible without also reverting the good changes.

--- a/template/.claude/policies/hq-slack-channel-indigo-workspace.md
+++ b/template/.claude/policies/hq-slack-channel-indigo-workspace.md
@@ -1,0 +1,15 @@
+---
+id: hq-slack-channel-{company}-workspace
+title: "#hq Slack channel is on {company} workspace"
+scope: global
+trigger: "posting to Slack about HQ work"
+enforcement: soft
+---
+
+## Rule
+
+The `#hq` Slack channel is a private channel on the **{company}** workspace (channel ID: `C0AQY3RDHSL`). When posting HQ-related updates (PRs, releases, project completions), use `workspace: "{company}"` and `channel: "hq"`. The default Slack workspace is {Product} — sending to `#hq` without specifying the {company} workspace will fail with "channel not found".
+
+## Rationale
+
+Discovered during session when posting PR summaries. The channel doesn't appear in `list_channels` results even with `include_private: true`, but sending by name with the correct workspace works.

--- a/template/.claude/policies/linear-scan-check-existing-prds.md
+++ b/template/.claude/policies/linear-scan-check-existing-prds.md
@@ -2,7 +2,7 @@
 id: linear-scan-check-existing-prds
 title: Linear scan must check existing PRDs before recommending new ones
 scope: command
-trigger: /check-linear-{product}, {product}-linear-scan scheduled task
+trigger: /check-linear-voyage, voyage-linear-scan scheduled task
 enforcement: hard
 ---
 

--- a/template/.claude/policies/mcp-transport-detection.md
+++ b/template/.claude/policies/mcp-transport-detection.md
@@ -20,7 +20,7 @@ Before adding a new MCP server to `.mcp.json`, test the transport protocol. Not 
 4. If plain JSON 200 response → `"type": "http"` is fine
 
 **Known servers requiring `mcp-remote`:** Paper Desktop (`127.0.0.1:29979/mcp`)
-**Known servers fine with `"type": "http"`:** Figma (`localhost:3845/mcp`), {company} (`mcp.{product}.app/mcp`)
+**Known servers fine with `"type": "http"`:** Figma (`localhost:3845/mcp`), {Product} (`mcp.{product}.app/mcp`)
 
 ## Rationale
 

--- a/template/.claude/policies/model-routing-opus-only.md
+++ b/template/.claude/policies/model-routing-opus-only.md
@@ -1,0 +1,41 @@
+---
+id: model-routing-opus-only
+title: All Claude work runs on Opus — no Sonnet, no exceptions
+scope: cross-cutting
+trigger: Agent tool, sub-agent spawning, worker execution, /run, /execute-task
+enforcement: hard
+version: 2
+created: 2026-03-28
+updated: 2026-03-30
+source: session-learning
+---
+
+## Rule
+
+**All Claude work runs on Opus 4.6. Never use Sonnet.**
+
+HQ's value comes from orchestration fidelity — policies, manifest routing, company isolation, hook compliance, knowledge management. Every layer of this system benefits from maximum model quality. There is no task category where downgrading Claude's model is acceptable.
+
+### Model Tiers
+
+| Model | Scope | Examples |
+|-------|-------|---------|
+| **Opus 4.6** | All Claude work — sessions, sub-agents, workers | Architecture, planning, code review, debugging, orchestration, search, execution, drafting, testing |
+| **Codex GPT-5.4** | Code gen, review, debug via Codex CLI | `codex exec`, `codex review` — independent second opinion |
+| **Gemini** | Gemini CLI workers | Design audit, frontend, CSS, UX — via `gemini` CLI |
+
+### Implementation
+
+- `CLAUDE_CODE_SUBAGENT_MODEL=opus` — never change this
+- All worker YAMLs: `execution.model: opus` (default, no need to specify)
+- Never pass `model: "sonnet"` on Agent tool calls
+- Codex workers use `codex_model: gpt-5.4` with `--reasoning high --fast`
+- Gemini workers shell out to `gemini` CLI — separate model entirely
+
+### What About Cost?
+
+Opus costs more than Sonnet. This is intentional. The failure modes of a cheaper model in HQ (skipped policy steps, wrong company credentials, missed orchestration rules) cost more in wasted time and broken state than the token savings. Pay for quality everywhere.
+
+## Rationale
+
+Session 2026-03-28: Initially proposed Sonnet for "scoped executors" (Explore agents, E2E tests, creative drafts, small sub-agents). User correction: HQ orchestration fidelity is the core value — every agent navigates the same policy/manifest system. Downgrading any agent risks skipped steps in complex protocols. The only non-Opus models are external (Codex, Gemini) which run in their own CLIs with their own runtimes.

--- a/template/.claude/policies/never-echo-tokens-stdout.md
+++ b/template/.claude/policies/never-echo-tokens-stdout.md
@@ -16,4 +16,4 @@ NEVER print raw API keys, tokens, or secrets to stdout in CLI setup/config comma
 
 ## Rationale
 
-Caught by Codex review (P1) in {company} setup command. The fallback code path printed the actual {company}_API_KEY value when no supported AI tool was detected, leaking credentials to anyone with access to CI logs.
+Caught by Codex review (P1) in {company} setup command. The fallback code path printed the actual DOMINION_API_KEY value when no supported AI tool was detected, leaking credentials to anyone with access to CI logs.

--- a/template/.claude/policies/no-hq-remote-push.md
+++ b/template/.claude/policies/no-hq-remote-push.md
@@ -10,7 +10,7 @@ enforcement: hard
 
 NEVER push HQ data to any remote repository. HQ is local-only. The `origin` remote (`indigoai-us/hq`) is used only for PULLING upstream updates, not for pushing local state.
 
-Only push repos inside `repos/` (e.g. `new-getindigo`, `{company}-cmohq`) — never the HQ root.
+Only push repos inside `repos/` (e.g. `new-getindigo`, `{your-repo}`) — never the HQ root.
 
 ## Rationale
 

--- a/template/.claude/policies/no-supabase-deletion.md
+++ b/template/.claude/policies/no-supabase-deletion.md
@@ -13,7 +13,7 @@ learned_from: "CLAUDE.md learned rules migration 2026-02-22"
 
 ## Rule
 
-NEVER delete Supabase projects without confirming with user first. rose-flower was {company}'s DB and was incorrectly deleted as "unused" on 2026-02-10. Always ask before deleting any Supabase/Vercel project.
+NEVER delete Supabase projects without confirming with user first. rose-flower was {Product}'s DB and was incorrectly deleted as "unused" on 2026-02-10. Always ask before deleting any Supabase/Vercel project.
 
 ## Rationale
 

--- a/template/.claude/policies/orchestrator-competing-processes.md
+++ b/template/.claude/policies/orchestrator-competing-processes.md
@@ -12,4 +12,4 @@ Before running `--resume` on a project, check for existing `run-project.sh` proc
 
 ## Rationale
 
-Session 2026-03-23: Two competing orchestrator processes for hpo-blog-cms caused state file corruption, requiring manual PID cleanup and resume.
+Session 2026-03-23: Two competing orchestrator processes for {company}-blog-cms caused state file corruption, requiring manual PID cleanup and resume.

--- a/template/.claude/policies/paginated-api-sort-priority.md
+++ b/template/.claude/policies/paginated-api-sort-priority.md
@@ -1,0 +1,15 @@
+---
+id: paginated-api-sort-priority
+title: Server-side sort by priority for paginated + filtered APIs
+scope: cross-cutting
+trigger: paginated API with client-side status filter
+enforcement: soft
+---
+
+## Rule
+
+When a paginated API serves data that the client filters by status/priority, add server-side `sort` param to return high-priority records first. Client-side filtering on page 1 of alphabetically-sorted data will show 0 results if all high-priority records are past the first page.
+
+## Rationale
+
+{company} field app loaded 50 accounts alphabetically — all churned. "Active" filter showed empty. Fix: `?sort=staleness` returns active accounts on page 1.

--- a/template/.claude/policies/post-bridge-api-field-names.md
+++ b/template/.claude/policies/post-bridge-api-field-names.md
@@ -15,7 +15,7 @@ learned_from: "social advisory council session — direct API posting for {your-
 
 When calling `POST https://api.post-bridge.com/v1/posts` directly (not via SDK), use these exact field names:
 - `caption` — the post text (NOT `content`)
-- `social_accounts` — array of numeric account IDs, e.g. `[{account-id}]` (NOT `account_id`)
+- `social_accounts` — array of numeric account IDs, e.g. `[34528]` (NOT `account_id`)
 - `scheduled_at` — ISO8601 datetime string
 
 Also: always check for existing scheduled posts before submitting (`GET /v1/posts?status=scheduled`) — duplicate posts from previous sessions may already exist at the same time slots.

--- a/template/.claude/policies/pre-deploy-domain-check.md
+++ b/template/.claude/policies/pre-deploy-domain-check.md
@@ -7,7 +7,7 @@ enforcement: hard
 version: 2
 created: 2026-02-22
 updated: 2026-03-12
-source: {app}.{domain} overwrite incident
+source: goclaw.getindigo.ai overwrite incident
 ---
 
 ## Rule
@@ -20,8 +20,8 @@ Before ANY Vercel deploy:
 4. **NEVER** remove a domain from one Vercel project to assign it to another — add new routes within the existing project instead
 5. **NEVER** deploy a repo whose registry entry shows a different `owner` without explicit user confirmation
 
-Protected domains (never reassign): `hq.{domain}`, `{app}.{domain}`, `{domain}`, `{company}.com`, `{company}.com`, `{company}.com`, `{company}pr.com`, `{company}.band`, `{company}.com`, `{your-username}.com`, `{company}app.com`, `www.{company}.ai`
+Protected domains (never reassign): `hq.getindigo.ai`, `goclaw.getindigo.ai`, `getindigo.ai`, `{company}.com`, `hollermgmt.com`, `havenslay.com`, `{your-domain}.com`, `goldenthread.band`, `{company}.com`, `{your-name}.com`, `moonflowapp.com`, `www.{company}.ai`
 
 ## Rationale
 
-{app}.{domain} was overwritten by another team member deploying to the wrong project (2026-03-12). hq.{domain} was nearly replaced in a prior incident. The deploy registry (`settings/deploy-registry.yaml`) is the source of truth for repo → project → domain mapping.
+goclaw.getindigo.ai was overwritten by another team member deploying to the wrong project (2026-03-12). hq.getindigo.ai was nearly replaced in a prior incident. The deploy registry (`settings/deploy-registry.yaml`) is the source of truth for repo → project → domain mapping.

--- a/template/.claude/policies/preview-clerk-auth.md
+++ b/template/.claude/policies/preview-clerk-auth.md
@@ -12,4 +12,4 @@ Preview tools (preview_screenshot, preview_snapshot) render blank for apps using
 
 ## Rationale
 
-{App} admin, {Company} admin, and other Clerk-protected apps all blank-screen in preview. Build verification (TypeScript + Next.js static generation) catches structural issues. Visual verification requires a real browser session.
+GoClaw admin, Holler admin, and other Clerk-protected apps all blank-screen in preview. Build verification (TypeScript + Next.js static generation) catches structural issues. Visual verification requires a real browser session.

--- a/template/.claude/policies/publish-kit-indigo-sed-ordering.md
+++ b/template/.claude/policies/publish-kit-indigo-sed-ordering.md
@@ -1,0 +1,24 @@
+---
+id: publish-kit-{company}-sed-ordering
+title: Use denylist exceptions to preserve indigoai-us during scrubbing
+scope: command
+trigger: /publish-kit
+enforcement: hard
+created: 2026-04-02
+updated: 2026-04-03
+---
+
+## Rule
+
+The scrub function uses a **two-phase approach** driven by `.claude/scrub-denylist.yaml`:
+
+1. **Replace phase**: Apply all company/product/person/domain/repo replacements (including `\bindigo\b` → `{company}`)
+2. **Restore phase**: Read the `exceptions` section from the denylist and restore any corrupted terms (e.g. `indigoai-us` → `indigoai-us`)
+
+The exceptions section in the denylist is the **single source of truth** for what to protect. Never hardcode restore passes in the scrub function — add entries to `exceptions:` instead.
+
+After scrubbing, verify: `grep -ri 'indigoai-us' template/` — must return 0 results.
+
+## Rationale
+
+The `indigoai-us` GitHub org and npm scope must remain literal in the public template. A naive `s/{company}/{company}/g` corrupts it to `indigoai-us`. The exceptions-based restore is data-driven — new collisions are fixed by adding a denylist entry, not editing code. Validated during v10.3.0 and v10.4.0 publishes.

--- a/template/.claude/policies/publish-kit-no-subagents-for-scrub.md
+++ b/template/.claude/policies/publish-kit-no-subagents-for-scrub.md
@@ -1,0 +1,16 @@
+---
+id: publish-kit-no-subagents-for-scrub
+title: Use direct sed pipelines for publish-kit scrubbing, not sub-agents
+scope: command
+trigger: /publish-kit
+enforcement: hard
+created: 2026-04-02
+---
+
+## Rule
+
+During `/publish-kit`, NEVER delegate file scrubbing (PII replacement, denylist application) to sub-agents. Sub-agents hit Write/Bash/Edit permission denials because they cannot receive interactive user approval. Use direct `sed` pipelines from the main session instead — batch all files through a single `for` loop with the full denylist sed chain.
+
+## Rationale
+
+v10.3.0 publish attempt delegated scrubbing to 3 background agents (policies-new-sync, config-sync, policies-rescrub). All 3 failed on permissions. Direct sed from the main session completed the same work in minutes. The permission model for sub-agents makes interactive-approval-required operations (Write, Edit, Bash) unreliable for bulk file mutations.

--- a/template/.claude/policies/regression-gate-lint-fix.md
+++ b/template/.claude/policies/regression-gate-lint-fix.md
@@ -12,4 +12,4 @@ When a regression gate fails due to lint error increase (e.g. "14 errors, baseli
 
 ## Rationale
 
-Session 2026-03-23: hpo-blog-cms regression gate caught a React compiler lint error in internal-links.tsx (setState synchronously in effect). Fixed by restructuring the useEffect to use async/await with cleanup function.
+Session 2026-03-23: {company}-blog-cms regression gate caught a React compiler lint error in internal-links.tsx (setState synchronously in effect). Fixed by restructuring the useEffect to use async/await with cleanup function.

--- a/template/.claude/policies/run-project-sigkill-retry.md
+++ b/template/.claude/policies/run-project-sigkill-retry.md
@@ -22,4 +22,4 @@ When monitoring: expect ~10-15 min per story. Output files (`US-XXX.output.json`
 
 ## Rationale
 
-During a project execution, US-001 attempt 1 was killed after 334s (exit 137). The orchestrator correctly auto-retried and attempt 2 completed successfully in 638s. Manual intervention would have been wasted effort — the built-in retry mechanism handled it.
+During the `shopify-webhook-ts-rollout` project (2026-04-02), US-001 attempt 1 was killed after 334s (exit 137). The orchestrator correctly auto-retried and attempt 2 completed successfully in 638s. Manual intervention would have been wasted effort — the built-in retry mechanism handled it.

--- a/template/.claude/policies/session-data-for-product-accuracy.md
+++ b/template/.claude/policies/session-data-for-product-accuracy.md
@@ -2,7 +2,7 @@
 id: session-data-for-product-accuracy
 title: Analyze session threads before writing user-facing guides
 scope: command
-trigger: creating getting-started guides, cheatsheets, or curriculum for HQ/{Company}
+trigger: creating getting-started guides, cheatsheets, or curriculum for HQ/{product}
 enforcement: soft
 version: 1
 created: 2026-03-29

--- a/template/.claude/policies/slack-workspace-routing.md
+++ b/template/.claude/policies/slack-workspace-routing.md
@@ -14,19 +14,28 @@ Before any Slack operation, determine the target workspace from context (company
 
 | Workspace | Company | Team ID |
 |-----------|---------|---------|
-| `{product}` | {company}, {product} | `{team-id}` |
-| `{company}` | {company}, {company}, personal | `{team-id}` |
+| `voyage` | {company}, voyage | `T7V83HY5B` |
+| `{company}` | {company}, {company}, personal | `T043AC36YE4` |
 
-Default is `{product}`. Always pass `workspace:` param when targeting non-default.
+Default is `voyage`. Always pass `workspace:` param when targeting non-default.
+
+### Known channels → workspace
+
+| Channel | Workspace | Notes |
+|---------|-----------|-------|
+| `#hq` | `{company}` | HQ project updates, private channel |
+| `#{company}-product` | `{company}` | Product updates |
+| `#releases` | `{company}` | Release announcements |
+| `#team-{company}-agents` | `voyage` | LR agent ops |
 
 ### Known people → workspace
 
 | Person | Workspace | Slack ID | Username |
 |--------|-----------|----------|----------|
-| {team-member} | {company} | `{slack-id}` | `{username}` |
-| {team-member} | {company} | `{slack-id}` | `{username}` |
-| {your-name} | both ({company} primary) | `{slack-id}` ({company}) | `{username}` |
-| {team-member}, {team-member}, {company} team | {product} | — | — |
+| {team-member} Johnson | {company} | `U065YSKUCJK` | `therealstefan` |
+| {team-member} Kalim | {company} | `U0823D5QDJM` | `{team-member}` |
+| {your-name} Epstein | both ({company} primary) | `U042Z9XCRK3` ({company}) | `me1` |
+| Ryan, Josh, {Product} team | voyage | — | — |
 
 **`find_user` gotcha**: Search matches `name` (username), not `real_name`. Use username or Slack ID directly if name search fails.
 

--- a/template/.claude/policies/supabase-migration-ghost-apply.md
+++ b/template/.claude/policies/supabase-migration-ghost-apply.md
@@ -1,0 +1,17 @@
+---
+id: supabase-migration-ghost-apply
+title: Supabase migrations can be tracked as applied without SQL executing
+scope: cross-cutting
+trigger: supabase migration debugging
+enforcement: soft
+---
+
+## Rule
+
+When debugging "table not found" errors on a Supabase-backed app, ALWAYS verify the table actually exists via REST API (`curl .../rest/v1/{table}?select=id&limit=1`) even if `supabase migration list` shows the migration as applied. Migrations with non-standard naming (e.g. `001_...` instead of timestamp prefix) can be recorded in the tracking table without the SQL executing.
+
+**Fix:** `supabase migration repair --status reverted {version}` then `supabase db push --include-all`.
+
+## Rationale
+
+Encountered on agent-ops-hq (Mar 2026): migration 015 showed as applied in both local and remote columns of `supabase migration list`, but the `trainees` table didn't exist. Root cause: non-standard migration file naming. The repair + re-push workflow resolved it.

--- a/template/.claude/policies/tailwind-v4-theme-tokens.md
+++ b/template/.claude/policies/tailwind-v4-theme-tokens.md
@@ -9,8 +9,8 @@ created_at: 2026-03-30
 
 ## Rule
 
-In Tailwind v4 projects using `@theme inline` blocks, prefer theme token utilities (`bg-hpo-plum`, `text-hpo-orange`) over arbitrary values (`bg-[#4d0d2e]`, `text-[#ef4323]`). Arbitrary color values can lose specificity against `@layer base` styles in v4's new cascade model, causing the computed style to differ from the class name.
+In Tailwind v4 projects using `@theme inline` blocks, prefer theme token utilities (`bg-{company}-plum`, `text-{company}-orange`) over arbitrary values (`bg-[#4d0d2e]`, `text-[#ef4323]`). Arbitrary color values can lose specificity against `@layer base` styles in v4's new cascade model, causing the computed style to differ from the class name.
 
 ## Rationale
 
-Discovered in `hpo-vision-deck`: dark slides used `bg-[#4d0d2e]` on a wrapper div, but the base layer `body { @apply bg-background }` overrode it at render time. Switching to `bg-hpo-plum` (defined via `--color-hpo-plum` in `@theme inline`) resolved the issue immediately because theme-generated utilities have correct layer precedence.
+Discovered in `{company}-vision-deck`: dark slides used `bg-[#4d0d2e]` on a wrapper div, but the base layer `body { @apply bg-background }` overrode it at render time. Switching to `bg-{company}-plum` (defined via `--color-{company}-plum` in `@theme inline`) resolved the issue immediately because theme-generated utilities have correct layer precedence.

--- a/template/.claude/policies/vercel-cross-team-domains.md
+++ b/template/.claude/policies/vercel-cross-team-domains.md
@@ -12,4 +12,4 @@ Vercel does NOT allow adding a domain registered on Team A to a project on Team 
 
 ## Rationale
 
-Discovered 2026-03-25 when setting up {company}brands.com ({company}-brands team) → {company}brandsgroup.com ({company} team). `vercel domains add {company}brands.com --scope {vercel-scope}` returned "Not authorized to use {company}brands.com (403)". Solution was a minimal `{company}brands-redirect` project on the {company}-brands team.
+Discovered 2026-03-25 when setting up amassbrands.com ({company}-brands team) → amassbrandsgroup.com ({company} team). `vercel domains add amassbrands.com --scope {company}-f0dc7e1b` returned "Not authorized to use amassbrands.com (403)". Solution was a minimal `amassbrands-redirect` project on the {company}-brands team.

--- a/template/.claude/policies/vercel-custom-domain-safety.md
+++ b/template/.claude/policies/vercel-custom-domain-safety.md
@@ -13,7 +13,7 @@ learned_from: "CLAUDE.md learned rules migration 2026-02-22"
 
 ## Rule
 
-NEVER deploy to a production custom domain (e.g. token.{domain}, {company}.com) without explicit user confirmation. "Deploy to a temporary Vercel site" means a fresh Vercel project with only a .vercel.app URL — no custom domain aliases. Existing Vercel projects with custom domains are live production sites.
+NEVER deploy to a production custom domain (e.g. token.getindigo.ai, hollermgmt.com) without explicit user confirmation. "Deploy to a temporary Vercel site" means a fresh Vercel project with only a .vercel.app URL — no custom domain aliases. Existing Vercel projects with custom domains are live production sites.
 
 ## Rationale
 

--- a/template/.claude/skills/brainstorm/SKILL.md
+++ b/template/.claude/skills/brainstorm/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: brainstorm
+description: Explore approaches and tradeoffs before committing to a PRD. Research HQ context, compare options, surface unknowns, generate brainstorm.md with recommendation.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*), Bash(qmd:*), Bash(ls:*), Bash(date:*)
+---
+
+# Brainstorm - Structured Exploration
+
+Think through a problem before committing to a PRD. Research HQ context, compare approaches, surface unknowns.
+
+**Input:** The user's argument — typically `[company] <idea description or board idea ID>`.
+
+**Pipeline:** idea capture --> **brainstorm** --> PRD --> run-project
+
+## Step 0: Parse Input & Company Anchor
+
+Check if the **first word** of the user's input matches a company slug in `companies/manifest.yaml`.
+
+**How to check:** Read `companies/manifest.yaml`. Extract top-level keys (company slugs). If the first word exactly matches one:
+
+1. **Set `{co}`** = matched slug. Strip from input — remaining text is the description
+2. **Announce:** "Anchored on **{co}**"
+3. **Load policies** — Read all files in `companies/{co}/policies/` (skip `example-policy.md`)
+4. **Scope qmd searches** — If company has `qmd_collections` in manifest, use `-c {collection}`
+
+**If no match** -- full input is the description text. Company resolved later.
+
+**Board ID detection:** After company check, see if remaining args match a board.json project ID pattern (`{prefix}-proj-{NNN}`). If so, this brainstorm is expanding an existing idea — proceed to Step 1 with that ID.
+
+## Step 0.5: Mode Selection
+
+Infer the brainstorm mode from context — no question needed:
+
+- **STARTUP** — early-stage idea, no existing solution, exploring whether worth building. Default when: no existing board entry with `prd_path`, no prior art in HQ, greenfield domain
+- **BUILDER** — existing product/system, designing a feature or extension. Default when: expanding existing project, board entry has `prd_path`, target repo already exists
+
+Announce mode: `Mode: **STARTUP**` or `Mode: **BUILDER**`
+
+Mode affects Steps 2-4 (premise challenge depth, question framing, research scope).
+
+## Step 1: Resolve Company + Board Idea
+
+**If board ID matched in Step 0:**
+1. If `{co}` already set: read `companies/{co}/board.json`, find entry by ID
+2. If `{co}` not set: scan all `companies/*/board.json` for the ID (use manifest `board_path` list)
+3. Extract the entry's `title` and `description` as starting context
+4. Set `source_idea_id` = matched ID
+
+**If no board ID and no company:** infer from cwd (`companies/{slug}/` --> use that slug, `repos/{pub|priv}/{name}` --> manifest lookup). If still ambiguous, ask the user directly in Step 3.
+
+**If input is empty:** go straight to Step 3 (full interview).
+
+## Step 2: HQ Research (before any questions)
+
+Do not ask questions yet. Build context from HQ first.
+
+**Semantic search:**
+- If anchored + company has `qmd_collections`: `qmd vsearch "<description keywords>" -c {collection} --json -n 10`
+- If not anchored: `qmd vsearch "<description keywords>" --json -n 10`
+
+**Existing projects:**
+- If anchored: search `companies/{co}/projects/` directly or `qmd search "prd.json" -c {co} --json -n 10`
+- Read top 2-3 match metadata (name, description, status) to check for overlap
+
+**Workers:**
+- Read `workers/registry.yaml` — identify workers with skills matching the description
+
+**Policies (anchored only):**
+- Already loaded in Step 0. Note any constraints that affect approach selection
+
+**Target repo (if inferable):**
+- Note existence, don't deep-read. If repo has qmd collection, run scoped search
+
+Present compact summary:
+```
+Research complete:
+- Related projects: {list or "none found"}
+- Relevant workers: {list}
+- Policies: {count loaded}
+- Prior art: {relevant knowledge hits or "none"}
+```
+
+### Premise Challenge (always run, both modes)
+
+After research, before asking the user anything, challenge the premise:
+
+1. **Is this the right problem?** What assumption must be true for this to matter?
+2. **What happens if we do nothing?** Is inaction a viable option?
+3. **What simpler/cheaper solution might already solve 80%?** Existing tool, manual process, or minor tweak?
+
+State a position. Don't hedge. If the premise is weak, say so before exploring approaches. This may eliminate the need for a full brainstorm.
+
+Present as:
+```
+Premise check:
+- Core assumption: {what must be true}
+- Inaction cost: {what happens if we skip this}
+- 80% solution: {simpler alternative, or "none — this requires dedicated work"}
+- Verdict: {STRONG / QUESTIONABLE / WEAK}
+```
+
+If verdict is WEAK: flag it and ask the user if they want to continue or reconsider.
+
+## Step 3: Light Interview (1 question max)
+
+Batch all missing directional info into **one** question posed directly to the user. Skip any field already clear from args, board entry, or research. Wait for the user's response before proceeding.
+
+### STARTUP mode questions (include only what's missing):
+
+1. **Demand Reality** — Who has this problem badly enough to hack a workaround today? Can you name a specific person or group?
+2. **Status Quo** — What do they do right now? Why isn't that good enough?
+3. **Narrowest Wedge** — What's the smallest starting point that delivers real value to one specific person?
+4. **Direction + constraints** — Speed vs quality? Hard constraints? (timeline, must-use-tech, budget ceiling)
+5. **Which company?** (only if not anchored and not inferrable from context)
+
+### BUILDER mode questions (include only what's missing):
+
+1. **What's the core problem or opportunity?** (skip if description is >15 words with clear intent)
+2. **Which direction matters most?**
+   - A. Speed to ship (MVP fast, iterate later)
+   - B. Quality/durability (build it right once)
+   - C. Exploration (prove or disprove a hypothesis first)
+   - D. Cost minimization (cheapest viable path)
+3. **Hard constraints?** (timeline, must-use-tech, budget ceiling, avoid-tech) — optional, free text
+4. **Which company?** (only if not anchored and not inferrable from context)
+
+**If all info is already clear** (description + company + direction obvious from context), skip the interview entirely.
+
+## Step 4: 3-Layer Landscape Gate
+
+Research in layers — stop as soon as you have enough signal. Don't research for thoroughness.
+
+**Layer 1 — HQ (always, already done in Step 2):**
+qmd, workers, policies, existing projects. Already complete.
+
+**Layer 2 — Reasoning (always, free):**
+Competitive landscape, known tools, pricing, market context from training data. No API calls needed. Run this as part of your analysis — identify alternatives, comparable tools, known pricing tiers, and market dynamics. 2-3 bullets.
+
+**Layer 3 — Live Web (conditional, privacy-gated):**
+**Only if:** idea involves a new API/service you're not confident about, unfamiliar domain, or user explicitly requested research.
+
+Before searching: announce what you'll search for and why. Proceed only after implicit or explicit approval (user continuing the conversation counts as approval).
+
+**If Layer 2 is sufficient** (internal tooling, known platforms — the common case): skip Layer 3 entirely.
+
+## Step 5: Generate brainstorm.md
+
+**Derive slug** from title (lowercase, hyphens, no special chars).
+
+**Create** `companies/{co}/projects/{slug}/brainstorm.md` (or `projects/{slug}/brainstorm.md` for personal/HQ):
+
+```markdown
+---
+company: {slug}
+created_at: {ISO8601}
+status: exploring
+promoted_to: null
+source_idea_id: {board ID or null}
+---
+
+# {Title}
+
+> {1-sentence problem/opportunity framing}
+
+## Context
+
+{2-4 sentences: why this matters now, what triggered the exploration, rough size of the thing}
+
+## What We Know
+
+- {Confirmed fact from HQ research — existing projects, prior work, tech constraints}
+- {Relevant worker or knowledge base that exists}
+- ...
+
+## What We Don't Know
+
+- {Open question that would change the approach}
+- {Assumption that needs validating}
+- {Missing info that blocks confident decision-making}
+- ...
+
+## Premise Check
+
+{Position on whether the core assumption holds. State verdict: STRONG / QUESTIONABLE / WEAK}
+
+## Narrowest Wedge *(STARTUP mode only)*
+
+{Smallest version that delivers real value to one specific person. What can you ship in days, not weeks?}
+
+## Approaches
+
+### Option A: {Name}
+
+**How it works:** {2-3 sentences describing the approach}
+
+**Tradeoffs:**
+- Pro: {specific advantage}
+- Pro: {specific advantage}
+- Con: {specific cost or risk}
+
+**Effort:** {S / M / L / XL}
+**When to choose this:** {specific signal or condition that makes this the right pick}
+
+---
+
+### Option B: {Name}
+
+**How it works:** {2-3 sentences}
+
+**Tradeoffs:**
+- Pro: {specific advantage}
+- Con: {specific cost or risk}
+
+**Effort:** {S / M / L / XL}
+**When to choose this:** {condition}
+
+---
+
+### Option C: {Name} *(only if genuinely distinct from A and B)*
+
+...
+
+---
+
+## Recommendation
+
+**Preferred approach:** Option {X} — {one sentence on why}
+
+**Key condition:** {What would make you choose a different option instead}
+
+**Biggest risk:** {The one thing most likely to blow up the preferred approach}
+
+## Next Steps
+
+- [ ] {Specific validation task or question to resolve before starting PRD}
+- [ ] {Other prerequisite}
+
+**Promotion path:**
+- Ready to build --> promote to PRD (brainstorm.md pre-populates the interview)
+- Needs more research --> edit this file, revisit later
+- Not worth pursuing --> park as idea on the board
+```
+
+**Approach rules:**
+- Generate exactly 2 approaches if the problem is well-defined
+- Generate 3 only if there's a genuine third dimension (build vs buy, now vs later, etc.)
+- Never more than 3 — collapse similar options or pick the most distinct
+- Each option must differ on at least one of: effort, reversibility, dependency, or user experience
+- Must state a recommendation — no "it depends" without a stated override condition
+- T-shirt effort: S (hours-days), M (days-week), L (week-month), XL (month+). Be honest
+
+## Step 6: Board Integration
+
+Read `companies/{co}/board.json`.
+
+**If started from existing board idea** (`source_idea_id` set):
+- Find that entry by ID
+- Update `status` --> `"exploring"`
+- Add `brainstorm_path: "companies/{co}/projects/{slug}/brainstorm.md"`
+- Update `updated_at`
+
+**If fresh brainstorm** (no existing board idea):
+- Generate next ID: collect all `id` values from `projects` array, extract numeric suffixes from `{prefix}-proj-{NNN}` pattern, next = `{prefix}-proj-{max_N + 1}` zero-padded to 3 digits
+- Append new entry:
+  ```json
+  {
+    "id": "{prefix}-proj-{NNN}",
+    "title": "{concise title}",
+    "description": "{user's description}",
+    "status": "exploring",
+    "scope": "company",
+    "app": null,
+    "initiative_id": null,
+    "objective_id": null,
+    "prd_path": null,
+    "brainstorm_path": "companies/{co}/projects/{slug}/brainstorm.md",
+    "created_at": "{ISO8601}",
+    "updated_at": "{ISO8601}"
+  }
+  ```
+
+Write updated `board.json`.
+
+## Step 7: Confirm & Reindex
+
+Print:
+```
+Brainstorm: **{title}** ({id})
+File: companies/{co}/projects/{slug}/brainstorm.md
+
+Approaches:
+  A. {Option A name} — {effort}
+  B. {Option B name} — {effort}
+  {C. Option C name — effort, if present}
+
+Recommendation: Option {X}
+
+Next: promote to PRD, edit brainstorm.md, or park on the board.
+```
+
+Reindex: `qmd update 2>/dev/null || true`
+
+## Rules
+
+- **Scan HQ before asking anything** — research phase (Step 2) happens before the first question. Never ask for info findable in qmd, board.json, or policies
+- **1 question max** — direction + constraints in one message. If everything is clear from args/context, zero questions is fine
+- **2-3 approaches, no more** — present distinct options, not variations. If only one reasonable path exists, say so and explain why
+- **State a recommendation** — "it depends" without a stated override condition is not a recommendation
+- **No execution** — brainstorm.md is the output. Do NOT write code, scaffold repos, or modify any implementation files
+- **No prd.json** — this skill does NOT produce prd.json. That is the PRD skill's job
+- **No Linear sync** — brainstorms are pre-planning. Linear happens at PRD time
+- **No orchestrator registration** — brainstorms are not executable
+- **Web research is conditional** — only if idea requires external context. Don't search for thoroughness
+- **board.json + brainstorm.md are the only files written** — no other files modified
+- **T-shirt effort, not story points** — S (hours-days), M (days-week), L (week-month), XL (month+)
+- **Company isolation enforced** — if anchored, scope all searches to that company. Never mix company knowledge in approaches
+- **brainstorm.md is human-editable** — the user may refine it after generation. The PRD skill reads whatever is in the file, not just what was machine-generated
+- **Do not create README.md** — brainstorm.md is self-contained
+- **Anti-sycophancy** — Never say "that's interesting," "great idea," "excellent question." Take a position immediately. If the premise is weak, say so before exploring approaches. State which approach you'd actually build and why. Brainstorm is for honest analysis, not validation

--- a/template/.claude/skills/brainstorm/agents/openai.yaml
+++ b/template/.claude/skills/brainstorm/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Brainstorm"
+  short_description: "Explore approaches and tradeoffs before committing to a PRD."

--- a/template/.claude/skills/execute-task/SKILL.md
+++ b/template/.claude/skills/execute-task/SKILL.md
@@ -1,0 +1,832 @@
+---
+name: execute-task
+description: Execute a single PRD story through coordinated inline worker phases (Ralph pattern). Workers run sequentially in current context — no sub-agent isolation.
+allowed-tools: Read, Write, Edit, Grep, Bash(qmd:*), Bash(grep:*), Bash(ls:*), Bash(git:*), Bash(cat:*), Bash(which:*), Bash(wc:*), Bash(mkdir:*), Bash(echo:*), Bash(curl:*), Bash(python3:*), Bash(kill:*), Bash(cd:*), Bash(bun:*), Bash(npm:*), Bash(scripts/*:*)
+argument-hint: "{project}/{task-id}"
+---
+
+# Execute Task - Worker-Coordinated Story Execution
+
+Execute a single user story from a PRD through coordinated worker phases. Each worker handles their domain, passes context to the next.
+
+> **Warning: Codex Adaptation Note — No Context Isolation**
+>
+> In Claude Code, `/execute-task` spawns an isolated Task sub-agent per worker phase. Worker context lives in a separate context window.
+>
+> In Codex, workers execute **inline** in the current context window. This means:
+> - All worker instructions, knowledge, and policies load into **your** active context
+> - Multi-phase pipelines (4-7 workers) will consume significant context budget
+> - For large tasks (full_stack with 6+ phases), consider using `$handoff` between phases
+> - Each phase's output stays visible — no context reclamation between workers
+> - Keep worker knowledge loading minimal (skill-relevant files only)
+
+**Usage:**
+```
+execute-task {project}/{task-id}
+```
+
+**User's input:** $ARGUMENTS
+
+---
+
+## Ralph Principle
+
+"Pick a task, complete it, commit it."
+
+- Fresh context per task
+- Workers execute inline sequentially
+- Back pressure (typecheck, lint, test) keeps code on rails
+- Handoff context passed between worker phases
+
+---
+
+## Step 1 — Parse Arguments
+
+Extract `{project}` and `{task-id}` from `$ARGUMENTS`.
+
+Split on `/`: first token is `project`, second is `task-id`.
+
+If no arguments or missing parts:
+```
+Usage: execute-task {project}/{task-id}
+
+Example: execute-task campaign-migration/US-003
+```
+Stop here.
+
+---
+
+## Step 2 — Load Task Spec
+
+### 2a. Find prd.json
+
+Use `qmd search` to discover the PRD file (never Glob for prd.json):
+
+```bash
+qmd search "{project} prd.json" --json -n 5
+```
+
+From results, find the entry whose path includes `/{project}/prd.json`. Extract the file path.
+
+If qmd is unavailable, try direct Read at these paths in order:
+1. `companies/{co}/projects/{project}/prd.json` (company projects)
+2. `projects/{project}/prd.json` (personal/HQ projects)
+
+If no prd.json found:
+```
+ERROR: prd.json not found for {project}. Run /prd {project} first.
+```
+Stop.
+
+### 2b. Read and Validate prd.json
+
+Read the prd.json file. Validate structure:
+
+1. **userStories array required**: If `userStories` is missing or not an array:
+   ```
+   ERROR: prd.json missing userStories array. Migrate legacy 'features' key to 'userStories'.
+   ```
+   Stop.
+
+2. **Validate required fields per story**: Each story must have `id`, `title`, `description`, `passes`. Report missing fields and stop.
+
+3. **Find the target story**: Match `task-id` against `story.id`. If not found:
+   ```
+   Task {task-id} not found in {project} prd.json.
+   ```
+   Stop.
+
+4. **Check completion**: If `story.passes === true`:
+   ```
+   Task {task-id} already complete (passes: true). Skipping.
+   ```
+   Stop.
+
+5. **Check dependencies**: If the story has `dependsOn`, verify each dependency story has `passes: true`. If any dependency is incomplete:
+   ```
+   Task {task-id} blocked: depends on {dep-id} which is not yet complete.
+   ```
+   Stop.
+
+Extract from the matched story:
+- `id`, `title`, `description`
+- `acceptance_criteria` (or `acceptanceCriteria`)
+- `files` (if specified — for file locking)
+- `dependsOn` (already checked)
+- `e2eTests` (if specified — for acceptance test phase)
+- `worker_hints` (if specified — for optional worker inclusion)
+- `model_hint` (if specified — overrides worker model)
+- `linearIssueId` (if specified — for Linear sync)
+
+Record metadata from `prd.metadata`:
+- `company` — active company slug
+- `repoPath` — target repo path
+- `linearCredentials` — path to Linear credentials (if configured)
+- `linearInProgressStateId`, `linearDoneStateId` — Linear state IDs
+- `qualityGates` — custom quality gate commands (if configured)
+- `docsPath` — documentation location (if configured)
+
+### 2c. Check Story Checkout State
+
+Guard against concurrent execution of the same story.
+
+1. Read `workspace/orchestrator/{project}/state.json` (if it exists)
+2. If `current_tasks` array contains an entry with `id` matching this story AND `checkedOutBy` is not null:
+   - Check if the PID is alive: `kill -0 {pid} 2>/dev/null`
+   - **PID alive**: Display warning and pause:
+     ```
+     WARNING: Story {task-id} is currently checked out by PID {pid} (started: {startedAt}).
+     Another execution may be running. Proceeding will override.
+     ```
+     Continue after warning (no interactive prompt in Codex).
+   - **PID dead**: Release the stale checkout — set `checkedOutBy: null`, update `updated_at`. Log: "Released stale checkout for {task-id} (dead PID {pid})."
+3. If no conflict, proceed normally.
+
+---
+
+## Step 3 — Classify Task Type
+
+Analyze the story's title, description, and acceptance criteria. Match against patterns:
+
+| Type | Indicators |
+|------|------------|
+| `schema_change` | database, migration, schema, table, column, prisma, SQL |
+| `api_development` | endpoint, API, REST, GraphQL, route, service |
+| `ui_component` | component, page, form, button, React, UI, responsive |
+| `full_stack` | Combination of backend + frontend indicators |
+| `enhancement` | animation, polish, refactor, optimization, UX |
+| `content` | copy, content, documentation, marketing text |
+
+Report classification:
+```
+Task: {task.id} - {task.title}
+Type: {type} (matched: {indicators})
+```
+
+---
+
+## Step 4 — Select Worker Sequence
+
+Based on task type, determine the inline worker sequence:
+
+```yaml
+schema_change:
+  - product-planner    # skip if detailed acceptance criteria exist
+  - database-dev
+  - backend-dev
+  - code-reviewer
+
+api_development:
+  - product-planner    # skip if detailed acceptance criteria exist
+  - backend-dev
+  - code-reviewer
+
+ui_component:
+  - product-planner    # skip if detailed acceptance criteria exist
+  - frontend-dev
+  - motion-designer
+  - code-reviewer
+
+full_stack:
+  - product-planner
+  - architect
+  - database-dev
+  - backend-dev
+  - frontend-dev
+  - code-reviewer
+
+enhancement:
+  - (relevant dev based on files — frontend-dev or backend-dev)
+  - code-reviewer
+
+content:
+  - content-brand
+  - content-product
+```
+
+**Rules for sequence construction:**
+- **Skip product-planner** if the story already has detailed acceptance criteria
+- **Skip codex-reviewer and codex-debugger** — these are Codex native workers, not HQ workers
+- **Skip dev-qa-tester** — inline execution means the implementing worker already tests
+- **Skip acceptance-test-writer** if `e2eTests` is empty or absent
+- **Add acceptance-test-writer** before code-reviewer if `e2eTests` is non-empty
+
+**Worker phase descriptions** (for execution plan display):
+
+| Worker | Phase Description |
+|--------|-------------------|
+| product-planner | Clarify spec and acceptance criteria |
+| architect | Design system architecture |
+| database-dev | Implement schema and migrations |
+| backend-dev | Implement backend service |
+| frontend-dev | Implement frontend UI |
+| motion-designer | Add animations and motion |
+| code-reviewer | Review changes and verify quality |
+| acceptance-test-writer | Write story-level acceptance tests from e2eTests |
+| content-brand | Brand-aligned content creation |
+| content-product | Product content and documentation |
+
+Present execution plan:
+```
+Execution Plan for {task.id}:
+
+Phase 1: {worker} -> {phase description}
+Phase 2: {worker} -> {phase description}
+Phase 3: {worker} -> {phase description}
+
+Phases: {N} | Type: {type}
+Proceed? [Y/n]
+```
+
+> **Context budget warning:** For full_stack tasks (5-6 phases), this pipeline will consume substantial context. Consider `$handoff` between phases if context is running low.
+
+---
+
+## Step 5 — Initialize Execution State
+
+### 5a. Create execution tracking directory and file
+
+```bash
+mkdir -p workspace/orchestrator/{project}/executions
+```
+
+Write to `workspace/orchestrator/{project}/executions/{task-id}.json`:
+```json
+{
+  "task_id": "{task.id}",
+  "project": "{project}",
+  "started_at": "{ISO8601}",
+  "status": "in_progress",
+  "current_phase": 1,
+  "phases": [
+    {"worker": "{worker1}", "status": "pending"},
+    {"worker": "{worker2}", "status": "pending"}
+  ],
+  "handoffs": []
+}
+```
+
+### 5a.5 Acquire Story Checkout
+
+Write a checkout entry into orchestrator state to prevent concurrent execution:
+
+1. Read `workspace/orchestrator/{project}/state.json` (create with minimal structure if missing)
+2. Set `current_tasks` entry for this story:
+   ```json
+   {
+     "id": "{task.id}",
+     "started_at": "{ISO8601}",
+     "checkedOutBy": {
+       "pid": {current PID from echo $$},
+       "startedAt": "{ISO8601}",
+       "sessionId": "{started_at}"
+     }
+   }
+   ```
+3. Write state.json back with updated `updated_at`
+
+Report: `Checkout acquired for {task.id} (PID: {pid})`
+
+### 5b. Audit: Task Started
+
+```bash
+scripts/audit-log.sh append \
+  --event task_started \
+  --project {project} \
+  --story-id {task.id} \
+  --company {company} \
+  --session-id {started_at} \
+  --action "Task execution started: {task.title}" || true
+```
+
+---
+
+## Step 5.5 — Acquire File Locks
+
+If the story has a non-empty `files` array and the prd metadata has `repoPath`:
+
+1. **Load config**: Read `settings/orchestrator.yaml` -> `file_locking`
+2. **Skip if disabled**: If `file_locking.enabled: false`, skip this step
+3. **Read existing locks**: Read `{repoPath}/.file-locks.json` (create if missing: `{"version":1,"locks":[]}`)
+4. **Stale lock cleanup**: For each existing lock, check if owner PID is running:
+   ```bash
+   kill -0 {pid} 2>/dev/null
+   ```
+   If not running AND lock is older than `stale_lock_timeout_minutes`, remove it
+5. **Conflict check**: For each file in `task.files`, check if already locked by another story:
+   - **Self-owned lock**: If already locked by same story ID, skip it
+   - **Conflict with different story**: Apply `conflict_mode` from config:
+     - `hard_block`: STOP — report conflicting files + owner story
+     - `soft_block`: Log warning, proceed but instruct workers to skip locked files
+     - `read_only_fallback`: Log warning, proceed with read-only constraint
+6. **Acquire locks**: For each unlocked file, append to `.file-locks.json`:
+   ```json
+   {"file": "{path}", "owner": {"project": "{project}", "story": "{task.id}", "pid": {$$}}, "acquired_at": "{ISO8601}"}
+   ```
+   (Get PID via `echo $$` in bash)
+7. **Update state.json**: If `workspace/orchestrator/{project}/state.json` exists, update the project's `checkedOutFiles` array
+
+Report: `File locks acquired: {N} files for {task.id}`
+
+---
+
+## Step 5.5.5 — Sync Linear Issue to In Progress (Best-Effort)
+
+If the story has `linearIssueId` and prd metadata has `linearCredentials`:
+
+1. **Cross-company guard**: Verify the `linearCredentials` path matches the active company per `companies/manifest.yaml`. If it points to a different company's settings, ABORT Linear sync and warn.
+
+2. **Read API key**:
+   ```bash
+   LINEAR_KEY=$(cat {prd.metadata.linearCredentials} | python3 -c "import sys,json; print(json.load(sys.stdin)['apiKey'])")
+   ```
+
+3. **Set issue to In Progress**:
+   ```bash
+   curl -s -X POST https://api.linear.app/graphql \
+     -H "Content-Type: application/json" \
+     -H "Authorization: $LINEAR_KEY" \
+     -d '{"query": "mutation { issueUpdate(id: \"'$ISSUE_ID'\", input: { stateId: \"'$IN_PROGRESS_STATE'\" }) { success } }"}'
+   ```
+
+4. **Comment on issue**: "Started by HQ — task in progress."
+
+Skip silently if no `linearIssueId` or no credentials configured. Never block execution on Linear sync failure.
+
+---
+
+## Step 5.6 — Load Applicable Policies
+
+Load policies from all applicable directories:
+
+1. **Company policies**: Determine active company from `prd.metadata.company` or path. Read all files in `companies/{co}/policies/` (skip `example-policy.md`).
+2. **Repo policies**: If working in a repo, check `{repoPath}/.claude/policies/` if it exists.
+3. **Global policies**: Read `.claude/policies/` — filter by `trigger` field relevance.
+
+Note:
+- **Hard enforcement** policies are absolute constraints during execution
+- **Soft enforcement** policies allow deviation with logging
+
+Include applicable policy rules in worker context (Step 6b).
+
+---
+
+## Step 6 — Execute Each Worker Phase (Inline)
+
+> **Key difference from Claude Code:** No sub-agent spawning. Each worker executes inline in this context. You read the worker's instructions and follow them directly.
+
+For each worker in the sequence:
+
+### 6a. Load Worker Config
+
+1. Read `workers/registry.yaml` to find the worker path:
+   ```bash
+   grep -A 4 "  - id: {worker-id}$" workers/registry.yaml | grep "path:"
+   ```
+   Extract the `path:` value.
+
+2. Read `{worker_path}/worker.yaml` to get:
+   - `instructions` — worker's role, process, and accumulated learnings
+   - `context.base` — files the worker always needs
+   - `skills.installed` — available skills
+   - `verification.post_execute` — back-pressure commands
+
+3. If the worker has a skill file relevant to the task, read `{worker_path}/skills/{relevant-skill}.md`.
+
+### 6b. Build Worker Context
+
+Assemble the following context mentally (do not output it — just internalize it):
+
+```
+Worker: {worker.name}
+Task: {task.id} - {task.title}
+
+Description: {task.description}
+Acceptance Criteria: {task.acceptance_criteria}
+Files to Focus On: {task.files or inferred}
+
+Context from Previous Phase:
+{handoff from previous worker, if any}
+
+Codebase Exploration:
+Use qmd vsearch for conceptual search. Use Grep for exact pattern matching.
+
+Applicable Policies:
+{policies from step 5.6}
+
+Worker Instructions:
+{worker.instructions from worker.yaml}
+
+Back Pressure (run before completing):
+{worker.verification.post_execute commands}
+```
+
+### 6c. Execute Worker Phase Inline
+
+Follow the worker's instructions step by step:
+
+1. **Understand the task** through the worker's lens (their role, their domain)
+2. **Explore the codebase** if needed — use `qmd vsearch` for concepts, Grep for exact patterns
+3. **Implement** — create/edit files as the worker's instructions direct
+4. **Run back-pressure checks** from `worker.verification.post_execute`:
+   - Typecheck (e.g. `bun check`, `tsc --noEmit`)
+   - Lint (e.g. `bun lint`, `eslint .`)
+   - Tests (e.g. `bun test`, `npm test`)
+   - Build (if applicable)
+5. **Collect output** — track what was done:
+   ```json
+   {
+     "summary": "What this worker phase accomplished",
+     "files_created": ["paths"],
+     "files_modified": ["paths"],
+     "key_decisions": ["decision and rationale"],
+     "context_for_next": "Instructions for next worker",
+     "back_pressure": {
+       "tests": "pass|fail",
+       "lint": "pass|fail",
+       "typecheck": "pass|fail"
+     },
+     "issues": ["any blocking issues"]
+   }
+   ```
+
+### 6c.5 Acceptance Test Writer Phase
+
+If the sequence includes `acceptance-test-writer` (i.e. `e2eTests` is non-empty):
+
+1. Read `task.e2eTests` from prd.json
+2. Read existing story test files in `{repo}/__tests__/stories/` to understand patterns
+3. Detect test framework from `package.json` (vitest/jest/bun:test)
+4. Write tests to `{repo}/__tests__/stories/{task.id}.test.ts`:
+   - One `describe("{task.id}: {task.title}")` block
+   - One `it()`/`test()` per e2eTests entry
+   - Import from actual implementation — no mocks unless necessary
+   - Tests verify BEHAVIOR described in e2eTests, not implementation details
+5. Run the new tests: `{test-runner} __tests__/stories/{task.id}.test.ts`
+6. Run ALL existing story tests to verify no regressions: `{test-runner} __tests__/stories/`
+7. All tests must pass before this phase completes
+
+### 6d. Handle Back-Pressure Failures
+
+If any back-pressure check fails after a worker phase:
+
+1. **First attempt**: Re-read the error output, diagnose the root cause, fix inline
+2. **Re-run the failed check** after the fix
+3. If it passes, continue to the next phase
+4. If it still fails after one retry, pause and report:
+   ```
+   Phase {N} ({worker}) back-pressure failed: {check}
+   Error: {error output}
+
+   Options:
+   1. Fix manually and continue
+   2. Skip this check and continue
+   3. Abort execution
+   ```
+
+### 6d.5 Expand File Locks (Dynamic)
+
+If file locking is enabled and the phase created/modified files not already locked:
+
+1. Compute new files from phase output not in `.file-locks.json` for this story
+2. Acquire locks for new files (same format as Step 5.5)
+3. Update story's `files` array in prd.json with new paths
+
+### 6e. Update Execution State
+
+After each phase completes, update `workspace/orchestrator/{project}/executions/{task-id}.json`:
+
+```json
+{
+  "phases": [
+    {"worker": "{worker}", "status": "completed", "completed_at": "{ISO8601}"},
+    {"worker": "{next-worker}", "status": "in_progress"}
+  ],
+  "handoffs": [
+    {
+      "from": "{completed-worker}",
+      "to": "{next-worker}",
+      "context": {
+        "summary": "...",
+        "files_created": [],
+        "files_modified": [],
+        "key_decisions": [],
+        "context_for_next": "..."
+      }
+    }
+  ]
+}
+```
+
+### 6e.5 Audit: Phase Completed
+
+```bash
+scripts/audit-log.sh append \
+  --event phase_completed \
+  --project {project} \
+  --story-id {task.id} \
+  --worker {worker.id} \
+  --result {success|fail} \
+  --action "Phase {N} completed: {worker.id}" || true
+```
+
+### 6f. Log Model Usage
+
+Append one line per phase to `workspace/metrics/model-usage.jsonl`:
+
+```json
+{"ts":"ISO8601","project":"{project}","task":"{task.id}","worker":"{worker.id}","model":"codex","phase":N,"company":"{company}"}
+```
+
+Create `workspace/metrics/` if it doesn't exist. This is append-only.
+
+**Resolving `company`:** Use `prd.metadata.company` if present. Otherwise match the project path against `companies/manifest.yaml`.
+
+### 6g. Repeat for Next Worker
+
+Advance `current_phase` and repeat from 6a for the next worker in the sequence.
+
+> **Context check:** If context is running low after a heavy phase (implementation workers), display a warning: "Context budget nearing limit. Consider $handoff to continue in a fresh session." The execution state file preserves progress for resumption.
+
+---
+
+## Step 7 — Complete Task
+
+When all phases complete successfully:
+
+### 7.0 Release File Locks
+
+If file locking was enabled and locks were acquired in Step 5.5:
+
+1. Read `{repoPath}/.file-locks.json`
+2. Remove all entries where `owner.project === "{project}" && owner.story === "{task.id}"`
+3. Write updated `.file-locks.json`
+4. Update orchestrator state.json: remove matching entries from `checkedOutFiles`
+
+Report: `File locks released for {task.id}`
+
+This runs BEFORE PRD update so locks are released even if later steps fail.
+
+### 7a. Update PRD
+
+Determine invocation mode:
+
+- **Standalone (interactive)**: Write `passes: true` directly on the story in prd.json
+- **Invoked by orchestrator** (prompt contains "Do NOT write passes to prd.json"): Skip this write. The orchestrator reads execution output and writes passes itself.
+
+Read prd.json, find the story by ID, set `passes: true`, write back.
+
+### 7a.5 Sync Linear Issue to Done (Best-Effort)
+
+If the story has `linearIssueId` and prd metadata has `linearCredentials`:
+
+1. **Cross-company guard**: Same validation as Step 5.5.5
+2. **Set issue to Done**:
+   ```bash
+   curl -s -X POST https://api.linear.app/graphql \
+     -H "Content-Type: application/json" \
+     -H "Authorization: $LINEAR_KEY" \
+     -d '{"query": "mutation { issueUpdate(id: \"'$ISSUE_ID'\", input: { stateId: \"'$DONE_STATE'\" }) { success } }"}'
+   ```
+3. **Comment**: "Completed by HQ. Ready for review."
+
+Skip silently on failure. Never block task completion on Linear sync.
+
+### 7a.6 Comment on Linear Issue (if configured)
+
+If prd.metadata has `linearReviewers`, include @mention in the completion comment. When task was blocked, comment with blocker context. Skip silently if not configured.
+
+### 7b. Update Documentation
+
+If the task introduced new features, changed behavior, or modified APIs:
+
+1. Check `prd.metadata.docsPath` for documentation location
+2. If not set, skip (do not prompt in Codex — no interactive questions)
+3. Based on `files_modified`, `files_created`, and `key_decisions` from worker outputs:
+   - New API endpoints -> update API docs
+   - New UI pages/features -> update feature docs
+   - Changed behavior -> update existing docs
+4. Skip if task was a pure bug fix, refactor, or `docsPath` is "none"
+
+### 7b.5 Capture Learnings
+
+If the execution encountered back-pressure failures, retries, or notable patterns, capture them via `$learn`:
+
+```json
+{
+  "task_id": "{task.id}",
+  "project": "{project}",
+  "source": "task-completion",
+  "severity": "medium",
+  "scope": "auto",
+  "workers_used": ["list of workers that ran"],
+  "back_pressure_failures": [{"worker": "...", "check": "...", "error": "..."}],
+  "retries": N,
+  "key_decisions": ["aggregated from worker outputs"],
+  "issues_encountered": ["from worker outputs"],
+  "patterns_discovered": ["success patterns worth preserving"]
+}
+```
+
+`$learn` handles: policy file creation, event logging, dedup.
+
+If task completed cleanly with no failures/retries/notable patterns, skip — not every task produces novel insights.
+
+### 7b.6 Reindex
+
+```bash
+qmd update 2>/dev/null || true
+```
+
+Ensures any modified knowledge, worker instructions, or rules are immediately searchable.
+
+### 7c.0 Audit: Task Completed
+
+```bash
+scripts/audit-log.sh append \
+  --event task_completed \
+  --project {project} \
+  --story-id {task.id} \
+  --company {company} \
+  --session-id {started_at} \
+  --files "{comma_separated_files_touched}" \
+  --action "Task completed: {total_phases} phases, {files_touched_count} files" \
+  --result success || true
+```
+
+### 7c. Report Completion
+
+```
+Task Complete: {task.id} - {task.title}
+
+Phases: {N} completed
+Workers: {list}
+Files touched: {count}
+
+Key decisions:
+- {decision 1}
+- {decision 2}
+
+PRD updated: passes: true
+```
+
+### 7d. Structured Output for Orchestrator
+
+When invoked as part of a project run, output this JSON so the orchestrator can parse results:
+
+```json
+{
+  "task_id": "{task.id}",
+  "status": "completed",
+  "summary": "1-sentence summary of what was accomplished",
+  "workers_used": ["{worker1}", "{worker2}"],
+  "back_pressure": {
+    "tests": "pass|fail|skipped",
+    "lint": "pass|fail|skipped",
+    "typecheck": "pass|fail|skipped",
+    "build": "pass|fail|skipped"
+  }
+}
+```
+
+---
+
+## Step 8 — Handle Failures
+
+If any phase fails after retry:
+
+### 8.0 Release Locks on Failure
+
+Same as Step 7.0 — release all file locks for this story from both `.file-locks.json` and state.json. Never orphan locks on failure.
+
+### 8.0.5 Audit: Task Failed
+
+```bash
+scripts/audit-log.sh append \
+  --event task_failed \
+  --project {project} \
+  --story-id {task.id} \
+  --company {company} \
+  --session-id {started_at} \
+  --worker {failed_worker} \
+  --error "{error_message}" \
+  --action "Task failed at phase {N}: {failed_worker}" \
+  --result fail || true
+```
+
+### 8.1 Update Execution State
+
+Write `status: "paused"` to the execution tracking file with error details.
+
+### 8.2 Report Failure
+
+```
+Phase {N} ({worker}) failed: {error}
+
+Options:
+1. Fix manually and resume: execute-task {project}/{task-id}
+2. Skip this worker and continue
+3. Abort execution
+```
+
+When invoked as part of a project run, also output structured JSON on failure:
+
+```json
+{
+  "task_id": "{task.id}",
+  "status": "failed",
+  "summary": "Phase {N} ({worker}) failed: {brief error}",
+  "workers_used": ["{workers that ran}"],
+  "back_pressure": {}
+}
+```
+
+---
+
+## Step 9 — Auto-Checkpoint
+
+After task completion (or failure), write a thread checkpoint file:
+
+```json
+{
+  "thread_id": "T-{YYYYMMDD}-{HHMMSS}-auto-{task-id}",
+  "version": 1,
+  "type": "auto-checkpoint",
+  "created_at": "{ISO8601}",
+  "updated_at": "{ISO8601}",
+  "workspace_root": "~/Documents/HQ",
+  "cwd": "{current working directory}",
+  "git": {
+    "branch": "{current branch from git branch --show-current}",
+    "current_commit": "{short hash from git rev-parse --short HEAD}",
+    "dirty": false
+  },
+  "conversation_summary": "Executed {task.id} ({task.title}): {1-sentence outcome}",
+  "files_touched": ["{list of files created or modified across all phases}"],
+  "metadata": {
+    "title": "Auto: execute-task {project}/{task-id}",
+    "tags": ["auto-checkpoint", "execute-task", "{project}", "{task-id}"],
+    "trigger": "worker-completion"
+  }
+}
+```
+
+Write to: `workspace/threads/{thread_id}.json`
+
+Get git state with:
+```bash
+git rev-parse --short HEAD 2>/dev/null
+git branch --show-current 2>/dev/null
+git status --short 2>/dev/null
+```
+
+---
+
+## Handoff Context Format
+
+Context passed between worker phases:
+
+```json
+{
+  "from_worker": "backend-dev",
+  "to_worker": "code-reviewer",
+  "timestamp": "ISO8601",
+  "summary": "1-2 sentence description",
+  "files_created": ["src/services/foo.ts"],
+  "files_modified": ["src/index.ts"],
+  "key_decisions": [
+    "Used strategy pattern for flexibility",
+    "Added caching for performance"
+  ],
+  "context_for_next": "Focus review on cache invalidation logic",
+  "back_pressure": {
+    "tests": "pass",
+    "lint": "pass",
+    "typecheck": "pass"
+  }
+}
+```
+
+---
+
+## Examples
+
+```
+execute-task campaign-migration/US-003    # Execute specific story
+execute-task order-system/CAM-001         # Full stack story
+execute-task landing-page/US-001          # UI component story
+```
+
+---
+
+## Notes
+
+- **No isolation** — all worker phases execute in your active context. This is the key difference from Claude Code.
+- **Worker path lookup** — always read `workers/registry.yaml` first. Never Glob for `worker.yaml`.
+- **PRD discovery** — always use `qmd search` first. Never Glob for `prd.json`.
+- **Quality gates** — run typecheck + lint + tests after every implementation phase (not just at end).
+- **File locking** — same JSON format as Claude Code. Locks are per-story, per-file.
+- **Linear sync** — best-effort. Attempt if credentials available, skip silently on failure.
+- **Context budget** — for heavy tasks, warn early. The execution state file supports resumption if you need to `$handoff`.
+- **Commit work** — each implementation phase should commit its changes before the next phase begins.
+- **Orchestrator mode** — when invoked by a project runner, output structured JSON and do NOT write `passes: true` (the orchestrator does that).

--- a/template/.claude/skills/execute-task/agents/openai.yaml
+++ b/template/.claude/skills/execute-task/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Execute Task"
+  short_description: "Execute a single PRD story through coordinated inline worker phases (Ralph pattern)."

--- a/template/.claude/skills/handoff/SKILL.md
+++ b/template/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: handoff
+description: Prepare for a new session to continue this work. Commits dirty repos, captures session state to a thread file, writes handoff.json, and updates the search index. Ensures continuity across sessions.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*), Bash(qmd:*), Bash(ls:*), Bash(date:*)
+---
+
+# Fresh Session Continuity
+
+Prepare for a new session to continue this work. Commits pending changes, writes thread state, and produces a handoff pointer.
+
+## Process
+
+### 0. Capture Session Learnings
+
+Reflect on the session and note any reusable learnings (mistakes that cost time, unexpected behaviors, patterns that worked well, gotchas). If there are notable learnings, include them in the thread file's `learnings` array when writing it. If nothing new was learned, skip.
+
+### 0b. Update Knowledge (skip if trivial)
+
+If session was a config tweak, typo fix, or minor edit with no new domain knowledge, skip entirely.
+
+Otherwise:
+- Detect active company from pwd or files touched. If ambiguous, scan `companies/manifest.yaml` for a company whose repos match current cwd
+- Check `companies/{co}/knowledge/` for relevant docs
+- If significant domain knowledge was created, note it in the thread file's `conversation_summary`
+
+### 1. Ensure Thread Exists
+
+Check `workspace/threads/` for a recent thread file. If none exists, write a basic checkpoint thread file first:
+
+```json
+{
+  "thread_id": "T-{YYYYMMDD}-{HHMMSS}-handoff",
+  "version": 1,
+  "type": "handoff",
+  "created_at": "ISO8601",
+  "updated_at": "ISO8601",
+  "workspace_root": "~/Documents/HQ",
+  "cwd": "current/working/dir",
+  "git": {
+    "branch": "current-branch",
+    "current_commit": "abc1234",
+    "dirty": false
+  },
+  "conversation_summary": "What was accomplished this session",
+  "next_steps": ["What should happen next"],
+  "files_touched": ["relative/paths"],
+  "learnings": [],
+  "metadata": {
+    "title": "Handoff: brief description",
+    "tags": ["handoff"]
+  }
+}
+```
+
+### 2. Find Latest Thread
+
+```bash
+ls -t workspace/threads/*.json | head -1
+```
+
+Update the thread file with current session state if needed (conversation_summary, next_steps, git state, files_touched, learnings).
+
+### 3. Commit Dirty Knowledge Repos
+
+```bash
+for dir in knowledge/public/* knowledge/private/* companies/*/knowledge; do
+  [ -d "$dir/.git" ] || { [ -L "$dir" ] && target=$(cd "$dir" && git rev-parse --show-toplevel 2>/dev/null) || continue; dir="$target"; } || continue
+  dirty=$(cd "$dir" && git status --porcelain 2>/dev/null)
+  [ -z "$dirty" ] && continue
+  (cd "$dir" && git add -A && git commit -m "checkpoint: auto-commit before handoff")
+done
+```
+
+### 3b. Commit HQ Changes
+
+```bash
+cd ~/Documents/HQ
+if [ -n "$(git status --porcelain)" ]; then
+  git add -A
+  git commit -m "checkpoint: auto-commit before handoff"
+fi
+```
+
+### 4. Update Search Index
+
+```bash
+qmd update 2>/dev/null && qmd embed 2>/dev/null || true
+```
+
+Skip silently if qmd CLI is unavailable.
+
+### 5. Write Handoff Note
+
+Write to `workspace/threads/handoff.json`:
+
+```json
+{
+  "created_at": "ISO8601 timestamp",
+  "message": "user's handoff message if provided",
+  "last_thread": "T-{YYYYMMDD}-{HHMMSS}-{slug}",
+  "thread_path": "workspace/threads/T-{YYYYMMDD}-{HHMMSS}-{slug}.json",
+  "context_notes": "important context for next session"
+}
+```
+
+### 6. Report
+
+```
+Handoff ready.
+
+Latest thread: {thread_id}
+Summary: {conversation_summary}
+Git: {branch} @ {commit}
+
+To continue in a fresh session:
+1. Start new session
+2. Run: startwork (it will find your thread)
+
+Or read: workspace/threads/handoff.json
+```
+
+## Rules
+
+- Always commit all pending changes before writing handoff.json
+- Never leave partial file edits — save everything first
+- Thread file must be valid JSON
+- handoff.json must point to the actual latest thread file
+- If git state is dirty after commit attempts, note it in the report
+- Skip INDEX.md rebuilds (Claude Code-specific)
+- If `document-release` skill is available, run it. Otherwise skip silently
+- Use `qmd update` via shell command — skip silently if unavailable
+- Context diet: don't load extra files just for the handoff. Use what's already in context

--- a/template/.claude/skills/handoff/agents/openai.yaml
+++ b/template/.claude/skills/handoff/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Handoff"
+  short_description: "Prepare session handoff — commit changes, write thread, ensure continuity."

--- a/template/.claude/skills/learn/SKILL.md
+++ b/template/.claude/skills/learn/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: learn
+description: Capture and classify learnings as structured policy files. Deduplicates via qmd (Grep fallback). Callable manually or from /execute-task and /run-project.
+allowed-tools: Read, Write, Edit, Grep, Bash(qmd:*), Bash(grep:*), Bash(mkdir:*), Bash(date:*), Bash(ls:*)
+---
+
+# Learn - Automated Learning Pipeline
+
+Capture a learning, classify it, and inject the rule as a structured policy file in the correct directory.
+
+Called programmatically by `$execute-task` and `$run-project` after task completion or failure. Also callable manually. `$remember` delegates here.
+
+**Input:** The user's argument — structured JSON event data, or free text description of what to learn.
+
+**Note:** Hook-triggered mode (observe-patterns) is not available in Codex. Use manual invocation or structured JSON from task pipelines instead.
+
+## Core Principle
+
+**Policy files are the primary output.** Learnings become structured policy files in scope-appropriate directories:
+
+| Scope | Target directory | Format |
+|-------|-----------------|--------|
+| Company | `companies/{co}/policies/{slug}.md` | Policy file (YAML frontmatter + Rule + Rationale) |
+| Repo | `repos/{pub\|priv}/{repo}/.claude/policies/{slug}.md` | Policy file |
+| Command | `.claude/policies/{slug}.md` (scope: command) | Policy file |
+| Global | `.claude/policies/{slug}.md` | Policy file |
+| Worker (legacy) | `workers/*/{id}/worker.yaml` | Instructions block `## Learnings` |
+
+**Before creating:** always scan existing policies for updates (Step 4.5). Update > duplicate.
+
+## Step 1: Parse Input
+
+### Mode A: Structured JSON (from $execute-task / $run-project)
+
+If input is a JSON object:
+```json
+{
+  "task_id": "TASK-001",
+  "project": "my-project",
+  "source": "back-pressure-failure|user-correction|success-pattern|task-completion|build-activity",
+  "severity": "critical|high|medium|low",
+  "scope": "global|worker:{id}|command:{name}|knowledge:{path}|project:{slug}",
+  "workers_used": ["backend-dev"],
+  "back_pressure_failures": [{"worker": "frontend-dev", "check": "lint", "error": "..."}],
+  "retries": 0,
+  "key_decisions": ["..."],
+  "issues_encountered": ["..."],
+  "patterns_discovered": ["..."]
+}
+```
+
+Parse it and proceed to Step 2.
+
+### Mode B: Free Text (manual invocation or $remember delegation)
+
+Parse for keywords to determine scope. Generate rule statement from description. Proceed to Step 2.
+
+## Step 2: Extract Rules
+
+From structured input, generate rules:
+
+- `back_pressure_failures` → `NEVER: {anti-pattern that caused failure}` (scope: worker:{id})
+- `retries > 0` → Rule about what caused retry and how to avoid it
+- `key_decisions` → `ALWAYS: {pattern}` if broadly applicable
+- `issues_encountered` → Scoped rule to prevent recurrence
+- `patterns_discovered` → `ALWAYS: {pattern}` for success patterns
+
+From free text:
+- Extract the core rule in NEVER/ALWAYS/condition→action format
+
+If no meaningful rules can be extracted (task completed cleanly, no failures, no notable patterns), skip injection — log to event log only.
+
+## Step 3: Classify Scope & Resolve Target
+
+For each extracted rule, determine scope (most specific wins):
+
+| Signal | Scope | Policy directory |
+|--------|-------|------------------|
+| Related to specific company | `company` | `companies/{co}/policies/` |
+| Related to specific repo | `repo` | `repos/{pub\|priv}/{repo}/.claude/policies/` |
+| Error in specific command | `command` | `.claude/policies/` (with `scope: command`) |
+| Failure in specific worker | `worker` | `workers/*/{id}/worker.yaml` instructions block |
+| Universal pattern | `global` | `.claude/policies/` |
+| User correction via $remember | From context, default global | Detected scope directory |
+
+**Resolve company/repo context:**
+- From `prd.json` metadata if in project context
+- From `companies/manifest.yaml` repo lookup if in repo context
+- From worker path if worker-scoped (`companies/{co}/workers/` → `{co}`)
+- Fall back to `.claude/policies/` (global scope)
+
+## Step 4: Dedup Check
+
+**Primary (if qmd available):**
+```bash
+qmd vsearch "{rule text}" --json -n 5
+```
+
+Check results for similarity to the new rule:
+- Similarity > 0.85 → **Skip** (already captured somewhere)
+- Similarity 0.6–0.85 → **Merge** (update existing rule to be more precise)
+- Similarity < 0.6 → **Add new**
+
+**Fallback (if qmd unavailable):**
+Use the Grep tool to search for key terms from the rule across the policy directories:
+- Pattern: key terms from the rule (2-3 significant words)
+- Files: `*.md` in `companies/*/policies/`, `.claude/policies/`, and any repo policy dirs
+- If matching content found → review and decide whether to merge or skip
+
+Report dedup action taken.
+
+## Step 4.5: Scan Existing Policies
+
+Before creating a new rule, check if an existing policy file already covers this topic:
+
+1. **Resolve policy directories** based on scope:
+   - Company scope → scan `companies/{co}/policies/` (skip `example-policy.md`)
+   - Repo scope → scan `{repoPath}/.claude/policies/`
+   - Global/command scope → scan `.claude/policies/`
+
+2. **Search for matching policies** using Grep:
+   - Pattern: key terms from the rule
+   - Files: `*.md` in the resolved policy directory
+   - Also check qmd vsearch results from Step 4 for hits in policy files
+
+3. **If matching policy found:**
+   - Read the policy file
+   - **Update** the existing policy: append to `## Rule` section, bump `version`, update `updated` date
+   - If new learning contradicts existing policy, flag for user review instead of auto-merging
+   - Set `dedup_action: "merged-into-policy"` in event log
+
+4. **If no matching policy found:**
+   - Proceed to Step 5 (create new rule)
+   - Prefer creating a **policy file** over injecting into worker.yaml or CLAUDE.md
+
+## Step 5: Create or Update Policy File
+
+### Primary: Policy File (company/repo/global/command scopes)
+
+If Step 4.5 found a matching policy → update was already handled. Otherwise, create a new policy file.
+
+**Target directory:**
+- Company scope → `companies/{co}/policies/{slug}.md`
+- Repo scope → `repos/{pub|priv}/{repo}/.claude/policies/{slug}.md`
+- Command scope → `.claude/policies/{slug}.md`
+- Global scope → `.claude/policies/{slug}.md`
+
+**Create the directory if needed:**
+```bash
+mkdir -p {target_directory}
+```
+
+**Policy file format:**
+
+```markdown
+---
+id: {scope-prefix}-{slug}
+title: {Rule title}
+scope: {company|repo|command|global}
+trigger: {when this applies}
+enforcement: {hard|soft}
+version: 1
+created: {YYYY-MM-DD}
+updated: {YYYY-MM-DD}
+source: {back-pressure-failure|user-correction|success-pattern|task-completion}
+---
+
+## Rule
+
+{Rule in imperative form}
+
+## Rationale
+
+{Why this rule exists — from context/failure/correction}
+```
+
+**Enforcement mapping:**
+- `source: user-correction` → `enforcement: hard`
+- `severity: critical` → `enforcement: hard`
+- Everything else → `enforcement: soft`
+
+**Slug generation:** lowercase, hyphens, from rule keywords. Prefix: `{co}-` for company, `{repo}-` for repo, `hq-cmd-{name}-` for command, `hq-` for global.
+
+### Fallback: Worker.yaml (worker-scoped learnings)
+
+For worker-specific learnings, inject into `workers/*/{id}/worker.yaml` instructions block:
+
+```yaml
+instructions: |
+  ...existing instructions...
+
+  ## Learnings
+  - NEVER: {new rule}
+```
+
+### Legacy: CLAUDE.md Learned Rules (global promotion only)
+
+Only used for **global promotion** of critical/user-correction rules (Step 6).
+
+## Step 6: Evaluate Global Promotion
+
+If the rule was injected into a scoped file (worker/command/knowledge), also add to `.claude/CLAUDE.md` `## Learned Rules` if ANY:
+- `severity == critical`
+- `source == user-correction` (explicit $remember invocation)
+- Rule triggered 3+ times (check event log)
+
+### Cap Enforcement
+
+`## Learned Rules` is capped at 20 rules.
+
+1. Count existing rules in section
+2. If >= 20: find the oldest rule (by date in comment), remove it from CLAUDE.md
+   - The rule still lives in its source file — only the CLAUDE.md copy is removed
+3. Append new rule
+
+Format:
+```markdown
+- **{NEVER|ALWAYS}**: {rule} <!-- {source} | {date} -->
+```
+
+## Step 7: Log Event
+
+```bash
+mkdir -p workspace/learnings
+```
+
+Write `workspace/learnings/learn-{YYYYMMDD-HHMMSS}.json`:
+```json
+{
+  "event_id": "learn-{timestamp}",
+  "rules": [
+    {
+      "rule": "NEVER: ...",
+      "scope": "worker:frontend-dev",
+      "target_file": "workers/public/dev-team/frontend-dev/worker.yaml",
+      "severity": "high"
+    }
+  ],
+  "source": "back-pressure-failure",
+  "task_id": "TASK-001",
+  "project": "my-project",
+  "dedup_action": "new|merged|skipped",
+  "promoted_to_global": true,
+  "created_at": "{ISO8601}"
+}
+```
+
+## Step 8: Reindex
+
+```bash
+qmd update 2>/dev/null || true
+```
+
+## Step 9: Report
+
+```
+Learning captured:
+  Rule: {rule}
+  Target: {policy file path | worker.yaml path}
+  Action: {created-policy | updated-policy | merged-into-policy | worker-yaml-injection}
+  Global: {promoted|not promoted}
+  Dedup: {new|merged|skipped}
+  Event: workspace/learnings/learn-{timestamp}.json
+```
+
+If multiple rules extracted, report each.
+
+## Rules
+
+- **Policy files first** — always create structured policy files for company/repo/global/command scoped rules. Worker.yaml injection only for worker-specific learnings
+- **Scan before create** — always check existing policies for updates before creating new files (Step 4.5)
+- **Never inject empty/trivial rules** — "task completed successfully" is not a learning
+- **Dedup is mandatory** — always check before injecting (qmd first, Grep fallback)
+- **Global cap is hard** — never exceed 20 rules in CLAUDE.md `## Learned Rules`
+- **Reindex after every injection** — keeps qmd search current
+- **Preserve existing rules** — append only, never overwrite existing rules
+- **User corrections always promote** — $remember delegations go to both target file AND CLAUDE.md
+- **Match existing style** — use the same rule format as existing rules in the target file
+- **No hook-triggered mode** — observe-patterns integration not available in Codex; skip if input is empty

--- a/template/.claude/skills/learn/agents/openai.yaml
+++ b/template/.claude/skills/learn/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Learn"
+  short_description: "Capture and classify learnings as structured policy files. Deduplicates automatically."

--- a/template/.claude/skills/prd/SKILL.md
+++ b/template/.claude/skills/prd/SKILL.md
@@ -1,0 +1,534 @@
+---
+name: prd
+description: Plan a project and generate PRD for execution. Creates prd.json + README.md with full HQ context awareness. Adapts interview depth to brainstorm context if available.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(git:*), Bash(qmd:*), Bash(ls:*), Bash(date:*)
+---
+
+# PRD — Project Planning & PRD Generation
+
+Create execution-ready PRDs with full HQ context awareness.
+
+**Important:** Do NOT implement. Just create the PRD.
+
+## Step 0: Company Anchor (from user input)
+
+Check if the **first word** of the user's input matches a company slug in `companies/manifest.yaml`.
+
+**How to check:** Read `companies/manifest.yaml`. Extract top-level keys (company slugs). If the first word exactly matches one of those slugs:
+
+1. **Set `{co}`** = matched slug for the entire flow. Strip the slug — the remaining text is the project description
+2. **Announce:** "Anchored on **{co}**"
+3. **Load policies** — Read all files in `companies/{co}/policies/` (skip `example-policy.md`). Apply these as constraints throughout the PRD
+4. **Scope qmd searches** — If company has `qmd_collections` in manifest, use `-c {collection}` for all `qmd` calls
+5. **Pre-load repos** — Extract `{co}.repos[]` from manifest. Present as repo options in Batch 3 Q10
+6. **Scope workers** — Filter to company workers (`companies/{co}/workers/`) + public workers (`workers/public/`)
+7. **Scope projects** — Only search `companies/{co}/projects/` for existing project collision check
+
+**If no match** (first word is not a company slug) — proceed normally. The full input text is the project description.
+
+## Step 1: Get Project Description
+
+If user provided input, use as starting point.
+If empty, ask: "Describe what you want to build or accomplish." Wait for response.
+
+## Step 2: Scan HQ Context
+
+Before asking questions, explore HQ. If company is anchored (Step 0), scope all searches to that company.
+
+**Companies & Context:**
+- Read `agents.md` (roles, priorities)
+- Read `companies/manifest.yaml` (companies already listed there — never Glob for company discovery)
+
+**Workers:**
+- Read `workers/registry.yaml` (workers already indexed there — never Glob for worker discovery)
+- If anchored: filter to company workers (`companies/{co}/workers/`) + public workers (`workers/public/`)
+
+**Existing Projects:**
+- If anchored: `qmd search "prd.json" --json -n 20 -c {co}` (scoped) or search `companies/{co}/projects/` directly
+- If not anchored: `qmd search "prd.json" --json -n 20` — existing projects across all companies and personal
+
+**Knowledge (use qmd, not Grep):**
+- If anchored + company has `qmd_collections`: `qmd vsearch "<description keywords>" -c {collection} --json -n 10`
+- If not anchored: `qmd vsearch "<description keywords>" --json -n 10` — semantic search for related knowledge, prior work, workers
+
+**Company Policies (anchored only):**
+- Read all files in `companies/{co}/policies/` (skip `example-policy.md`). These constrain the PRD
+
+**Repo Policies (if repo resolved):**
+- If target repo identified, check `{repoPath}/.claude/policies/` for repo-scoped rules. These constrain the PRD (e.g., commit hooks, deploy procedures, code location rules)
+
+**Target Repo (if repo specified or discovered):**
+- If anchored: company repos already pre-loaded from manifest. Present as options
+- If target repo has a qmd collection (e.g. `{product}`): `qmd vsearch "<description keywords>" -c {collection} --json -n 10` — find related code, patterns, existing implementations
+- Present: "Found related code: {list of relevant files}"
+
+Present:
+```
+Scanned HQ:
+- Company: {co} (anchored) | TBD
+- Workers: {relevant list}
+- Existing projects: {list or "none matching"}
+- Relevant knowledge: {if any}
+- Policies: {count loaded, or "none"}
+- Category: [company-specific | cross-company | personal | HQ infrastructure]
+```
+
+## Step 2.5: Infrastructure Pre-Check
+
+Before generating the PRD, verify infrastructure exists for the target company/repo:
+
+1. **Company**: If project targets a company, read `companies/manifest.yaml`. If company has `knowledge: null`, flag: "Company {co} has no knowledge repo. Create one? [Y/n]" — if yes, create embedded repo at `companies/{co}/knowledge/` with `git init`, update manifest + modules.yaml.
+
+2. **Repo**: If `repoPath` specified and doesn't exist locally, flag: "Repo not found at {path}. Clone it or create new?" Add to `manifest.yaml` if missing.
+
+3. **qmd collection**: If company has `qmd_collections: []` in manifest, flag and offer to create collection.
+
+Fix any gaps before proceeding.
+
+## Step 3: Get + Validate Project Name
+
+Ask for project slug (or infer from description). Then:
+1. If `{co}` already set by Step 0: use it directly (skip company detection)
+   If NOT set: determine company from context (infer from description, repo, or ask)
+2. Check if `companies/{co}/projects/{name}/` exists (also check root `projects/{name}/` for personal/HQ)
+   - If exists: "Project exists. Continue editing or choose different name?"
+3. Validate slug format (lowercase, hyphens only)
+
+## Step 3.5: Brainstorm Detection
+
+Now that `{co}` and `{slug}` are resolved, check if a brainstorm file exists:
+
+```
+companies/{co}/projects/{slug}/brainstorm.md
+```
+
+**If found:**
+1. Read it. Extract YAML frontmatter (`status`, `source_idea_id`)
+2. If `status: "promoted"` — warn: "This brainstorm was already promoted to a PRD. Open existing prd.json instead?"
+3. **Pre-load brainstorm content** into interview context for Step 4:
+   - **Batch 1** (Problem/Success): pre-fill from brainstorm's `## Context`, `## Recommendation`. Present as confirmations ("Based on brainstorm: {X}. Confirm or modify?") instead of open-ended questions
+   - **Batch 2** (Users/Current State): pre-fill audience and current solution from brainstorm context if mentioned
+   - **Batch 3** (Scope/Constraints): pre-fill from `## What We Don't Know` + any constraints mentioned. Surface unknowns as explicit questions to resolve. Pre-fill non-goals from brainstorm's rejected approaches
+   - **Batch 4** (Data/Architecture): pre-fill from brainstorm's recommended approach's tech choices, data model mentions
+   - **Batch 5** (Integrations): pre-fill from brainstorm's identified external services
+   - **Batch 6** (Quality/Shipping): pre-fill from brainstorm's identified workers, repos
+   - **Batch 7** (E2E): unchanged — brainstorm doesn't cover testing specifics
+4. **Effect**: interview batches collapse to confirmations rather than open-ended questions. User answers faster, stories are better anchored to the evaluated approach
+
+**If not found:** proceed normally (no change to existing behavior).
+
+## Step 4: Discovery Interview
+
+Ask questions in batches. Users respond with shorthand: "1a A, 1b: build a dashboard, 1c B"
+
+Each question has lettered options for fast answers + free text override. Present one batch at a time, wait for response, then present next batch.
+
+**Before Batch 4:** Classify project type from description + Batch 1-3 answers:
+- **Code project** (has repoPath, or code/app/API/feature keywords) — ask all batches
+- **Content/knowledge/report** — skip Batches 4, 5; skip 6g/6h. Note: "(Batch 4 skipped — non-code project)"
+- **Personal/HQ tooling** — skip 5b, 5c, 6g, 6h
+
+### Dynamic Question Enrichment
+
+Use the context gathered in Step 2 (company policies, repo policies, manifest, repo scan) to **enrich questions with specific details** rather than asking generic versions. This makes questions faster to answer and surfaces constraints the user might forget.
+
+**From company policies** (`companies/{co}/policies/`):
+- Policy mentions feature flags / rollout — pre-fill 5c with the required approach, present as confirmation
+- Policy mentions PII / GDPR / compliance — always surface 5b regardless of keywords, note the policy
+- Policy mentions brand voice / design system — pre-fill 2c option C with the specific system name
+- Policy mentions specific deploy procedures — add context to 6a (quality gates)
+- Any `enforcement: hard` policy that constrains architecture, auth, or integrations — surface as a constraint in the relevant batch header (e.g. "Note: company policy requires Clerk auth for all new features")
+
+**From repo scan** (target repo's CLAUDE.md, package.json, existing patterns):
+- Repo uses specific auth (Clerk, NextAuth, Supabase Auth) — pre-fill 4b option A with: "Uses existing auth ({system}) — no changes needed"
+- Repo uses specific ORM/DB (Prisma, pgClient, Supabase) — add hint to 4a: "This repo uses {ORM}. Describe entities in those terms"
+- Repo has analytics/tracking (PostHog, Segment, Mixpanel, GA) — pre-fill 6g option B with the system name
+- Repo has monitoring (Sentry, Datadog, CloudWatch) — pre-fill 6h option B/D with the service name
+- Repo has existing test commands — pre-fill 6a with detected commands
+- Repo has existing design system / component library — mention in 2c option C
+
+**From manifest** (`companies/manifest.yaml`):
+- Company has `services: [stripe, ...]` — if project might involve payments, surface in 5a as a hint
+- Company has `vercel_team` — enrich 5c with "deploys via Vercel to {team}"
+- Company has existing integrations — list them as option B context in 5a
+
+**Presentation:** Weave enrichments into the question text naturally. Don't add a separate "detected context" dump — make each question smarter:
+```
+// Generic (bad):
+4b. Auth / permissions model?
+    A. Uses existing auth — no changes needed
+
+// Enriched (good):
+4b. Auth / permissions model? (repo uses Clerk via @clerk/nextjs)
+    A. Uses existing Clerk auth — no changes needed
+```
+
+If a policy or repo context **fully answers** a question, present it as a confirmation rather than an open question:
+```
+5c. Rollout strategy? → Company policy requires feature flags for all new features.
+    Confirming: B. Feature flag (env var)  [Y/n]
+```
+
+---
+
+**Batch 1 — Problem & Success**
+1a. Core problem or goal?
+1b. What does success look like? (measurable metric or verifiable state)
+1c. Who benefits? (list all beneficiaries)
+
+---
+
+**Batch 2 — Users & Current State**
+2a. Who are the primary users?
+    A. Internal / admin only
+    B. External customers / end users
+    C. Both internal and external
+    D. Developer tooling / no direct end user
+    (free text to specify roles and technical level, e.g. "Geoff — CEO, non-technical")
+
+2b. What exists today? (current solution, even if it's a spreadsheet or nothing)
+    A. Nothing — greenfield
+    B. Existing feature being replaced or upgraded
+    C. Manual process being automated
+    D. Third-party tool being replaced
+    (free text to describe what's being replaced and why it's insufficient)
+
+2c. Are there reference designs, mockups, or brand constraints? *(skip if non-UI)*
+    A. Figma file exists (provide file/node ID)
+    B. Visual reference / screenshot (describe or link)
+    C. Follow existing design system exactly (name which one)
+    D. No design constraints — AI chooses
+    E. Not a UI project (skip)
+    *Conditional: auto-skip with E for pure backend/CLI/data projects*
+
+---
+
+**Batch 3 — Scope & Constraints**
+3a. What's in scope for MVP?
+3b. Hard constraints (time, tech, budget)?
+3c. Dependencies on other projects?
+3d. What is explicitly NOT in scope? (non-goals — things users might ask for but we won't build)
+    (free text list, or "none")
+
+---
+
+**Batch 4 — Data & Architecture** *(conditional: code projects only)*
+*Trigger: project has repoPath or description contains DB/schema/API/model keywords. Auto-skip for content/knowledge/reports/social.*
+
+4a. Key data entities? (tables, columns, domain objects this project touches)
+    (free text, e.g. "new `depletions` table, adds `sku_id` FK to `line_items`" — or "no DB changes")
+
+4b. Auth / permissions model?
+    A. Uses existing auth — no changes needed
+    B. New role or permission level needed (describe)
+    C. New auth provider or login method
+    D. No auth (public or internal tool)
+
+4c. Architecture approach?
+    A. Follow existing patterns in the repo exactly
+    B. New pattern needed (describe)
+    C. No opinion — let workers decide
+
+4d. Performance requirements? *(conditional: only if real-time/scale/latency/throughput keywords in description)*
+    A. Standard — no special requirements
+    B. Latency target: [specify, e.g. "< 2s page load"]
+    C. Throughput target: [specify, e.g. "1000 req/s"]
+    D. Mobile / low-bandwidth optimization needed
+    *Default: A*
+
+---
+
+**Batch 5 — Integrations & Security** *(conditional: projects with external service interaction)*
+*Trigger: description contains API/webhook/OAuth/third-party/Stripe/Slack/integration keywords. Auto-skip for fully internal projects.*
+
+5a. External integrations or third-party APIs?
+    A. None — fully self-contained
+    B. Existing integrations (already wired up, just using them)
+    C. New integration needed — list: which service, what data flows, are credentials already set up?
+
+5b. Sensitive data or security considerations? *(conditional: only if user/payment/PII/customer keywords)*
+    A. No PII or sensitive data
+    B. PII handled (email, name, payment info) — existing compliance approach applies
+    C. New compliance requirement (HIPAA, GDPR, etc.)
+    D. Rate limiting or abuse protection needed
+    E. User-generated content with moderation needs
+
+5c. Rollout strategy? *(conditional: only for production-deployed projects with real users)*
+    A. Ship to all users immediately
+    B. Feature flag (specify: env var, LaunchDarkly, user segment)
+    C. Staged rollout (% of users or specific cohort)
+    D. Internal only first, then broader rollout
+    *Default: A*
+
+---
+
+**Batch 6 — Quality & Shipping**
+6a. Quality gates? (detect repo from scan, suggest commands)
+    A. `pnpm typecheck && pnpm lint`
+    B. `npm run typecheck && npm run lint`
+    C. None (no automated checks)
+    D. Other: [specify]
+
+6b. Based on scan: "Should this use {relevant workers}?"
+6c. Does this need a new worker or skill?
+6d. Repo path? (e.g. `repos/private/{name}`, or "none" if non-code)
+6e. Branch name? (default: `feature/{project-name}`)
+6f. Base branch? (default: `main`, or `staging` for {your-repo}, etc.)
+
+6g. Analytics / event tracking needed? *(conditional: deployable UI projects only)*
+    A. No — not a user-facing feature
+    B. Yes — use existing tracking system (name it)
+    C. Yes — new tracking events needed (list key events, e.g. "depletion.filter.applied")
+    D. Not sure — include tracking stub only
+    *Default: A*
+
+6h. How do we know it's working in production? *(conditional: production-deployed projects only)*
+    A. Manual testing only
+    B. Existing monitoring covers it (no changes needed)
+    C. New health check or monitoring alert needed (describe)
+    D. Success metric visible in existing dashboard (name it)
+    *Default: B for existing repos, A for greenfield*
+
+---
+
+**Batch 7 — E2E Testing** *(recommended for deployable projects)*
+For each user story targeting a deployable repo, specify E2E tests:
+
+7a. What E2E tests should verify each story works?
+    - For UI: "Page loads", "User can complete [action]", "Form shows validation errors"
+    - For API: "Endpoint returns expected response", "Error cases handled"
+    - For CLI: "Command runs successfully", "Opens correct URL"
+    - For integration: "Full flow from [A] to [B] works"
+    - Leave empty for non-deployable projects (knowledge, content, data)
+
+## Step 5: Generate PRD
+
+Create `companies/{co}/projects/{name}/` folder with two files. Use root `projects/{name}/` only for personal/HQ projects.
+
+### Primary: companies/{co}/projects/{name}/prd.json
+
+This is the **source of truth**. `$run-project` and `$execute-task` consume this file.
+
+```json
+{
+  "name": "{project-slug}",
+  "description": "{1-sentence goal}",
+  "branchName": "feature/{name}",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "{Story title}",
+      "description": "{As a [user], I want [feature] so that [benefit]}",
+      "acceptanceCriteria": ["{Specific verifiable criterion}"],
+      "e2eTests": [],
+      "priority": 1,
+      "passes": false,
+      "files": [],
+      "labels": [],
+      "dependsOn": [],
+      "notes": "",
+      "model_hint": ""
+    }
+  ],
+  "metadata": {
+    "createdAt": "{ISO8601}",
+    "goal": "{Overall project goal}",
+    "successCriteria": "{Measurable outcome}",
+    "qualityGates": ["{commands from Batch 6a}"],
+    "repoPath": "{repos/private/repo-name or empty}",
+    "baseBranch": "{main or staging or master}",
+    "relatedWorkers": ["{worker-ids from scan}"],
+    "knowledge": ["{relevant knowledge paths}"],
+    "audiences": ["{from Batch 2a — user roles + technical level}"],
+    "currentSolution": "{from Batch 2b — what exists today}",
+    "designRef": "{from Batch 2c — Figma ID, reference, or empty}",
+    "nonGoals": ["{from Batch 3d — explicit out-of-scope items}"],
+    "dataModel": "{from Batch 4a — key entities/tables or empty}",
+    "authModel": "{from Batch 4b — auth approach or empty}",
+    "architectureNotes": "{from Batch 4c — approach or empty}",
+    "performanceRequirements": "{from Batch 4d — targets or empty}",
+    "integrations": ["{from Batch 5a — service name, type, credentialsReady}"],
+    "securityNotes": "{from Batch 5b — PII/compliance notes or empty}",
+    "rolloutStrategy": "{from Batch 5c — ship strategy or empty}",
+    "analyticsEvents": ["{from Batch 6g — event names or empty}"],
+    "monitoringNotes": "{from Batch 6h — prod monitoring plan or empty}"
+  }
+}
+```
+
+**Populating `files`:** For each story, infer file paths from the description + acceptance criteria + target repo structure. If `repoPath` is set, search the repo (via qmd or Glob) to find existing files the story will modify, and predict new files it will create. Paths are repo-relative (e.g. `src/middleware/auth.ts`, not absolute). Best-effort — empty is fine for stories with unclear scope.
+
+### Derived: companies/{co}/projects/{name}/README.md
+
+Generate FROM the prd.json data. Human-friendly view.
+
+```markdown
+# {name from prd.json}
+
+**Goal:** {metadata.goal}
+**Success:** {metadata.successCriteria}
+**Repo:** {metadata.repoPath}
+**Branch:** {branchName}
+
+## Overview
+{description}
+
+## Audiences
+{metadata.audiences — who uses this and their technical level. Omit section if empty}
+
+## Quality Gates
+- `{metadata.qualityGates[0]}`
+
+## User Stories
+
+### US-001: {title}
+**Description:** {description}
+**Priority:** {priority}
+**Depends on:** {dependsOn or "None"}
+
+**Acceptance Criteria:**
+- [ ] {criterion 1}
+- [ ] {criterion 2}
+
+**E2E Tests:** (if non-empty)
+- [ ] {e2eTest 1}
+- [ ] {e2eTest 2}
+
+## Non-Goals
+{metadata.nonGoals — from Batch 3d answers. If empty, state "None defined"}
+
+## Technical Considerations
+{Enriched from interview answers:}
+- **Data model:** {metadata.dataModel — or omit if empty}
+- **Auth:** {metadata.authModel — or omit if empty}
+- **Architecture:** {metadata.architectureNotes — or omit if empty}
+- **Performance:** {metadata.performanceRequirements — or omit if empty}
+- **Integrations:** {metadata.integrations — list services, note if creds ready. Or omit if empty}
+- **Security:** {metadata.securityNotes — or omit if empty}
+- **Rollout:** {metadata.rolloutStrategy — or omit if empty}
+- **Analytics:** {metadata.analyticsEvents — list events. Or omit if empty}
+- **Monitoring:** {metadata.monitoringNotes — or omit if empty}
+{Omit any sub-bullet where the field is empty. If ALL fields empty, write general constraints/dependencies instead}
+
+## Open Questions
+{Remaining questions}
+```
+
+## Step 5.5: Update Brainstorm (if exists)
+
+If a `brainstorm.md` was detected in Step 3.5, update its YAML frontmatter:
+- Set `status: "promoted"`
+- Set `promoted_to: "companies/{co}/projects/{name}/prd.json"`
+
+This marks the brainstorm as consumed. The file is preserved for reference.
+
+## Step 5.6: Sync to Company Board
+
+Read `companies/manifest.yaml` to find `metadata.company` — `board_path`.
+
+If `board_path` exists, read `companies/{co}/board.json` and upsert a project entry:
+- **Match**: find existing entry by `prd_path === "companies/{co}/projects/{name}/prd.json"` or title similarity
+- **If found**: update `status` to `prd_created`, set `prd_path`, update `updated_at`
+- **If not found**: append new entry:
+  ```json
+  {
+    "id": "{co-prefix}-proj-{N+1}",
+    "title": "{project name}",
+    "description": "{1-sentence description}",
+    "status": "prd_created",
+    "scope": "company",
+    "app": null,
+    "initiative_id": null,
+    "prd_path": "companies/{co}/projects/{name}/prd.json",
+    "created_at": "{ISO8601}",
+    "updated_at": "{ISO8601}"
+  }
+  ```
+- Write updated `board.json` back to `board_path`
+- If no `metadata.company` in prd.json or no board_path, skip silently
+
+**Verify:** After upserting the board entry, re-read board.json and confirm the new project ID exists. If the write failed silently (file parse error, missing board, manifest lookup miss), log the error and retry once. Silent failure leaves projects invisible in the HQ app.
+
+## Step 6: Reindex & Wrap Up
+
+Reindex search so fresh sessions can find the new project:
+
+```bash
+qmd update 2>/dev/null || true
+```
+
+Note: Registration with orchestrator state.json happens when `$run-project` or `$execute-task` is invoked.
+
+## Step 7: Linear Sync (best-effort, optional)
+
+If the company has Linear credentials configured, attempt Linear sync. If credentials are unavailable or API fails, skip silently — Linear sync never blocks PRD creation.
+
+1. Read `companies/{co}/settings/linear/credentials.json` and `config.json`
+2. Validate workspace name in config matches expected company
+3. Create Linear project linked to best-fit initiative, with `leadId` and `targetDate` (default: today+1d)
+4. Create issue per story with `assigneeId` (resolved by team routing) and `dueDate` (matches project targetDate)
+5. Store all IDs in prd.json: `metadata.linearProjectId`, `metadata.linearCredentials`, per-story `linearIssueId`, `linearAssigneeId`
+
+No orphan issues — every issue must have a `projectId`. If project creation fails, skip issue creation.
+
+## Step 8: Confirm & STOP
+
+Tell user:
+```
+Project **{name}** created with {N} user stories.
+
+Files:
+  companies/{co}/projects/{name}/prd.json   (source of truth — tracks all work)
+  companies/{co}/projects/{name}/README.md  (human-readable view)
+
+To execute, start a new session and run:
+  $run-project {name}        (multi-story orchestrator)
+  $execute-task {name}/US-001 (single story)
+```
+
+**Then STOP. Do NOT proceed to execution.**
+
+## Story Guidelines
+
+- Each story completable in one AI session
+- Acceptance criteria must be verifiable (not "works correctly")
+- Order: schema — backend — UI — integration
+- Keep stories atomic (one deliverable each)
+- Every story starts with `passes: false`
+- `model_hint` (optional): override model for all workers in this story. Values: `"opus"`, `"sonnet"`, `"haiku"`. Leave empty to use worker defaults from worker.yaml
+- `files` (recommended): list of repo-relative file paths this story will likely create/modify. Used by file-locking system to prevent concurrent edit conflicts. Infer from story description + codebase search. Empty `[]` = no locks (backwards-compatible). Agents can expand the list dynamically during execution
+- `e2eTests` (recommended for deployable projects): list of executable test descriptions that verify each acceptance criterion. Leave `[]` for non-code projects. These drive acceptance test generation which creates real test files — cumulative back-pressure that protects completed stories from regression by later stories
+  - Format each entry as a Given/When/Then assertion: `"Given [context], when [action], then [expected]"`
+  - At least 1 test per acceptance criterion for code stories
+  - Tests should verify BEHAVIOR, not implementation details
+  - Examples: `"Given a logged-in user, when they pull to refresh, then the list reloads with fresh data"`, `"Given the settings form, when email is cleared and submitted, then a validation error shows"`
+- For deployable projects, include at least one story dedicated to E2E test infrastructure (Phase 0 pattern)
+
+### Story Complexity Budget
+
+Score each story: **(AC count x 1) + (file count x 2)**. Threshold: **<= 20**.
+
+At PRD generation, compute per-story. If score > 20:
+1. Warn: `"US-004 complexity=29. Recommend splitting."`
+2. Offer auto-split by: tab group, entity boundary, or API/UI separation
+3. If user declines split: add `"model_hint": "opus"` to the story
+
+Splitting heuristics:
+- **Tab-heavy UI**: split by tab group (tabs 1-3 / tabs 4-5)
+- **Multi-entity**: split by entity (brand detail / brand SKU)
+- **API + UI**: always split (schema/API story — UI story depends on it)
+- **12+ ACs**: almost always needs a split regardless of file count
+
+## Rules
+
+- Scan HQ first, ask questions second
+- Batch questions (don't overwhelm)
+- **prd.json is the source of truth** — README.md is derived from it, never the reverse
+- **All stories start with `passes: false`** — `$run-project` marks them true
+- **HARD BLOCK: Do NOT implement** — ONLY create the PRD files (`companies/{co}/projects/{name}/prd.json` + `README.md`). NEVER edit target files (repos, decks, sites, etc.) during a PRD session. Plan mode approval = "approved to generate PRD files," NOT "approved to implement." Implementation happens via `$execute-task` or `$run-project` AFTER PRD creation. Violating this bypasses project tracking, worker assignment, handoffs, and quality gates
+- **STOP after PRD creation** — After Step 8 confirmation, STOP. NEVER start executing stories, running workers, or writing implementation code in the same session. No exceptions, regardless of project size or user request. If user asks to start immediately, explain that execution requires a fresh session for context isolation. prd.json tracks all work for humans and future agent runs — this separation is mandatory
+- **Infrastructure before planning** — never create a PRD that references infrastructure (company, repo, knowledge) that doesn't exist. Fix gaps first (Step 2.5)
+- **MANDATORY: Always create project files** — Every PRD invocation MUST produce `companies/{co}/projects/{name}/prd.json` and `companies/{co}/projects/{name}/README.md`. No exceptions. These files are how HQ tracks work — they are NOT just inputs for $run-project. Never output a PRD to chat only, never skip file creation because the user "just wants a quick plan", never treat file generation as optional. If the user provides enough info to generate stories, write the files
+- **Every story MUST have testable acceptance criteria** — "works correctly" is not acceptable
+- **Include testing stories** — For deployable projects, at least one story should be dedicated to E2E test infrastructure
+- **Verify board.json write in Step 5.6** — After upserting the board entry, re-read board.json and confirm the new project ID exists. If the write failed silently, log the error and retry once

--- a/template/.claude/skills/prd/agents/openai.yaml
+++ b/template/.claude/skills/prd/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "PRD"
+  short_description: "Plan a project and generate a PRD for execution."

--- a/template/.claude/skills/run-project/SKILL.md
+++ b/template/.claude/skills/run-project/SKILL.md
@@ -1,0 +1,859 @@
+---
+name: run-project
+description: Run a multi-story project through sequential inline execution (Ralph loop). Stories execute one at a time via $execute-task — no process isolation, no parallel dispatch.
+allowed-tools: Read, Write, Edit, Grep, Bash(qmd:*), Bash(grep:*), Bash(ls:*), Bash(git:*), Bash(cat:*), Bash(which:*), Bash(wc:*), Bash(mkdir:*), Bash(echo:*), Bash(curl:*), Bash(python3:*), Bash(kill:*), Bash(cd:*), Bash(jq:*), Bash(bun:*), Bash(npm:*), Bash(scripts/*:*)
+argument-hint: "{project} [--status] [--resume] [--dry-run]"
+---
+
+# Run Project - Sequential Project Orchestrator
+
+Execute all stories in a PRD sequentially through the Ralph loop. Each story delegates to `$execute-task` inline.
+
+> **CRITICAL: Context Budget Warning**
+>
+> This is the most context-intensive skill in the HQ system. Each story executes inline via `$execute-task`, which itself loads worker configs, knowledge, policies, and runs multi-phase pipelines — all within your single context window.
+>
+> **Hard limits to understand:**
+> - A 3-story project with `api_development` tasks (~3 phases each) will consume roughly 40-60% of available context
+> - A 5-story `full_stack` project (~6 phases each) will almost certainly exceed context limits
+> - There is NO context reclamation between stories — everything accumulates
+> - Context overflow means lost work if you haven't checkpointed
+>
+> **Mandatory for projects with >5 stories:**
+> Run `$handoff` after completing each story. The next session resumes from where you left off — state.json and prd.json track progress. This is slower but guarantees completion.
+>
+> **Recommended for all projects:**
+> Commit after every story. Write auto-checkpoints. Monitor your context usage. When in doubt, handoff early.
+
+**Usage:**
+```
+run-project {project}
+run-project {project} --status
+run-project {project} --resume
+run-project {project} --dry-run
+```
+
+**User's input:** $ARGUMENTS
+
+---
+
+## Ralph Principle
+
+"Pick a task, complete it, commit it."
+
+- Sequential execution — one story at a time
+- Each story delegates to `$execute-task` inline
+- Back pressure (typecheck, lint, test) keeps code on rails
+- State files track progress for resumption across sessions
+- Handoffs between stories preserve context for large projects
+
+---
+
+## Step 1 — Parse Arguments
+
+Extract from `$ARGUMENTS`:
+- `project` — the project name (required unless `--status`)
+- `--status` — show project status and exit
+- `--resume` — explicitly resume from next incomplete story (auto-detected by default)
+- `--dry-run` — show execution plan without running anything
+
+If no arguments:
+```
+Usage: run-project {project} [--status] [--resume] [--dry-run]
+
+Example: run-project campaign-migration
+         run-project campaign-migration --dry-run
+         run-project --status
+```
+Stop here.
+
+### Handle --status (no project required)
+
+If `$ARGUMENTS` contains `--status`:
+
+1. List all directories under `workspace/orchestrator/`:
+   ```bash
+   ls -d workspace/orchestrator/*/state.json 2>/dev/null
+   ```
+2. For each state.json found, read and extract: project name, status, progress counts, last updated
+3. Display:
+   ```
+   Project Status:
+
+     campaign-migration   completed   4/4 stories   2026-03-08
+     order-system         in_progress 2/6 stories   2026-03-09
+     landing-page         not_started 0/3 stories   —
+   ```
+4. Stop here.
+
+---
+
+## Step 2 — Validate PRD + Display Summary
+
+### 2a. Find prd.json
+
+Use `qmd search` to discover the PRD file (never Glob for prd.json):
+
+```bash
+qmd search "{project} prd.json" --json -n 5
+```
+
+From results, find the entry whose path includes `/{project}/prd.json`. Extract the file path.
+
+If qmd is unavailable, try direct Read at these paths in order:
+1. `companies/{co}/projects/{project}/prd.json` (company projects)
+2. `projects/{project}/prd.json` (personal/HQ projects)
+
+If no prd.json found:
+```
+ERROR: prd.json not found for {project}. Run /prd {project} first.
+```
+Stop.
+
+### 2b. Read and Validate prd.json
+
+Read the prd.json file. Validate structure:
+
+1. **userStories array required**: If `userStories` is missing or not an array:
+   ```
+   ERROR: prd.json missing userStories array. Key must be "userStories" (not "stories" or "features").
+   ```
+   Stop.
+
+2. **Validate required fields per story**: Each story must have `id`, `title`, `description`, `passes`. Report missing fields.
+
+3. **Extract metadata**:
+   - `company` — active company slug
+   - `repoPath` — target repo path
+   - `linearCredentials` — path to Linear credentials (if configured)
+   - `linearProjectId` — Linear project ID (if configured)
+   - `qualityGates` — custom quality gate commands (if configured)
+   - `baseBranch` — base git branch (default: `main`)
+
+### 2c. Display Project Summary
+
+```
+Project: {project}
+Company: {company}
+Repo: {repoPath}
+
+Stories: {total} total | {completed} complete | {remaining} remaining
+```
+
+List each story with status:
+```
+  [done] US-001: Set up database schema
+  [done] US-002: Create API endpoints
+  [    ] US-003: Build frontend UI        (depends on: US-002)
+  [    ] US-004: Add authentication        (depends on: US-001, US-002)
+  [    ] US-005: Write integration tests   (depends on: US-003, US-004)
+```
+
+If all stories have `passes: true`:
+```
+All stories complete. Nothing to execute.
+```
+Stop.
+
+### 2d. Context Budget Assessment
+
+Count remaining stories. Display warning based on count:
+
+| Remaining | Warning Level |
+|-----------|---------------|
+| 1-3 | None — safe for single session |
+| 4-5 | CAUTION: May exhaust context. Commit after each story. Consider `$handoff` if context runs low. |
+| 6-10 | WARNING: Will almost certainly exceed context. MUST `$handoff` after each story. |
+| 11+ | CRITICAL: Run one story, then `$handoff`. Multi-session execution required. |
+
+Display the appropriate warning before proceeding.
+
+---
+
+## Step 3 — Handle --dry-run
+
+If `--dry-run` was specified:
+
+1. Compute story execution order (Step 5 logic — deps + priority + array order)
+2. For each story in order, classify task type and determine worker sequence (same as `$execute-task` steps 3-4)
+3. Display the full plan:
+
+```
+Dry Run: {project} — Execution Plan
+
+1. {story-id}: {title}
+   Type: api_development
+   Workers: product-planner → backend-dev → code-reviewer
+   Depends on: (none)
+
+2. {story-id}: {title}
+   Type: ui_component
+   Workers: frontend-dev → motion-designer → code-reviewer
+   Depends on: US-001
+
+Regression gates: after stories 3, 6, 9...
+Quality gates: {qualityGates from metadata}
+
+Estimated context cost: HIGH (6 stories × ~3 phases each)
+Recommendation: Use $handoff after each story
+```
+
+Stop here — do not execute.
+
+---
+
+## Step 4 — Load Policies
+
+Load policies from all applicable directories:
+
+1. **Company policies**: Determine active company from `prd.metadata.company` or path. Read all files in `companies/{co}/policies/` (skip `example-policy.md`).
+2. **Repo policies**: If `metadata.repoPath` is set, check `{repoPath}/.claude/policies/` if it exists.
+3. **Global policies**: Read `.claude/policies/` — filter by `trigger` field relevance to "task execution", "deployment", "commit".
+
+Note:
+- **Hard enforcement** policies are absolute constraints during execution
+- **Soft enforcement** policies allow deviation with logging
+
+Display: `Loaded {N} policies ({H} hard, {S} soft)`
+
+---
+
+## Step 5 — Initialize Project State
+
+### 5a. Create orchestrator directory
+
+```bash
+mkdir -p workspace/orchestrator/{project}/executions
+```
+
+### 5b. Read or Create state.json
+
+Read `workspace/orchestrator/{project}/state.json` if it exists. If not, create initial state:
+
+```json
+{
+  "project": "{project}",
+  "prd_path": "{prd_path}",
+  "status": "in_progress",
+  "started_at": "{ISO8601}",
+  "updated_at": "{ISO8601}",
+  "progress": {
+    "total": {N},
+    "completed": {count of passes:true},
+    "failed": 0,
+    "in_progress": 0
+  },
+  "current_tasks": [],
+  "completed_tasks": [],
+  "failed_tasks": [],
+  "retry_queue": [],
+  "regression_gates": [],
+  "orchestrator": "codex-inline"
+}
+```
+
+If state.json already exists with `status: "in_progress"` or `status: "paused"`, this is a resume. Log:
+```
+Resuming {project} from story {N+1}/{total}
+```
+
+### 5c. Initialize progress.txt
+
+If `workspace/orchestrator/{project}/progress.txt` does not exist, create it:
+
+```
+{project}: 0/{total} complete
+Started: {ISO8601}
+```
+
+### 5d. Audit: Project Started
+
+```bash
+scripts/audit-log.sh append \
+  --event project_started \
+  --project {project} \
+  --company {company} \
+  --action "Project execution started: {total} stories, {remaining} remaining" || true
+```
+
+---
+
+## Step 5.5 — Linear Project Sync (Best-Effort)
+
+If prd metadata has `linearProjectId` and `linearCredentials`:
+
+1. **Cross-company guard**: Verify the `linearCredentials` path matches the active company per `companies/manifest.yaml`. If mismatch, ABORT Linear sync and warn.
+
+2. **Read API key**:
+   ```bash
+   LINEAR_KEY=$(cat {prd.metadata.linearCredentials} | python3 -c "import sys,json; print(json.load(sys.stdin)['apiKey'])")
+   ```
+
+3. **Set project to Started** (if first run, not resume):
+   ```bash
+   curl -s -X POST https://api.linear.app/graphql \
+     -H "Content-Type: application/json" \
+     -H "Authorization: $LINEAR_KEY" \
+     -d '{"query": "mutation { projectUpdate(id: \"'$PROJECT_ID'\", input: { state: \"started\" }) { success } }"}'
+   ```
+
+Skip silently if no `linearProjectId` or no credentials. Never block execution on Linear sync failure.
+
+---
+
+## Step 6 — Compute Story Execution Order
+
+Build the ordered list of stories to execute:
+
+### 6a. Filter Incomplete Stories
+
+From prd.json `userStories`, select all stories where `passes` is not `true`.
+
+### 6b. Topological Sort by Dependencies
+
+For each story with `dependsOn`, verify all dependencies have `passes: true`. Stories with unresolved dependencies are deferred until their deps complete.
+
+Sort order: **deps resolved → lowest priority value → array order**
+
+1. Stories with no dependencies (or all deps satisfied) come first
+2. Among those, sort by `priority` field (lowest number = highest priority)
+3. Among same priority, preserve prd.json array order
+
+### 6c. Detect Blocked Stories
+
+If any story has dependencies that are themselves incomplete AND also have unresolvable dependencies (circular), report:
+```
+ERROR: Circular dependency detected: {story-id} → {dep-id} → ... → {story-id}
+```
+Stop.
+
+### 6d. Display Execution Order
+
+```
+Execution Order:
+  1. US-001: Set up database schema (priority 1, no deps)
+  2. US-002: Create API endpoints (priority 2, deps: US-001)
+  3. US-003: Build frontend UI (priority 2, deps: US-002)
+  4. US-004: Add authentication (priority 3, deps: US-001, US-002)
+
+Regression gates at: story 3, story 6, ...
+```
+
+---
+
+## Step 7 — Sequential Story Execution (Ralph Loop)
+
+For each story in the computed execution order:
+
+### 7a. Pre-Story Check
+
+1. **Re-read prd.json** — a previous story's execution may have modified it
+2. **Verify story still incomplete** — skip if `passes: true` (another session may have completed it)
+3. **Verify dependencies satisfied** — all `dependsOn` stories have `passes: true`
+4. **Check file lock conflicts** — if story has `files` array, check `{repoPath}/.file-locks.json` for conflicts. Skip story if hard-blocked; log warning if soft-blocked.
+
+### 7b. Announce Story
+
+```
+════════════════════════════════════════════════
+[{N}/{total}] Story: {story.id} - {story.title}
+════════════════════════════════════════════════
+
+Description: {story.description}
+
+Acceptance Criteria:
+  - {criterion 1}
+  - {criterion 2}
+  - {criterion 3}
+```
+
+### 7c. Update State — Story Started
+
+Update `workspace/orchestrator/{project}/state.json`:
+- Set `progress.in_progress` to 1
+- Add story to `current_tasks` array:
+  ```json
+  {
+    "id": "{story.id}",
+    "started_at": "{ISO8601}",
+    "status": "in_progress"
+  }
+  ```
+- Update `updated_at`
+
+### 7d. Delegate to $execute-task
+
+Execute the story by invoking `$execute-task` inline:
+
+**Invoke:** `execute-task {project}/{story.id}`
+
+This delegates the full worker pipeline:
+- Task classification
+- Worker sequence selection
+- Per-worker inline execution
+- Back-pressure checks (typecheck, lint, test)
+- PRD update (`passes: true`)
+- Execution state tracking
+- Linear sync (in progress → done)
+- File lock management
+
+> **Orchestrator mode directive:** When invoking `$execute-task` from this orchestrator context, the execute-task skill handles everything end-to-end including setting `passes: true`. The orchestrator verifies the result after execution.
+
+### 7e. Verify Story Completion
+
+After `$execute-task` returns:
+
+1. **Re-read prd.json** — check if `passes: true` was set on the story
+2. **Check git state**:
+   ```bash
+   git status --short
+   ```
+   If there are uncommitted changes, commit them:
+   ```bash
+   git add -A && git commit -m "Auto-commit: {story.id} - {story.title}"
+   ```
+
+3. **Parse result**: Determine success or failure from execute-task output
+
+### 7f. Update State — Story Completed/Failed
+
+**On success:**
+- Move story from `current_tasks` to `completed_tasks`
+- Increment `progress.completed`
+- Set `progress.in_progress` to 0
+- Update `updated_at`
+
+**On failure:**
+- Move story from `current_tasks` to `failed_tasks` with error details
+- Increment `progress.failed`
+- Set `progress.in_progress` to 0
+- Add to `retry_queue` (for end-of-run retry pass)
+- Update `updated_at`
+
+### 7g. Update progress.txt
+
+Append to `workspace/orchestrator/{project}/progress.txt`:
+
+```
+[pass] {story.id}: {story.title} — completed {ISO8601}
+```
+or
+```
+[FAIL] {story.id}: {story.title} — failed at phase {N} ({worker}): {error}
+```
+
+### 7h. Auto-Checkpoint After Story
+
+Write a thread checkpoint:
+
+```json
+{
+  "thread_id": "T-{YYYYMMDD}-{HHMMSS}-auto-{project}-{story.id}",
+  "version": 1,
+  "type": "auto-checkpoint",
+  "created_at": "{ISO8601}",
+  "updated_at": "{ISO8601}",
+  "workspace_root": "~/Documents/HQ",
+  "cwd": "{current working directory}",
+  "git": {
+    "branch": "{current branch}",
+    "current_commit": "{short hash}",
+    "dirty": false
+  },
+  "conversation_summary": "Completed {story.id} ({story.title}) in {project}. Progress: {completed}/{total}.",
+  "files_touched": ["{files from execute-task output}"],
+  "metadata": {
+    "title": "Auto: run-project {project} [{N}/{total}]",
+    "tags": ["auto-checkpoint", "run-project", "{project}", "{story.id}"],
+    "trigger": "worker-completion"
+  }
+}
+```
+
+Write to: `workspace/threads/{thread_id}.json`
+
+### 7i. Context Budget Check
+
+After each story completes, assess context usage:
+
+- If this is a project with >5 total stories: recommend `$handoff`
+  ```
+  Context check: {completed}/{total} stories done. This project has >5 stories.
+  RECOMMENDED: Run $handoff now and resume in a fresh session.
+  State is saved — the next session will pick up from story {next_id}.
+  ```
+
+- If context appears to be running low (many long outputs from execute-task):
+  ```
+  Context budget warning: Running low on context after {N} stories.
+  Run $handoff to continue in a fresh session. Progress is saved.
+  ```
+
+### 7j. Regression Gates
+
+Every 3 completed stories, run quality gates:
+
+1. Check if `progress.completed % 3 === 0` (and `progress.completed > 0`)
+2. If yes, run each command in `metadata.qualityGates`:
+   ```bash
+   cd {repoPath} && {gate_command}
+   ```
+3. Record results in state.json `regression_gates` array:
+   ```json
+   {
+     "after_story": "{story.id}",
+     "story_count": {N},
+     "gates": [
+       {"command": "bun test", "result": "pass"},
+       {"command": "bun check", "result": "pass"},
+       {"command": "bun lint", "result": "fail", "error": "..."}
+     ],
+     "timestamp": "{ISO8601}"
+   }
+   ```
+
+**On regression gate failure:**
+```
+REGRESSION GATE FAILED after story {story.id}
+
+  bun test:  pass
+  bun check: FAIL — 3 TypeScript errors
+  bun lint:  pass
+
+Options:
+  1. Fix the issue and continue (you're in the session)
+  2. Skip and continue (risk accumulating regressions)
+  3. Stop execution — run $handoff to preserve state
+```
+
+Do NOT auto-skip. Surface the failure and let the context decide next steps.
+
+### 7k. Repeat for Next Story
+
+Return to Step 7a for the next story in the execution order.
+
+---
+
+## Step 8 — Retry Queue
+
+After all stories in the execution order have been attempted:
+
+If `retry_queue` is non-empty:
+1. Log: `Retry pass: {N} failed stories to retry`
+2. For each story in `retry_queue`:
+   - Reset story status
+   - Re-attempt via `$execute-task`
+   - On success: move to `completed_tasks`, update PRD
+   - On second failure: leave in `failed_tasks`, report as permanent failure
+
+---
+
+## Step 9 — Completion Flow
+
+When all stories have `passes: true` (or all remaining are permanently failed):
+
+### 9a. Linear Project Sync (Best-Effort)
+
+If `linearProjectId` is configured:
+- Set project to "completed" state
+- Comment: "Project completed by HQ. {completed}/{total} stories passed."
+
+### 9b. Summary Report
+
+Generate `workspace/reports/{project}-summary.md`:
+
+```markdown
+# {project} — Execution Summary
+
+**Status:** {completed|partial}
+**Started:** {started_at}
+**Completed:** {ISO8601}
+**Duration:** {elapsed}
+
+## Stories
+
+| ID | Title | Result | Phases | Workers |
+|----|-------|--------|--------|---------|
+| US-001 | Set up schema | pass | 4 | architect, database-dev, code-reviewer |
+| US-002 | Create API | pass | 3 | backend-dev, code-reviewer |
+
+## Regression Gates
+
+| After Story | Result | Details |
+|-------------|--------|---------|
+| US-003 | pass | All 3 gates passed |
+
+## Metrics
+
+- Total phases executed: {N}
+- Total workers used: {N} unique
+- Back-pressure failures: {N} (all recovered)
+- Retry queue: {N} stories retried
+```
+
+### 9c. Update Final State
+
+Write `workspace/orchestrator/{project}/state.json`:
+
+```json
+{
+  "project": "{project}",
+  "prd_path": "{prd_path}",
+  "status": "completed",
+  "started_at": "{original_start}",
+  "updated_at": "{ISO8601}",
+  "completed_at": "{ISO8601}",
+  "progress": {
+    "total": {N},
+    "completed": {N},
+    "failed": {N},
+    "in_progress": 0
+  },
+  "current_tasks": [],
+  "completed_tasks": ["{list}"],
+  "failed_tasks": ["{list}"],
+  "retry_queue": [],
+  "regression_gates": ["{list}"],
+  "orchestrator": "codex-inline"
+}
+```
+
+### 9d. Final progress.txt Update
+
+Append to `workspace/orchestrator/{project}/progress.txt`:
+
+```
+────────────────────────────────
+{project}: {completed}/{total} complete
+Completed: {ISO8601}
+Duration: {elapsed}
+Regression gates: {passed}/{total_gates} passed
+────────────────────────────────
+```
+
+### 9e. Capture Learnings
+
+If the project encountered notable patterns (regression failures, retry successes, dependency issues), capture via `$learn`:
+
+```json
+{
+  "project": "{project}",
+  "source": "project-completion",
+  "severity": "medium",
+  "scope": "auto",
+  "stories_completed": {N},
+  "stories_failed": {N},
+  "regression_failures": ["{details}"],
+  "patterns_discovered": ["{insights}"]
+}
+```
+
+Skip if project completed cleanly with no notable events.
+
+### 9f. Reindex
+
+```bash
+qmd update 2>/dev/null || true
+```
+
+### 9g. Audit: Project Completed
+
+```bash
+scripts/audit-log.sh append \
+  --event project_completed \
+  --project {project} \
+  --company {company} \
+  --action "Project completed: {completed}/{total} stories, {elapsed} elapsed" \
+  --result {success|partial} || true
+```
+
+### 9h. Report Completion
+
+```
+Project Complete: {project}
+
+Stories: {completed}/{total} passed
+Failed: {failed_count} (see retry queue)
+Duration: {elapsed}
+Regression gates: {passed}/{total_gates} passed
+
+Report: workspace/reports/{project}-summary.md
+State:  workspace/orchestrator/{project}/state.json
+
+Next steps:
+  - Review report for any noted issues
+  - Run /run-project --status to see all projects
+```
+
+---
+
+## Step 10 — Handle Project-Level Failures
+
+If execution must stop before all stories complete:
+
+### 10a. Save State
+
+Write current state to state.json with `status: "paused"`:
+
+```json
+{
+  "status": "paused",
+  "paused_at": "{ISO8601}",
+  "pause_reason": "{reason}",
+  "next_story": "{story.id}"
+}
+```
+
+### 10b. Update progress.txt
+
+```
+PAUSED: {reason}
+Next story: {next_story_id}
+Resume: run-project {project} --resume
+```
+
+### 10c. Report Pause
+
+```
+Project Paused: {project}
+
+Completed: {N}/{total} stories
+Reason: {pause_reason}
+Next story: {next_story_id}
+
+Resume: run-project {project} --resume
+```
+
+---
+
+## Step 11 — Auto-Checkpoint (Project Level)
+
+After project completion (or pause), write a project-level checkpoint:
+
+```json
+{
+  "thread_id": "T-{YYYYMMDD}-{HHMMSS}-auto-{project}-complete",
+  "version": 1,
+  "type": "auto-checkpoint",
+  "created_at": "{ISO8601}",
+  "updated_at": "{ISO8601}",
+  "workspace_root": "~/Documents/HQ",
+  "cwd": "{current working directory}",
+  "git": {
+    "branch": "{current branch}",
+    "current_commit": "{short hash}",
+    "dirty": false
+  },
+  "conversation_summary": "Project {project}: {completed}/{total} stories completed. Status: {status}.",
+  "files_touched": [
+    "workspace/orchestrator/{project}/state.json",
+    "workspace/orchestrator/{project}/progress.txt",
+    "workspace/reports/{project}-summary.md"
+  ],
+  "metadata": {
+    "title": "Auto: run-project {project} complete",
+    "tags": ["auto-checkpoint", "run-project", "{project}"],
+    "trigger": "worker-completion"
+  }
+}
+```
+
+Write to: `workspace/threads/{thread_id}.json`
+
+---
+
+## Examples
+
+```
+run-project campaign-migration           # Execute all stories sequentially
+run-project campaign-migration --resume  # Resume from next incomplete story
+run-project campaign-migration --dry-run # Show execution plan without running
+run-project --status                     # Show all project statuses
+run-project order-system                 # Execute another project
+```
+
+### Worked Example: 4-Story Project
+
+```
+> run-project campaign-migration
+
+Project: campaign-migration
+Company: {company}
+Repo: repos/private/{product}
+
+Stories: 4 total | 0 complete | 4 remaining
+  [    ] CM-001: Set up campaign database tables (priority 1)
+  [    ] CM-002: Migrate campaign A data (depends on: CM-001)
+  [    ] CM-003: Migrate campaign B data (depends on: CM-001)
+  [    ] CM-004: Verify all campaigns migrated (depends on: CM-002, CM-003)
+
+Context budget: OK (4 stories — safe for single session)
+Loaded 5 policies (3 hard, 2 soft)
+
+Execution Order:
+  1. CM-001 (priority 1, no deps)
+  2. CM-002 (priority 2, deps: CM-001)
+  3. CM-003 (priority 2, deps: CM-001)
+  4. CM-004 (priority 3, deps: CM-002, CM-003)
+
+════════════════════════════════════════════════
+[1/4] Story: CM-001 - Set up campaign database tables
+════════════════════════════════════════════════
+→ Delegating to $execute-task campaign-migration/CM-001
+  ... (execute-task runs full worker pipeline) ...
+→ Result: PASS (4 phases, 3 files touched)
+→ Checkpoint saved
+
+════════════════════════════════════════════════
+[2/4] Story: CM-002 - Migrate campaign A data
+════════════════════════════════════════════════
+→ Delegating to $execute-task campaign-migration/CM-002
+  ... (execute-task runs full worker pipeline) ...
+→ Result: PASS (3 phases, 2 files touched)
+→ Checkpoint saved
+
+════════════════════════════════════════════════
+[3/4] Story: CM-003 - Migrate campaign B data
+════════════════════════════════════════════════
+→ Delegating to $execute-task campaign-migration/CM-003
+  ... (execute-task runs full worker pipeline) ...
+→ Result: PASS (3 phases, 2 files touched)
+→ Checkpoint saved
+
+>>> REGRESSION GATE (after 3 stories)
+  bun test:  pass
+  bun check: pass
+  bun lint:  pass
+All gates passed.
+
+════════════════════════════════════════════════
+[4/4] Story: CM-004 - Verify all campaigns migrated
+════════════════════════════════════════════════
+→ Delegating to $execute-task campaign-migration/CM-004
+  ... (execute-task runs full worker pipeline) ...
+→ Result: PASS (2 phases, 1 file touched)
+→ Checkpoint saved
+
+Project Complete: campaign-migration
+Stories: 4/4 passed | Duration: 2h 15m
+Regression gates: 1/1 passed
+Report: workspace/reports/campaign-migration-summary.md
+```
+
+---
+
+## Notes
+
+- **No process isolation** — unlike Claude Code's `run-project.sh` which spawns `claude -p` per story, this skill executes everything inline. Each story's full worker pipeline runs in your context window.
+- **No parallel dispatch** — Claude Code supports `--swarm` for parallel story execution via worktrees. This skill is sequential only. Stories with independent deps still run one at a time.
+- **No background process** — Claude Code launches `run-project.sh` as a background OS process and polls state files. This skill runs synchronously in-session.
+- **No tmux mode** — no `--tmux` flag. Everything is visible in the current session.
+- **State.json compatibility** — the state.json format matches Claude Code's format exactly. A project started in Claude Code can be resumed in Codex and vice versa (the `orchestrator` field distinguishes them).
+- **PRD discovery** — always use `qmd search` first. Never Glob for `prd.json`.
+- **Worker path lookup** — always read `workers/registry.yaml` first. Never Glob for `worker.yaml`.
+- **Linear sync** — best-effort at both project and story level. Never blocks execution.
+- **Regression gates** — run every 3 completed stories using `metadata.qualityGates` from prd.json. Failures surface inline for decision.
+- **Context is the bottleneck** — this is the fundamental constraint. Claude Code uses process isolation to give each story a fresh context window. Here, everything accumulates. For large projects, `$handoff` after each story is not a suggestion — it's a requirement.
+- **Resume is first-class** — state.json and prd.json together capture full progress. Running `run-project {project}` on a partially-completed project automatically resumes from the next incomplete story.
+- **Commit discipline** — the orchestrator verifies git state after each story and auto-commits if `$execute-task` left uncommitted work. Never lose work to context overflow.
+- **Audit trail** — every project start, story completion, and project completion is logged to `workspace/metrics/audit-log.jsonl` via `scripts/audit-log.sh`.

--- a/template/.claude/skills/run-project/agents/openai.yaml
+++ b/template/.claude/skills/run-project/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Run Project"
+  short_description: "Execute a multi-story PRD project through sequential inline story execution (Ralph loop)."

--- a/template/.claude/skills/run/SKILL.md
+++ b/template/.claude/skills/run/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: run
+description: Run a worker or list available workers. Executes worker skills inline — no sub-agent isolation.
+allowed-tools: Read, Grep, Bash(qmd:*), Bash(grep:*), Bash(ls:*), Bash(git:*), Bash(cat:*), Bash(which:*), Bash(wc:*), Edit, Write
+argument-hint: "[worker-id] [skill] [args]"
+---
+
+# Run - Worker Execution
+
+Unified interface to run workers and their skills in Codex sessions.
+
+> **⚠️ Codex Adaptation Note — No Context Isolation**
+>
+> In Claude Code, `/run` spawns an isolated Task sub-agent per worker. Worker context (instructions, knowledge, policies) lives in a separate context window and does not bleed into the parent session.
+>
+> In Codex, workers execute **inline** in the current context window. This means:
+> - Worker instructions, knowledge, and policies are loaded into **your** active context
+> - Worker state and outputs are visible to the rest of the session
+> - Long-running workers or knowledge-heavy workers will consume your context budget
+> - Consider using `$handoff` between workers for large multi-worker sessions
+
+**Usage:**
+```
+run                          # List available workers
+run {worker-id}              # Show worker skills
+run {worker-id} {skill}      # Run specific skill
+run {worker-id} {skill} arg  # Run with argument
+```
+
+**User's input:** $ARGUMENTS
+
+---
+
+## Step 1 — Parse Arguments
+
+Extract from `$ARGUMENTS`:
+- `worker_id` — first token
+- `skill` — second token (optional)
+- `args` — remaining tokens (optional, passed to skill as `$ARGUMENTS`)
+
+---
+
+## Step 2 — Route by Input
+
+### No Arguments → List Workers
+
+Read `workers/registry.yaml` and display all workers:
+
+```
+Available Workers:
+
+  x-{your-name}            X/Twitter posting for {your-name}
+  cfo-{company}    Financial reporting
+  {company}-analyst LR/{PRODUCT} data analysis
+  ...
+
+Usage: run {worker-id} [skill] [args]
+```
+
+Stop here.
+
+### Worker ID Only → Show Skills
+
+1. Read `workers/registry.yaml`
+2. Find the entry matching `{worker_id}`
+3. Read `{worker_path}/worker.yaml`
+4. List skills from the `skills:` section
+
+```
+Worker: x-{your-name}
+Description: X/Twitter posting for {your-name}
+
+Skills:
+  contentidea   Build out a content idea into posts
+  suggestposts  Research and suggest posts
+  scheduleposts Choose what to post now
+
+Usage: run x-{your-name} {skill}
+```
+
+Stop here.
+
+### Worker + Skill (+ Args) → Execute Inline
+
+Proceed to the full execution pipeline below.
+
+---
+
+## Step 3 — Load Worker Context
+
+### 3a. Find Worker Registry Entry
+
+Use the Read tool to read `workers/registry.yaml`. The registry stores workers as a YAML list under the `workers:` key, with each entry shaped like:
+
+```yaml
+workers:
+  - id: x-{your-name}
+    path: companies/personal/workers/x-{your-name}/
+    description: "..."
+```
+
+Scan the list for the entry where `id:` matches `{worker_id}` and extract its `path:` field. If needed, use Grep with the correct pattern to find the path:
+
+```bash
+grep -A 4 "  - id: {worker_id}$" workers/registry.yaml | grep "path:"
+```
+
+Extract the `path:` value (strip the `path: ` prefix). If no matching entry found, display:
+```
+Error: Worker '{worker_id}' not found in registry.
+Run 'run' (no args) to list available workers.
+```
+Stop.
+
+### 3b. Read worker.yaml
+
+Read `{worker_path}/worker.yaml` in full. This contains:
+- `instructions:` — the worker's accumulated knowledge and learnings
+- `tools:` — permitted tools (respect these during execution)
+- `knowledge:` — paths to knowledge files (load relevant ones)
+- `company:` — company scope (used for policy loading)
+- `skills:` — available skill definitions
+
+### 3c. Find and Read the Skill File
+
+Skill definitions are in `{worker_path}/skills/{skill}.md`.
+
+If the skill file does not exist, check `worker.yaml` `skills:` section for an inline definition. If still not found:
+```
+Error: Skill '{skill}' not found for worker '{worker_id}'.
+Run 'run {worker_id}' to see available skills.
+```
+Stop.
+
+---
+
+## Step 4 — Load Policies
+
+Determine the company scope from:
+1. `worker.yaml` `company:` field
+2. Worker path prefix: `companies/{co}/workers/` → company is `{co}`
+3. Fallback: no company scope
+
+If company determined, read policies:
+```bash
+ls companies/{co}/policies/ 2>/dev/null
+```
+
+Read each policy file (skip `example-policy.md`). Note:
+- **Hard enforcement** → treat as absolute constraints during execution
+- **Soft enforcement** → note deviations, proceed
+
+If worker targets a specific repo (from `worker.yaml` `repo:` field), also read:
+```bash
+ls {repoPath}/.claude/policies/ 2>/dev/null
+```
+
+---
+
+## Step 5 — Load Knowledge
+
+From `worker.yaml` `knowledge:` section, load relevant knowledge files referenced. Prioritize files related to the requested skill. Use:
+
+```bash
+which qmd 2>/dev/null && qmd search "{worker_id} {skill}" --json -n 5 -c hq
+```
+
+Or read knowledge files directly via Read tool if paths are specified in worker.yaml.
+
+---
+
+## Step 6 — Execute Skill Inline
+
+With all context loaded (worker instructions, skill file, policies, knowledge):
+
+1. **Understand the skill** — re-read `{skill}.md` instructions
+2. **Apply worker constraints** — only use tools listed in `worker.yaml` `tools:` section
+3. **Execute** — follow the skill's instructions step by step
+4. **Pass arguments** — `$ARGUMENTS` in the skill file refers to the args from `$ARGUMENTS` (tokens after `{worker_id} {skill}`)
+5. **Verify** — run any verification steps defined in the skill file
+
+> **Context reminder:** You are executing inline. Keep responses focused. If the skill involves large knowledge loads or multi-step research, note the context cost at the start of execution.
+
+---
+
+## Step 7 — Auto-Checkpoint
+
+After skill completion, write a thread checkpoint file:
+
+```json
+{
+  "thread_id": "T-{YYYYMMDD}-{HHMMSS}-{worker_id}-{skill}",
+  "version": 1,
+  "type": "auto-checkpoint",
+  "created_at": "{ISO8601}",
+  "updated_at": "{ISO8601}",
+  "workspace_root": "~/Documents/HQ",
+  "cwd": "{current working directory}",
+  "git": {
+    "branch": "{current branch from git branch --show-current}",
+    "current_commit": "{short hash from git rev-parse --short HEAD}",
+    "dirty": "{true if git status --short output is non-empty, false otherwise}"
+  },
+  "conversation_summary": "Ran {worker_id}/{skill}: {1-sentence description of what was accomplished}",
+  "files_touched": ["{list of files created or modified}"],
+  "metadata": {
+    "title": "Auto: {worker_id} {skill}",
+    "tags": ["auto-checkpoint", "{worker_id}", "{skill}"],
+    "trigger": "worker-completion"
+  }
+}
+```
+
+Write to: `workspace/threads/{thread_id}.json`
+
+Get git state with:
+```bash
+git rev-parse --short HEAD 2>/dev/null
+git branch --show-current 2>/dev/null
+git status --short 2>/dev/null
+```
+
+Set `dirty: true` if `git status --short` output is non-empty; `false` if empty.
+
+---
+
+## Examples
+
+```
+run                              # See all workers
+run x-{your-name}                      # See x-{your-name} skills
+run x-{your-name} contentidea          # Run contentidea skill
+run x-{your-name} contentidea "AI workforce"  # Run with topic arg
+run cfo-{company} mrr          # Run MRR report
+run {company}-analyst weekly   # Run weekly analysis
+```
+
+---
+
+## Notes
+
+- **No isolation** — worker context bleeds into your session. This is the key difference from Claude Code.
+- **Tool constraints** — only use tools listed in `worker.yaml` `tools:` while executing the skill.
+- **Knowledge loading** — load only knowledge relevant to the skill; don't load everything.
+- **Context budget** — for heavy workers (large knowledge bases, complex skills), warn the user upfront. Suggest `$handoff` before and after if context budget is a concern.
+- **Worker path lookup** — always read `workers/registry.yaml` first. Never Glob for `worker.yaml`.
+- **Skill args** — `$ARGUMENTS` in skill files is replaced by everything after `{worker_id} {skill}` in the user's input.

--- a/template/.claude/skills/run/agents/openai.yaml
+++ b/template/.claude/skills/run/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Run"
+  short_description: "Run an HQ worker skill inline. Executes workers in the current context (no sub-agent isolation)."

--- a/template/.claude/skills/search/SKILL.md
+++ b/template/.claude/skills/search/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: search
+description: Search across HQ and indexed repos (qmd-powered semantic + full-text). Falls back to Grep if qmd is unavailable.
+allowed-tools: Read, Grep, Bash(qmd:*), Bash(grep:*), Bash(ls:*)
+---
+
+# Search - HQ + Codebase Search
+
+Semantic + full-text search across HQ and indexed codebases using qmd. Falls back to Grep if qmd is unavailable.
+
+**Input:** The user's search query, with optional flags.
+
+## Parse Arguments
+
+Extract from the user's input:
+- `query` — search text (everything except flags)
+- `--mode` — `search` (BM25), `vsearch` (semantic), `query` (hybrid). Default: `search`
+- `-n` — result count (default: 10)
+- `-c` — collection name (e.g. `hq`, `{product}`). Default: auto-detect or all collections
+- `--full` — show full content of top result
+
+## Company Auto-Detection
+
+If `-c` was NOT explicitly provided, infer the active company from context:
+
+1. **cwd**: If inside `companies/{name}/` or `repos/private/` matching a company repo → use that company's collection
+2. **Recent files**: If recent file access is scoped to a single company → use that company's collection
+3. **Fallback**: No collection flag (search all)
+
+Available company collections: `{company}`, `{company}`, `{company}`, `personal`
+Also: `hq` (all HQ), `{product}` ({PRODUCT} codebase)
+
+When auto-detected, display: `(auto: {company})` in results header.
+
+## Check qmd Availability
+
+```bash
+which qmd 2>/dev/null && qmd --version 2>/dev/null
+```
+
+If qmd is not available, skip to **Fallback** section.
+
+## Execute Search
+
+Run the matching qmd command. Add `-c $COLLECTION` if a collection was specified or auto-detected:
+
+**Default (BM25 full-text):**
+```bash
+qmd search "$QUERY" -n $N --json [-c $COLLECTION]
+```
+
+**Semantic (conceptual match):**
+```bash
+qmd vsearch "$QUERY" -n $N --json [-c $COLLECTION]
+```
+
+**Hybrid (BM25 + vector + re-rank — best quality, slower):**
+```bash
+qmd query "$QUERY" -n $N --json [-c $COLLECTION]
+```
+
+## Display Results
+
+Parse JSON output. Display:
+
+```
+Search: "{query}" (mode: {mode}, collection: {collection or "all"})
+
+Results:
+  1. [0.92] hq: knowledge/public/Ralph/02-core-concepts.md
+     "Ralph methodology emphasizes small loops with human checkpoints..."
+
+  2. [0.84] {product}: libs/core/src/auth/middleware.ts
+     "export function authMiddleware..."
+
+  3. [0.71] hq: workers/public/dev-team/architect/skills/design-review.md
+     "Architecture review following Ralph back-pressure patterns..."
+
+{n} results. Use --full to show top result content.
+```
+
+- Score in brackets
+- Collection prefix + relative path (strip `qmd://{collection}/` prefix)
+- Snippet truncated to ~100 chars
+
+## Full Content
+
+If `--full` flag, after listing results, read the top result file with the Read tool.
+
+## Fallback
+
+If qmd is unavailable or errors:
+
+Use the Grep tool to search file contents:
+- Search pattern: the query text
+- Search directories: `knowledge/`, `companies/`, `workers/`, `.claude/commands/`, `workspace/`
+- Show matching file paths
+
+Display: "qmd unavailable, falling back to Grep"
+
+If Grep is also unavailable, run:
+```bash
+grep -rl "$QUERY" ~/Documents/HQ/knowledge/ \
+  ~/Documents/HQ/companies/ \
+  ~/Documents/HQ/workers/ \
+  ~/Documents/HQ/.claude/commands/ \
+  ~/Documents/HQ/workspace/ 2>/dev/null | head -20
+```
+
+## Examples
+
+```
+search ralph                                    # BM25 keyword search (default, all collections)
+search "how do workers execute" --mode vsearch  # Semantic across all
+search auth middleware -c {product}                   # Search {PRODUCT} codebase only
+search "webhook handler" -c {product} --mode vsearch  # Semantic search in {PRODUCT}
+search {company} brand --mode query                # Hybrid with re-ranking
+search stripe -n 20                             # More results
+search authentication --full                    # Show top match content
+search "brand guidelines" -c {company}             # Search {company} knowledge only
+search "recovery metrics" -c {company}        # Search {Product} knowledge only
+```
+
+## Notes
+
+- Default `search` mode is fastest — use for exact keywords
+- Use `--mode vsearch` for conceptual/semantic queries
+- Use `--mode query` for highest quality (slower, uses LLM re-ranking)
+- Use `-c` to scope to a collection: `hq`, `{product}`, `{company}`, `{company}`, `{company}`, `personal`
+- Without `-c`, auto-detects company from context; falls back to all collections
+- Scores 0.0–1.0; above 0.5 is a good match
+- For exact pattern matching in code (imports, function names), use Grep directly

--- a/template/.claude/skills/search/agents/openai.yaml
+++ b/template/.claude/skills/search/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Search"
+  short_description: "Search across HQ and indexed repos using qmd (semantic + full-text)."

--- a/template/.claude/skills/startwork/SKILL.md
+++ b/template/.claude/skills/startwork/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: startwork
+description: Start a work session — resolve company, project, or repo context, gather state from handoff.json and manifest.yaml, present smart options. Lightweight session entry point that replaces ad-hoc orientation.
+allowed-tools: Read, Grep, Glob, Bash(git:*), Bash(qmd:*), Bash(ls:*)
+---
+
+# Start Work Session
+
+Lightweight session entry point. Resolves context fast, presents smart options, gets you working.
+
+## When to Use
+
+Beginning of every session. Replaces ad-hoc orientation.
+
+## Process
+
+### 1. Resolve Argument
+
+Determine mode from the user's argument (first match wins):
+
+- **No arg / empty** — Resume mode
+- **Arg matches company slug** in `companies/manifest.yaml` — Company mode
+- **Arg matches a directory** in `projects/` (not `_archive/`) or `companies/*/projects/` — Project mode
+- **Arg matches a directory** in `repos/private/` or `repos/public/` — Repo mode
+- **Partial match** — arg is a substring of any company slug, project dir, or repo name. 1 match: use that mode. 2-5 matches: present numbered list, wait for user to pick. >5: ask user to be more specific
+- **No match** — ask user to clarify
+
+### 2. Gather Context
+
+#### Resume Mode (no arg)
+
+1. Read `workspace/threads/handoff.json`
+2. Read the thread file it points to. Extract: `conversation_summary`, `next_steps`, `git.branch`, `git.current_commit`, `git.dirty`, `files_touched`
+3. Run `git log --oneline -3` for recent HQ commits
+4. Search for active projects:
+   - Primary: `qmd search "prd.json" --json -n 10` via shell
+   - Fallback (if qmd unavailable): `grep -rl '"passes"' projects/ companies/ --include='prd.json'`
+   - Filter results for `projects/` paths and `companies/*/projects/` paths (skip `_archive`). For each (max 5), read the prd.json and extract `name` + count stories where `passes !== true`. Collect projects with remaining work.
+
+#### Company Mode (arg = company slug)
+
+1. Read `companies/manifest.yaml` — extract the company's entry (repos, workers, knowledge, qmd_collections)
+2. Read `workspace/threads/handoff.json` — if last thread relates to this company, note it
+3. Search for company projects:
+   - Primary: `qmd search "prd.json" --json -n 10` via shell
+   - Fallback: `grep -rl '"passes"' projects/ companies/ --include='prd.json'`
+   - Filter to projects whose repoPath matches any of the company's repos. Count incomplete stories per project.
+4. If company has repos, run `git -C {first-repo} log --oneline -3` and `git -C {first-repo} branch --show-current`
+5. List the company's workers from manifest (names only, don't read worker.yaml files)
+
+#### Project Mode (arg = project name)
+
+1. Read `projects/{name}/prd.json` — extract: `name`, `description`, `branchName`, incomplete stories (where `passes !== true`) with id + title + priority
+2. Extract `metadata.repoPath` — identify company by matching against manifest repos
+3. If repoPath exists: `git -C {repoPath} branch --show-current` and `git -C {repoPath} status --short`
+
+#### Repo Mode (arg = repo directory name)
+
+1. Resolve full path: check `repos/private/{arg}` then `repos/public/{arg}`
+2. Git state: `git -C {repoPath} branch --show-current`, `git -C {repoPath} log --oneline -5`, `git -C {repoPath} status --short`
+3. Owning company: scan `companies/manifest.yaml` for a company whose `repos:` list contains this path
+4. Related projects:
+   - Primary: `qmd search "{repo-name} prd.json" --json -n 10` via shell
+   - Fallback: use Grep to find prd.json files referencing this repo
+   - For each match (max 5), read the prd.json and extract `name` + count incomplete stories
+
+### 2.5 Load Applicable Policies
+
+Once company `{co}` is resolved (from any mode):
+
+1. **Company policies**: If `{co}` known, read all files in `companies/{co}/policies/` (skip `example-policy.md`). Note count + any `enforcement: hard` rules
+2. **Repo policies**: If repo context resolved, check `{repoPath}/.claude/policies/` (if dir exists). Note count
+3. **Global policies**: Count files in `.claude/policies/`. Don't load all — just count and note hard-enforcement ones
+
+Display in orientation block:
+```
+Policies: {N} company, {M} repo, {K} global ({H} hard-enforcement)
+```
+
+Hard-enforcement policies: list titles in orientation block so user sees constraints upfront.
+
+Rules:
+- Only READ policy frontmatter (title, enforcement, trigger) — don't load full body into context
+- Exception: hard-enforcement policies — read full `## Rule` section
+
+### 3. Present Options
+
+Display a concise orientation block:
+
+```
+Session Start
+--------------
+{Mode: Resume | Company: {slug} | Project: {name}}
+
+{If resume: "Last session: {summary}" + "Next steps: {next_steps}"}
+{If company: "Repos: {list}" + "Workers: {list}"}
+{If project: "Goal: {description}" + "Branch: {branchName}"}
+{If repo: "Repo: {repoPath}" + "Company: {slug}" + "Branch: {branch}"}
+
+Git: {branch} @ {short-hash} {" (dirty)" if dirty}
+
+Active work:
+  - {project} -- {done}/{total} stories ({remaining} left)
+  ...
+```
+
+Then present numbered options built from context:
+
+- **Resume mode**: next_steps items (up to 3) + "Pick a project" + "Something else"
+- **Company mode**: active projects for that company (up to 3) + "Run a worker" + "Something else"
+- **Project mode**: top 3 incomplete stories by priority + "Something else"
+- **Repo mode**: related projects with incomplete work (up to 3) + "Open repo (no project)" + "Something else"
+
+Output the numbered list and wait for user input. After user picks, proceed directly into the work.
+
+## Rules
+
+- NEVER read INDEX.md, agents files, or company knowledge dirs during startup
+- NEVER run exploratory searches to orient — this skill replaces exploration with targeted reads
+- Max file reads: handoff.json + 1 thread + manifest + up to 5 prd.json (headers only)
+- If >5 active projects found, show top 5 by most recent file modification
+- Always verify git branch with `git branch --show-current` before displaying git state
+- Context diet: every read must serve the orientation summary. No speculative loading
+- If handoff.json doesn't exist, skip resume context — go straight to asking what to work on
+- Use `qmd search` via shell command — if qmd unavailable, fall back to Grep to scan for prd.json files

--- a/template/.claude/skills/startwork/agents/openai.yaml
+++ b/template/.claude/skills/startwork/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Start Work"
+  short_description: "Start a work session — resolve context, gather state, present options."

--- a/template/CHANGELOG.md
+++ b/template/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [10.4.0] — 2026-04-03
+
+### Added
+- **9 new Codex-ready skills** — `brainstorm`, `execute-task`, `handoff`, `learn`, `prd`, `run`, `run-project`, `search`, `startwork` — each with `SKILL.md` + `agents/openai.yaml` for dual Claude Code / Codex discovery
+- **Codex dual-format documentation** — CLAUDE.md now documents the skill structure, adaptation rules, and `codex-skill-bridge.sh status` coverage tool
+- **Denylist exceptions mechanism** — `scrub-denylist.yaml` now supports an `exceptions` section for terms that must survive scrubbing (e.g. `indigoai-us`)
+- **Codex conversion step** in `/publish-kit` — Step 4.5 verifies all synced skills have `agents/openai.yaml`
+
+### Changed
+- `scripts/codex-skill-bridge.sh` — enhanced with `commands_with_skills_count()`, `print_coverage_report()`, and symlink support in `openai_yaml_count()`
+- `scripts/run-project.sh` — refreshed with latest orchestrator improvements
+- 154 policies synced (scope-filtered: global, command, cross-cutting only)
+- Skill coverage: 39/40 skills now Codex-ready (97%)
+
 ## [10.3.0] — 2026-04-02
 
 ### Added

--- a/template/MIGRATION.md
+++ b/template/MIGRATION.md
@@ -4,6 +4,54 @@ Instructions for updating existing HQ installations to new versions.
 
 ---
 
+## Migrating to v10.4.0 (from v10.3.0)
+
+### New Skills (9 Codex-ready skills)
+
+Copy these skill directories:
+
+```bash
+for s in brainstorm execute-task handoff learn prd run run-project search startwork; do
+  cp -r template/.claude/skills/$s/ your-hq/.claude/skills/$s/
+done
+```
+
+Each includes `SKILL.md` + `agents/openai.yaml` for dual Claude Code / Codex discovery.
+
+### Updated Scripts
+
+```bash
+cp template/scripts/codex-skill-bridge.sh your-hq/scripts/codex-skill-bridge.sh
+chmod +x your-hq/scripts/codex-skill-bridge.sh
+```
+
+### Updated CLAUDE.md
+
+The Skills section now includes Codex dual-format documentation. Merge the new section from `template/.claude/CLAUDE.md` into your CLAUDE.md.
+
+### Updated Denylist
+
+If you use `/publish-kit`, update your `scrub-denylist.yaml` with the new `exceptions` section:
+
+```yaml
+exceptions:
+  "{company}ai-us": "indigoai-us"
+  "@{company}ai-us": "@indigoai-us"
+  "{company}ai-us/hq": "indigoai-us/hq"
+```
+
+### Updated Policies
+
+154 policies synced. Run a diff to merge new/changed policies:
+```bash
+diff -rq template/.claude/policies/ your-hq/.claude/policies/
+```
+
+### Breaking Changes
+- (none)
+
+---
+
 ## Migrating to v10.3.0 (from v10.2.0)
 
 Minor release. No breaking changes.

--- a/template/core.yaml
+++ b/template/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "10.3.0"
-updatedAt: "2026-04-03T05:41:27Z"
+hqVersion: "10.4.0"
+updatedAt: "2026-04-03T09:00:00Z"
 rules:
   locked:
     - .claude/CLAUDE.md

--- a/template/scripts/codex-skill-bridge.sh
+++ b/template/scripts/codex-skill-bridge.sh
@@ -44,7 +44,42 @@ policy_count() {
 }
 
 openai_yaml_count() {
-  find "${SKILLS_SOURCE_DIR}" -mindepth 1 -maxdepth 1 -type d -exec test -f '{}/agents/openai.yaml' \; -print | wc -l | tr -d '[:space:]'
+  find "${SKILLS_SOURCE_DIR}" -mindepth 1 -maxdepth 1 \( -type d -o -type l \) -exec test -f '{}/agents/openai.yaml' \; -print | wc -l | tr -d '[:space:]'
+}
+
+commands_with_skills_count() {
+  local count=0
+  while IFS= read -r cmd_file; do
+    local cmd_name
+    cmd_name="$(basename "${cmd_file}" .md)"
+    if [[ -d "${SKILLS_SOURCE_DIR}/${cmd_name}" ]]; then
+      (( count++ )) || true
+    fi
+  done < <(find "${COMMANDS_SOURCE_DIR}" -mindepth 1 -maxdepth 1 -type f -name '*.md')
+  echo "${count}"
+}
+
+print_coverage_report() {
+  local total_cmds with_skills without_skills
+  total_cmds="$(command_count)"
+  with_skills="$(commands_with_skills_count)"
+  without_skills=$(( total_cmds - with_skills ))
+
+  echo "Codex coverage: ${with_skills}/${total_cmds} commands have skills"
+
+  if (( without_skills > 0 )); then
+    echo
+    echo "Commands without skills (${without_skills}):"
+    while IFS= read -r cmd_file; do
+      local cmd_name
+      cmd_name="$(basename "${cmd_file}" .md)"
+      if [[ ! -d "${SKILLS_SOURCE_DIR}/${cmd_name}" ]]; then
+        echo "  - ${cmd_name}"
+      fi
+    done < <(find "${COMMANDS_SOURCE_DIR}" -mindepth 1 -maxdepth 1 -type f -name '*.md' | sort)
+  else
+    echo "All commands have corresponding skills."
+  fi
 }
 
 resolve_dir_link() {
@@ -122,11 +157,18 @@ ensure_dir_symlink() {
 }
 
 print_status() {
+  local skill_total skill_with skill_without
+  skill_total="$(skill_count)"
+  skill_with="$(openai_yaml_count)"
+  skill_without=$(( skill_total - skill_with ))
+
   echo "HQ Claude source: ${CLAUDE_SOURCE_DIR}"
-  echo "Skills in source: $(skill_count) ($(openai_yaml_count) with agents/openai.yaml)"
+  echo "Skills in source: ${skill_total} (${skill_with} with agents/openai.yaml, ${skill_without} without)"
   echo "Commands in source: $(command_count)"
   echo "Hooks in source: $(hook_count)"
   echo "Policies in source: $(policy_count)"
+  echo
+  print_coverage_report
   echo
 
   print_link_status "Global skills bridge (legacy)" "${SKILLS_SOURCE_DIR}" "${GLOBAL_SKILLS_TARGET_DIR}"


### PR DESCRIPTION
## Summary

- **Spinner hang** (reported by Zahin): The ora spinner in `scaffold.ts` was animating over readline `confirm()` prompts in `deps.ts`, hiding install prompts for missing deps (qmd/yq). Users saw a spinner and thought it was loading — it was waiting for invisible input. Fixed by stopping the spinner before entering `checkDeps()`.
- **Integrity failure**: `compute-checksums.sh` and `core-integrity.sh` both require `yq`, but the integrity check ran before the dep installer where yq would be offered. Now pre-checks for yq and skips gracefully if missing.
- **Smoke test PATH** (reported by Stefan): Scheduled tasks don't source `~/.zshrc`, so Homebrew tools aren't in PATH. Added PATH bootstrap + pre-flight tool check to `run-smoke-tests.sh`.
- **New `--yes` flag**: Non-interactive mode that auto-accepts required dep installs and skips optional deps + cloud sync prompt.

## Test plan

- [x] `tsc` compiles clean
- [x] `vitest run` — 66 pass, 2 pre-existing failures (Docker not running + template placeholders), no regressions
- [ ] Manual: run `npx create-hq test-dir` on a machine missing qmd — confirm install prompt is visible
- [ ] Manual: run with `--yes` — confirm no interactive prompts
- [ ] Manual: run with `--skip-deps` — confirm deps step skipped