### PR TITLE
fix: remove hardcoded paths + add context meter

### DIFF
--- a/template/.claude/CLAUDE.md
+++ b/template/.claude/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Personal OS for orchestrating work across companies, workers, and AI.
 
+## Context Meter (mandatory)
+
+A Stop hook writes context window usage to `/tmp/.hq-context-meter`. **At the END of every response, output the contents of this file as the last line of your message.** Format: `CTX: {pct}% ({tokens}/{window})`. If it says HANDOFF SOON, warn the user. Do NOT use a tool to read it — just output the value from the system-reminder injected by the hook.
+
 ## Key Files
 
 - `INDEX.md` - Directory map (load only for HQ infra tasks or when disoriented)
@@ -366,7 +370,7 @@ PostToolUse hooks on Bash, Edit, and Write tool calls detect checkpoint-worthy e
   "type": "auto-checkpoint",
   "created_at": "ISO8601",
   "updated_at": "ISO8601",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "current/working/dir",
   "git": {
     "branch": "main",

--- a/template/.claude/commands/audit.md
+++ b/template/.claude/commands/audit.md
@@ -37,7 +37,7 @@ Based on flags parsed above, choose one of three modes:
 
 **If no `--since` and no `--company` flags**, call the script's built-in summary:
 ```bash
-cd ~/Documents/HQ && bash scripts/audit-log.sh summary 2>/dev/null
+cd "${HQ_ROOT:-$HOME/hq}" && bash scripts/audit-log.sh summary 2>/dev/null
 ```
 Display the output directly — it already includes by-project and by-worker tables.
 
@@ -45,7 +45,7 @@ Display the output directly — it already includes by-project and by-worker tab
 
 Compute `SINCE_DATE`: if `--since` was provided use that value, otherwise use 7 days ago in `YYYY-MM-DD` format.
 ```bash
-cd ~/Documents/HQ && \
+cd "${HQ_ROOT:-$HOME/hq}" && \
   SINCE="$(date -v-7d +%Y-%m-%d 2>/dev/null || date -d '7 days ago' +%Y-%m-%d)" && \
   bash scripts/audit-log.sh query --since "$SINCE" 2>/dev/null
 ```
@@ -114,7 +114,7 @@ Sort by tasks descending.
 
 Run:
 ```bash
-cd ~/Documents/HQ && \
+cd "${HQ_ROOT:-$HOME/hq}" && \
   bash scripts/audit-log.sh query --event task_failed 2>/dev/null
 ```
 
@@ -147,7 +147,7 @@ If zero results: print `No task failures found.`
 
 Build query:
 ```bash
-cd ~/Documents/HQ && \
+cd "${HQ_ROOT:-$HOME/hq}" && \
   bash scripts/audit-log.sh query --project <name> 2>/dev/null
 ```
 

--- a/template/.claude/commands/harness-audit.md
+++ b/template/.claude/commands/harness-audit.md
@@ -193,8 +193,8 @@ CATEGORY SCORES:
 TOTAL: 63/70 (A grade)
 
 TOP 3 IMPROVEMENTS:
-1. Add missing hook: ~/Documents/HQ/.claude/hooks/observe-patterns.sh (S)
-2. Write security policy: ~/Documents/HQ/.claude/policies/company-isolation-validation.md (M)
+1. Add missing hook: $HQ_ROOT/.claude/hooks/observe-patterns.sh (S)
+2. Write security policy: $HQ_ROOT/.claude/policies/company-isolation-validation.md (M)
 3. Add /tdd command to .claude/commands/ (S)
 
 NOTES:

--- a/template/.claude/commands/pr.md
+++ b/template/.claude/commands/pr.md
@@ -20,7 +20,7 @@ Dispatch PR tasks to {company}-agent for autonomous execution. Results appear at
 Run the agent locally with Bash:
 
 ```bash
-cd ~/Documents/HQ/repos/private/{company}-agent && node dist/entry.js agent --local -m "{message}"
+cd $HQ_ROOT/repos/private/{company}-agent && node dist/entry.js agent --local -m "{message}"
 ```
 
 The `--local` flag runs the embedded agent (uses model provider API keys from shell). The `-m` flag passes the task message. The agent auto-loads the relevant skill based on the message content.

--- a/template/.claude/commands/recover-session.md
+++ b/template/.claude/commands/recover-session.md
@@ -269,7 +269,7 @@ Build thread in HQ format:
 
 Use the death timestamp (not current time) for the thread ID — represents when work happened.
 
-Relativize file paths: strip `~/Documents/HQ/` prefix.
+Relativize file paths: strip `$HQ_ROOT/` prefix.
 
 If `--dry-run`, display what would be written and stop here. Do NOT write any files.
 

--- a/template/.claude/commands/run-project.md
+++ b/template/.claude/commands/run-project.md
@@ -53,7 +53,7 @@ Parse `$ARGUMENTS` into project name + passthrough flags:
 
 ```bash
 # Bash tool with run_in_background: true
-cd ~/Documents/HQ && \
+cd $HQ_ROOT && \
   nohup bash scripts/run-project.sh {project} {passthrough_flags} --no-permissions \
   > workspace/orchestrator/{project}/run.log 2>&1 &
 echo "PID:$!"

--- a/template/.claude/commands/search-reindex.md
+++ b/template/.claude/commands/search-reindex.md
@@ -15,8 +15,8 @@ Re-index and re-embed all qmd collections (HQ knowledge + indexed codebases).
 
 | Collection | Path | Pattern | Files |
 |---|---|---|---|
-| `hq` | `~/Documents/HQ` | `**/*.md` | ~1870 |
-| `{product}` | `~/Documents/HQ/repos/private/{product}` | `**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,css,prisma}` | ~3060 |
+| `hq` | `$HQ_ROOT` | `**/*.md` | ~1870 |
+| `{product}` | `$HQ_ROOT/repos/private/{product}` | `**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,css,prisma}` | ~3060 |
 
 ## Process
 
@@ -73,7 +73,7 @@ To completely rebuild all collections:
 qmd cleanup
 
 # HQ collection
-qmd collection add ~/Documents/HQ --name hq --mask "**/*.md"
+qmd collection add $HQ_ROOT --name hq --mask "**/*.md"
 qmd context add qmd://hq "HQ knowledge base: company knowledge, AI worker definitions, project PRDs, slash commands, reports, social drafts, and session threads."
 qmd context add qmd://hq/knowledge "HQ-level knowledge bases: Ralph coding methodology, worker framework patterns, dev-team practices, design styles, security framework, project templates."
 qmd context add qmd://hq/.claude/commands "Claude Code slash commands: 30 agent skills for session management, worker execution, project management, content creation, design, deployment."
@@ -83,7 +83,7 @@ qmd context add qmd://hq/projects "Project PRDs and READMEs for active and plann
 qmd context add qmd://hq/workspace "Runtime workspace: session threads, checkpoints, orchestrator state, reports, social drafts, content ideas, metrics."
 
 # {PRODUCT} collection
-qmd collection add ~/Documents/HQ/repos/private/{product} --name {product} --mask "**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,css,prisma}"
+qmd collection add $HQ_ROOT/repos/private/{product} --name {product} --mask "**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,css,prisma}"
 qmd context add qmd://{product} "{PRODUCT} monorepo: Nx monorepo for {Product}/{Product}. Apps (web-admin, web-client, web-front, function, {company}, cdp) + libs (core, db, ui, web, util, schema). Next.js, React 19, TypeScript, SST, Prisma, PostgreSQL."
 qmd context add qmd://{product}/apps "Application code: Next.js web apps, AWS Lambda functions, {Product} SMS platform, CDP."
 qmd context add qmd://{product}/libs "Shared libraries: db/Prisma schemas, core feature modules (auth, billing, brand, conversation, ai, workflow), UI components, utilities."

--- a/template/.claude/commands/search.md
+++ b/template/.claude/commands/search.md
@@ -86,11 +86,12 @@ If `--full` flag, after listing results, read top result file with Read tool.
 If qmd errors or isn't installed:
 
 ```bash
-grep -rl "$QUERY" ~/Documents/HQ/knowledge/ \
-  ~/Documents/HQ/companies/ \
-  ~/Documents/HQ/workers/ \
-  ~/Documents/HQ/.claude/commands/ \
-  ~/Documents/HQ/workspace/ 2>/dev/null | head -20
+HQ_ROOT="${HQ_ROOT:-$HOME/hq}"
+grep -rl "$QUERY" "$HQ_ROOT/knowledge/" \
+  "$HQ_ROOT/companies/" \
+  "$HQ_ROOT/workers/" \
+  "$HQ_ROOT/.claude/commands/" \
+  "$HQ_ROOT/workspace/" 2>/dev/null | head -20
 ```
 
 Display: "qmd unavailable, falling back to grep"

--- a/template/.claude/hooks/auto-checkpoint-trigger.sh
+++ b/template/.claude/hooks/auto-checkpoint-trigger.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-HQ="~/Documents/HQ"
+HQ="${HQ_ROOT:-$HOME/hq}"
 INPUT=$(cat)
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')

--- a/template/.claude/hooks/context-meter.sh
+++ b/template/.claude/hooks/context-meter.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Context meter — fires on Stop hook, reads transcript to estimate context usage.
+# Writes a one-line CTX report to /tmp/.hq-context-meter.
+# CLAUDE.md instructs the model to output this at the end of every response.
+
+set -euo pipefail
+
+INPUT=$(cat)
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null) || exit 0
+
+[ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ] && exit 0
+
+# Get the last assistant message's input_tokens (= current context size)
+TOKENS=$(tail -20 "$TRANSCRIPT" | grep -o '"input_tokens":[0-9]*' | tail -1 | cut -d: -f2) || exit 0
+[ -z "$TOKENS" ] && exit 0
+
+# Also grab cache_read tokens
+CACHE=$(tail -20 "$TRANSCRIPT" | grep -o '"cache_read_input_tokens":[0-9]*' | tail -1 | cut -d: -f2) || true
+CACHE=${CACHE:-0}
+TOTAL=$((TOKENS + CACHE))
+
+# Context window is 200K (Claude Code effective limit)
+WINDOW=200000
+PCT=$((TOTAL * 100 / WINDOW))
+
+# Write to file AND stdout (stdout → system-reminder for model to repeat)
+METER_FILE="/tmp/.hq-context-meter"
+if [ "$PCT" -ge 75 ]; then
+  MSG="⚠️ CTX: ${PCT}% (${TOTAL}/${WINDOW}) — HANDOFF SOON"
+elif [ "$PCT" -ge 50 ]; then
+  MSG="📊 CTX: ${PCT}% (${TOTAL}/${WINDOW})"
+else
+  MSG="CTX: ${PCT}% (${TOTAL}/${WINDOW})"
+fi
+echo "$MSG" > "$METER_FILE"
+echo "$MSG"
+
+exit 0

--- a/template/.claude/hooks/observe-patterns.sh
+++ b/template/.claude/hooks/observe-patterns.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-HQ="~/Documents/HQ"
+HQ="${HQ_ROOT:-$HOME/hq}"
 INPUT=$(cat)
 
 # Ensure learnings directory exists

--- a/template/.claude/hooks/screenshot-resize-trigger.sh
+++ b/template/.claude/hooks/screenshot-resize-trigger.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-HQ="~/Documents/HQ"
+HQ="${HQ_ROOT:-$HOME/hq}"
 RESIZE="$HQ/scripts/resize-screenshot.sh"
 COUNT_FILE="/tmp/hq-screenshot-count-${PPID}"
 WARN_THRESHOLD=30

--- a/template/.claude/policies/hook-macos-case-paths.md
+++ b/template/.claude/policies/hook-macos-case-paths.md
@@ -14,7 +14,7 @@ source: debugging
 
 When writing bash hooks that compare file paths (e.g. checking if a path is inside `repos/`), always use case-insensitive matching or pattern-based checks (e.g. `*/repos/private/*`) instead of prefix matching against a hardcoded `HQ_ROOT`.
 
-macOS is case-insensitive but `pwd` may return a different casing than the hardcoded path. Example: `pwd` returns `~/Documents/hq` but `HQ_ROOT` is set to `~/Documents/HQ` — string comparison fails silently.
+macOS is case-insensitive but `pwd` may return a different casing than the hardcoded path. Example: `pwd` returns `~/Documents/hq` but `HQ_ROOT` is set to `$HQ_ROOT` — string comparison fails silently.
 
 **Safe pattern:** lowercase both sides with `tr '[:upper:]' '[:lower:]'` before comparing, or match on a case-stable segment like `*/repos/private/*`.
 

--- a/template/.claude/scripts/run-project.sh
+++ b/template/.claude/scripts/run-project.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 #   --tmux              Launch in tmux session with Remote Control
 # =============================================================================
 
-HQ_ROOT="~/Documents/HQ"
+HQ_ROOT="${HQ_ROOT:-$HOME/hq}"
 export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
 ORCH_DIR="$HQ_ROOT/workspace/orchestrator"
 REGRESSION_INTERVAL=3

--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -151,6 +151,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/context-meter.sh",
+            "timeout": 3
+          }
+        ]
       }
     ]
   }

--- a/template/.claude/skills/execute-task/SKILL.md
+++ b/template/.claude/skills/execute-task/SKILL.md
@@ -754,7 +754,7 @@ After task completion (or failure), write a thread checkpoint file:
   "type": "auto-checkpoint",
   "created_at": "{ISO8601}",
   "updated_at": "{ISO8601}",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "{current working directory}",
   "git": {
     "branch": "{current branch from git branch --show-current}",

--- a/template/.claude/skills/handoff/SKILL.md
+++ b/template/.claude/skills/handoff/SKILL.md
@@ -34,7 +34,7 @@ Check `workspace/threads/` for a recent thread file. If none exists, write a bas
   "type": "handoff",
   "created_at": "ISO8601",
   "updated_at": "ISO8601",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "current/working/dir",
   "git": {
     "branch": "current-branch",
@@ -74,7 +74,7 @@ done
 ### 3b. Commit HQ Changes
 
 ```bash
-cd ~/Documents/HQ
+cd $HQ_ROOT
 if [ -n "$(git status --porcelain)" ]; then
   git add -A
   git commit -m "checkpoint: auto-commit before handoff"

--- a/template/.claude/skills/run-project/SKILL.md
+++ b/template/.claude/skills/run-project/SKILL.md
@@ -453,7 +453,7 @@ Write a thread checkpoint:
   "type": "auto-checkpoint",
   "created_at": "{ISO8601}",
   "updated_at": "{ISO8601}",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "{current working directory}",
   "git": {
     "branch": "{current branch}",
@@ -737,7 +737,7 @@ After project completion (or pause), write a project-level checkpoint:
   "type": "auto-checkpoint",
   "created_at": "{ISO8601}",
   "updated_at": "{ISO8601}",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "{current working directory}",
   "git": {
     "branch": "{current branch}",

--- a/template/.claude/skills/run/SKILL.md
+++ b/template/.claude/skills/run/SKILL.md
@@ -194,7 +194,7 @@ After skill completion, write a thread checkpoint file:
   "type": "auto-checkpoint",
   "created_at": "{ISO8601}",
   "updated_at": "{ISO8601}",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "{current working directory}",
   "git": {
     "branch": "{current branch from git branch --show-current}",

--- a/template/.claude/skills/search/SKILL.md
+++ b/template/.claude/skills/search/SKILL.md
@@ -100,11 +100,11 @@ Display: "qmd unavailable, falling back to Grep"
 
 If Grep is also unavailable, run:
 ```bash
-grep -rl "$QUERY" ~/Documents/HQ/knowledge/ \
-  ~/Documents/HQ/companies/ \
-  ~/Documents/HQ/workers/ \
-  ~/Documents/HQ/.claude/commands/ \
-  ~/Documents/HQ/workspace/ 2>/dev/null | head -20
+grep -rl "$QUERY" $HQ_ROOT/knowledge/ \
+  $HQ_ROOT/companies/ \
+  $HQ_ROOT/workers/ \
+  $HQ_ROOT/.claude/commands/ \
+  $HQ_ROOT/workspace/ 2>/dev/null | head -20
 ```
 
 ## Examples

--- a/template/MIGRATION.md
+++ b/template/MIGRATION.md
@@ -1192,7 +1192,7 @@ Copy these directories to your `knowledge/`:
 go install github.com/tobi/qmd@latest
 
 # Index your HQ
-cd ~/Documents/HQ
+cd $HQ_ROOT
 qmd update && qmd embed
 ```
 

--- a/template/knowledge/gemini-cli/patterns.md
+++ b/template/knowledge/gemini-cli/patterns.md
@@ -3,7 +3,7 @@
 ## Loading API Key
 
 ```bash
-KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
 ```
 
 ## One-Shot Generation

--- a/template/knowledge/hq-core/desktop-claude-code-integration.md
+++ b/template/knowledge/hq-core/desktop-claude-code-integration.md
@@ -14,7 +14,7 @@ relates_to: []
 
 ### Current State
 
-Desktop and Claude Code share the same HQ filesystem (`~/Documents/HQ/`). Today there is **no file locking** on either side:
+Desktop and Claude Code share the same HQ filesystem (`$HQ_ROOT/`). Today there is **no file locking** on either side:
 
 - **Desktop reads**: All Rust commands (`list_prds`, `list_workers`, `list_threads`, `get_empire_data`, `read_file_content`, `read_json`, `read_yaml`) use `std::fs::read_to_string` with no locking, advisory or otherwise.
 - **Claude Code writes**: Claude Code (via its tools) writes files atomically using temp-file-then-rename, but does not acquire locks visible to other processes.

--- a/template/knowledge/hq-core/hq-desktop/knowledge-system-mapping.md
+++ b/template/knowledge/hq-core/hq-desktop/knowledge-system-mapping.md
@@ -141,7 +141,7 @@ The `@tauri-apps/plugin-fs` `readDir()` also follows symlinks transparently. The
 ### Edge Cases
 
 1. **Broken symlinks:** If a repo is deleted but the symlink remains, `fs::read_dir()` will fail. Desktop should catch this and show a "broken link" indicator.
-2. **Relative vs absolute symlinks:** HQ uses both relative (`../../repos/public/knowledge-hq-core`) and absolute (`~/Documents/HQ/repos/public/knowledge-curious-minds`) symlinks. `fs::canonicalize()` handles both.
+2. **Relative vs absolute symlinks:** HQ uses both relative (`../../repos/public/knowledge-hq-core`) and absolute (`$HQ_ROOT/repos/public/knowledge-curious-minds`) symlinks. `fs::canonicalize()` handles both.
 3. **Nested symlinks:** Some knowledge repos contain internal symlinks (e.g., {company} CDP knowledge has `audit/` and `flow-migration/` symlinks). Desktop should resolve these recursively.
 
 ---

--- a/template/knowledge/hq-core/hq-desktop/terminal-session-audit.md
+++ b/template/knowledge/hq-core/hq-desktop/terminal-session-audit.md
@@ -8,7 +8,7 @@ Comprehensive audit of the HQ Desktop terminal subsystem: PTY implementation, co
 
 | Command | Signature | Behavior |
 |---------|-----------|----------|
-| `spawn_pty` | `(cmd, cwd, cols, rows) -> session_id` | Spawns PTY via `portable_pty`. Defaults to `$SHELL -l` (login shell), cwd defaults to `~/Documents/HQ`. Inherits full env, sets `TERM=xterm-256color`. Spawns reader thread that emits `pty-output` events. On exit, emits `pty-exit` with exit code and auto-cleans session. |
+| `spawn_pty` | `(cmd, cwd, cols, rows) -> session_id` | Spawns PTY via `portable_pty`. Defaults to `$SHELL -l` (login shell), cwd defaults to `$HQ_ROOT`. Inherits full env, sets `TERM=xterm-256color`. Spawns reader thread that emits `pty-output` events. On exit, emits `pty-exit` with exit code and auto-cleans session. |
 | `write_pty` | `(session_id, data: Vec<u8>)` | Writes raw bytes to PTY master. Flushes after write. |
 | `resize_pty` | `(session_id, cols, rows)` | Resizes PTY via master handle. |
 | `kill_pty` | `(session_id)` | Removes session from HashMap, kills child process. |

--- a/template/knowledge/hq-core/hq-desktop/terminal-session-ux-specs.md
+++ b/template/knowledge/hq-core/hq-desktop/terminal-session-ux-specs.md
@@ -96,7 +96,7 @@ async function executeInPTY(command: HQCommand, args?: string) {
     sessionStore.addSession({
       id: sessionId,
       type: 'claude',
-      cwd: '~/Documents/HQ',
+      cwd: '$HQ_ROOT',
       status: 'running',
       startedAt: new Date().toISOString(),
       title: `/${command.id}`,

--- a/template/knowledge/hq-core/hq-structure-detection.md
+++ b/template/knowledge/hq-core/hq-structure-detection.md
@@ -394,27 +394,27 @@ interface HQDetectionResult {
 
 ## 5. Desktop Hardcoded Path Assumptions (Current State)
 
-The current HQ Desktop Rust backend (`files.rs`, `orchestrator.rs`) hardcodes the path `~/Documents/HQ` in every Tauri command:
+The current HQ Desktop Rust backend (`files.rs`, `orchestrator.rs`) hardcodes the path `$HQ_ROOT` in every Tauri command:
 
 | Tauri Command | Hardcoded Path |
 |--------------|---------------|
-| `list_prds()` | `~/Documents/HQ/projects` + `~/Documents/HQ/apps` + `~/Documents/HQ/repos/private` |
+| `list_prds()` | `$HQ_ROOT/projects` + `$HQ_ROOT/apps` + `$HQ_ROOT/repos/private` |
 | `start_prd_watcher()` | Same 3 paths |
-| `read_dir_tree()` | Falls back to `~/Documents/HQ` |
-| `list_workers()` | `~/Documents/HQ/workers/registry.yaml` |
-| `list_threads()` | `~/Documents/HQ/workspace/threads` |
-| `list_checkpoints()` | `~/Documents/HQ/workspace/checkpoints` |
-| `list_companies()` | `~/Documents/HQ/companies` |
-| `list_projects()` | `~/Documents/HQ/projects` |
+| `read_dir_tree()` | Falls back to `$HQ_ROOT` |
+| `list_workers()` | `$HQ_ROOT/workers/registry.yaml` |
+| `list_threads()` | `$HQ_ROOT/workspace/threads` |
+| `list_checkpoints()` | `$HQ_ROOT/workspace/checkpoints` |
+| `list_companies()` | `$HQ_ROOT/companies` |
+| `list_projects()` | `$HQ_ROOT/projects` |
 | `list_claude_sessions()` | `~/.claude/projects/-Users-{your-username}-Documents-HQ` (user-specific!) |
-| `get_hq_stats()` | `~/Documents/HQ` (multiple sub-paths) |
-| `get_worker_detail()` | `~/Documents/HQ/workers/{id}` (flat, not public/private split) |
-| `get_company_detail()` | `~/Documents/HQ/companies/{id}` |
-| `get_project_detail()` | `~/Documents/HQ/projects/{name}` |
-| `spawn_worker_skill()` | `~/Documents/HQ` |
-| `open_terminal_in_hq()` | `~/Documents/HQ` |
-| `get_orchestrator_state()` | `~/Documents/HQ/workspace/orchestrator/state.json` |
-| `get_checkouts_state()` | `~/Documents/HQ/workspace/orchestrator/checkouts.json` |
+| `get_hq_stats()` | `$HQ_ROOT` (multiple sub-paths) |
+| `get_worker_detail()` | `$HQ_ROOT/workers/{id}` (flat, not public/private split) |
+| `get_company_detail()` | `$HQ_ROOT/companies/{id}` |
+| `get_project_detail()` | `$HQ_ROOT/projects/{name}` |
+| `spawn_worker_skill()` | `$HQ_ROOT` |
+| `open_terminal_in_hq()` | `$HQ_ROOT` |
+| `get_orchestrator_state()` | `$HQ_ROOT/workspace/orchestrator/state.json` |
+| `get_checkouts_state()` | `$HQ_ROOT/workspace/orchestrator/checkouts.json` |
 
 ### Type Mismatches (Preview for US-003)
 

--- a/template/knowledge/hq-core/starter-kit-compatibility-contract.md
+++ b/template/knowledge/hq-core/starter-kit-compatibility-contract.md
@@ -273,7 +273,7 @@ This section is the formal contract that Desktop code MUST adhere to.
 ### MUST NOT
 
 1. Desktop MUST NOT crash or show unhandled errors when any optional structure is missing.
-2. Desktop MUST NOT hardcode `~/Documents/HQ` as the HQ path (currently 17 places do this -- see US-001 Section 5).
+2. Desktop MUST NOT hardcode `$HQ_ROOT` as the HQ path (currently 17 places do this -- see US-001 Section 5).
 3. Desktop MUST NOT assume `companies/` exists (it is optional, not present in starter-kit).
 4. Desktop MUST NOT assume `workers/public/` or `workers/private/` layout (starter-kit uses flat `workers/`).
 5. Desktop MUST NOT assume `knowledge/public/` layout (starter-kit uses flat `knowledge/`).
@@ -296,7 +296,7 @@ This section is the formal contract that Desktop code MUST adhere to.
 
 The current Rust backend (see US-001, Section 5) needs these changes to comply with this contract:
 
-1. **Config-based HQ path:** Replace all 17 hardcoded `~/Documents/HQ` references with a config value loaded at startup. The HQ path comes from a config file (e.g., `~/.hq-desktop/config.json`) or the Tauri app's settings store.
+1. **Config-based HQ path:** Replace all 17 hardcoded `$HQ_ROOT` references with a config value loaded at startup. The HQ path comes from a config file (e.g., `~/.hq-desktop/config.json`) or the Tauri app's settings store.
 
 2. **Validation command:** Add a `validate_hq_instance(path: String)` Tauri command that runs the 7-item check and returns the `HQDetectionResult` (see US-001 detection algorithm).
 

--- a/template/knowledge/hq-core/thread-schema.md
+++ b/template/knowledge/hq-core/thread-schema.md
@@ -30,7 +30,7 @@ Example: `T-20260123-143052-mrr-report`
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:35:00.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {
@@ -80,7 +80,7 @@ Auto-checkpoints are created automatically by PostToolUse hooks after git commit
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:30:52.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {

--- a/template/knowledge/hq/desktop-claude-code-integration.md
+++ b/template/knowledge/hq/desktop-claude-code-integration.md
@@ -14,7 +14,7 @@ relates_to: []
 
 ### Current State
 
-Desktop and Claude Code share the same HQ filesystem (`~/Documents/HQ/`). Today there is **no file locking** on either side:
+Desktop and Claude Code share the same HQ filesystem (`$HQ_ROOT/`). Today there is **no file locking** on either side:
 
 - **Desktop reads**: All Rust commands (`list_prds`, `list_workers`, `list_threads`, `get_empire_data`, `read_file_content`, `read_json`, `read_yaml`) use `std::fs::read_to_string` with no locking, advisory or otherwise.
 - **Claude Code writes**: Claude Code (via its tools) writes files atomically using temp-file-then-rename, but does not acquire locks visible to other processes.

--- a/template/knowledge/hq/hq-desktop/knowledge-system-mapping.md
+++ b/template/knowledge/hq/hq-desktop/knowledge-system-mapping.md
@@ -141,7 +141,7 @@ The `@tauri-apps/plugin-fs` `readDir()` also follows symlinks transparently. The
 ### Edge Cases
 
 1. **Broken symlinks:** If a repo is deleted but the symlink remains, `fs::read_dir()` will fail. Desktop should catch this and show a "broken link" indicator.
-2. **Relative vs absolute symlinks:** HQ uses both relative (`../../repos/public/knowledge-hq-core`) and absolute (`~/Documents/HQ/repos/public/knowledge-curious-minds`) symlinks. `fs::canonicalize()` handles both.
+2. **Relative vs absolute symlinks:** HQ uses both relative (`../../repos/public/knowledge-hq-core`) and absolute (`$HQ_ROOT/repos/public/knowledge-curious-minds`) symlinks. `fs::canonicalize()` handles both.
 3. **Nested symlinks:** Some knowledge repos contain internal symlinks (e.g., {company} CDP knowledge has `audit/` and `flow-migration/` symlinks). Desktop should resolve these recursively.
 
 ---

--- a/template/knowledge/hq/hq-desktop/terminal-session-audit.md
+++ b/template/knowledge/hq/hq-desktop/terminal-session-audit.md
@@ -8,7 +8,7 @@ Comprehensive audit of the HQ Desktop terminal subsystem: PTY implementation, co
 
 | Command | Signature | Behavior |
 |---------|-----------|----------|
-| `spawn_pty` | `(cmd, cwd, cols, rows) -> session_id` | Spawns PTY via `portable_pty`. Defaults to `$SHELL -l` (login shell), cwd defaults to `~/Documents/HQ`. Inherits full env, sets `TERM=xterm-256color`. Spawns reader thread that emits `pty-output` events. On exit, emits `pty-exit` with exit code and auto-cleans session. |
+| `spawn_pty` | `(cmd, cwd, cols, rows) -> session_id` | Spawns PTY via `portable_pty`. Defaults to `$SHELL -l` (login shell), cwd defaults to `$HQ_ROOT`. Inherits full env, sets `TERM=xterm-256color`. Spawns reader thread that emits `pty-output` events. On exit, emits `pty-exit` with exit code and auto-cleans session. |
 | `write_pty` | `(session_id, data: Vec<u8>)` | Writes raw bytes to PTY master. Flushes after write. |
 | `resize_pty` | `(session_id, cols, rows)` | Resizes PTY via master handle. |
 | `kill_pty` | `(session_id)` | Removes session from HashMap, kills child process. |

--- a/template/knowledge/hq/hq-desktop/terminal-session-ux-specs.md
+++ b/template/knowledge/hq/hq-desktop/terminal-session-ux-specs.md
@@ -96,7 +96,7 @@ async function executeInPTY(command: HQCommand, args?: string) {
     sessionStore.addSession({
       id: sessionId,
       type: 'claude',
-      cwd: '~/Documents/HQ',
+      cwd: '$HQ_ROOT',
       status: 'running',
       startedAt: new Date().toISOString(),
       title: `/${command.id}`,

--- a/template/knowledge/hq/hq-structure-detection.md
+++ b/template/knowledge/hq/hq-structure-detection.md
@@ -394,27 +394,27 @@ interface HQDetectionResult {
 
 ## 5. Desktop Hardcoded Path Assumptions (Current State)
 
-The current HQ Desktop Rust backend (`files.rs`, `orchestrator.rs`) hardcodes the path `~/Documents/HQ` in every Tauri command:
+The current HQ Desktop Rust backend (`files.rs`, `orchestrator.rs`) hardcodes the path `$HQ_ROOT` in every Tauri command:
 
 | Tauri Command | Hardcoded Path |
 |--------------|---------------|
-| `list_prds()` | `~/Documents/HQ/projects` + `~/Documents/HQ/apps` + `~/Documents/HQ/repos/private` |
+| `list_prds()` | `$HQ_ROOT/projects` + `$HQ_ROOT/apps` + `$HQ_ROOT/repos/private` |
 | `start_prd_watcher()` | Same 3 paths |
-| `read_dir_tree()` | Falls back to `~/Documents/HQ` |
-| `list_workers()` | `~/Documents/HQ/workers/registry.yaml` |
-| `list_threads()` | `~/Documents/HQ/workspace/threads` |
-| `list_checkpoints()` | `~/Documents/HQ/workspace/checkpoints` |
-| `list_companies()` | `~/Documents/HQ/companies` |
-| `list_projects()` | `~/Documents/HQ/projects` |
+| `read_dir_tree()` | Falls back to `$HQ_ROOT` |
+| `list_workers()` | `$HQ_ROOT/workers/registry.yaml` |
+| `list_threads()` | `$HQ_ROOT/workspace/threads` |
+| `list_checkpoints()` | `$HQ_ROOT/workspace/checkpoints` |
+| `list_companies()` | `$HQ_ROOT/companies` |
+| `list_projects()` | `$HQ_ROOT/projects` |
 | `list_claude_sessions()` | `~/.claude/projects/-Users-{your-username}-Documents-HQ` (user-specific!) |
-| `get_hq_stats()` | `~/Documents/HQ` (multiple sub-paths) |
-| `get_worker_detail()` | `~/Documents/HQ/workers/{id}` (flat, not public/private split) |
-| `get_company_detail()` | `~/Documents/HQ/companies/{id}` |
-| `get_project_detail()` | `~/Documents/HQ/projects/{name}` |
-| `spawn_worker_skill()` | `~/Documents/HQ` |
-| `open_terminal_in_hq()` | `~/Documents/HQ` |
-| `get_orchestrator_state()` | `~/Documents/HQ/workspace/orchestrator/state.json` |
-| `get_checkouts_state()` | `~/Documents/HQ/workspace/orchestrator/checkouts.json` |
+| `get_hq_stats()` | `$HQ_ROOT` (multiple sub-paths) |
+| `get_worker_detail()` | `$HQ_ROOT/workers/{id}` (flat, not public/private split) |
+| `get_company_detail()` | `$HQ_ROOT/companies/{id}` |
+| `get_project_detail()` | `$HQ_ROOT/projects/{name}` |
+| `spawn_worker_skill()` | `$HQ_ROOT` |
+| `open_terminal_in_hq()` | `$HQ_ROOT` |
+| `get_orchestrator_state()` | `$HQ_ROOT/workspace/orchestrator/state.json` |
+| `get_checkouts_state()` | `$HQ_ROOT/workspace/orchestrator/checkouts.json` |
 
 ### Type Mismatches (Preview for US-003)
 

--- a/template/knowledge/hq/starter-kit-compatibility-contract.md
+++ b/template/knowledge/hq/starter-kit-compatibility-contract.md
@@ -273,7 +273,7 @@ This section is the formal contract that Desktop code MUST adhere to.
 ### MUST NOT
 
 1. Desktop MUST NOT crash or show unhandled errors when any optional structure is missing.
-2. Desktop MUST NOT hardcode `~/Documents/HQ` as the HQ path (currently 17 places do this -- see US-001 Section 5).
+2. Desktop MUST NOT hardcode `$HQ_ROOT` as the HQ path (currently 17 places do this -- see US-001 Section 5).
 3. Desktop MUST NOT assume `companies/` exists (it is optional, not present in starter-kit).
 4. Desktop MUST NOT assume `workers/public/` or `workers/private/` layout (starter-kit uses flat `workers/`).
 5. Desktop MUST NOT assume `knowledge/public/` layout (starter-kit uses flat `knowledge/`).
@@ -296,7 +296,7 @@ This section is the formal contract that Desktop code MUST adhere to.
 
 The current Rust backend (see US-001, Section 5) needs these changes to comply with this contract:
 
-1. **Config-based HQ path:** Replace all 17 hardcoded `~/Documents/HQ` references with a config value loaded at startup. The HQ path comes from a config file (e.g., `~/.hq-desktop/config.json`) or the Tauri app's settings store.
+1. **Config-based HQ path:** Replace all 17 hardcoded `$HQ_ROOT` references with a config value loaded at startup. The HQ path comes from a config file (e.g., `~/.hq-desktop/config.json`) or the Tauri app's settings store.
 
 2. **Validation command:** Add a `validate_hq_instance(path: String)` Tauri command that runs the 7-item check and returns the `HQDetectionResult` (see US-001 detection algorithm).
 

--- a/template/knowledge/hq/thread-schema.md
+++ b/template/knowledge/hq/thread-schema.md
@@ -30,7 +30,7 @@ Example: `T-20260123-143052-mrr-report`
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:35:00.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {
@@ -80,7 +80,7 @@ Auto-checkpoints are created automatically by PostToolUse hooks after git commit
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:30:52.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {

--- a/template/knowledge/public/gemini-cli/patterns.md
+++ b/template/knowledge/public/gemini-cli/patterns.md
@@ -3,7 +3,7 @@
 ## Loading API Key
 
 ```bash
-KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
 ```
 
 ## One-Shot Generation

--- a/template/knowledge/public/hq-core/desktop-claude-code-integration.md
+++ b/template/knowledge/public/hq-core/desktop-claude-code-integration.md
@@ -14,7 +14,7 @@ relates_to: []
 
 ### Current State
 
-Desktop and Claude Code share the same HQ filesystem (`~/Documents/HQ/`). Today there is **no file locking** on either side:
+Desktop and Claude Code share the same HQ filesystem (`$HQ_ROOT/`). Today there is **no file locking** on either side:
 
 - **Desktop reads**: All Rust commands (`list_prds`, `list_workers`, `list_threads`, `get_empire_data`, `read_file_content`, `read_json`, `read_yaml`) use `std::fs::read_to_string` with no locking, advisory or otherwise.
 - **Claude Code writes**: Claude Code (via its tools) writes files atomically using temp-file-then-rename, but does not acquire locks visible to other processes.

--- a/template/knowledge/public/hq-core/hq-desktop/knowledge-system-mapping.md
+++ b/template/knowledge/public/hq-core/hq-desktop/knowledge-system-mapping.md
@@ -141,7 +141,7 @@ The `@tauri-apps/plugin-fs` `readDir()` also follows symlinks transparently. The
 ### Edge Cases
 
 1. **Broken symlinks:** If a repo is deleted but the symlink remains, `fs::read_dir()` will fail. Desktop should catch this and show a "broken link" indicator.
-2. **Relative vs absolute symlinks:** HQ uses both relative (`../../repos/public/knowledge-hq-core`) and absolute (`~/Documents/HQ/repos/public/knowledge-curious-minds`) symlinks. `fs::canonicalize()` handles both.
+2. **Relative vs absolute symlinks:** HQ uses both relative (`../../repos/public/knowledge-hq-core`) and absolute (`$HQ_ROOT/repos/public/knowledge-curious-minds`) symlinks. `fs::canonicalize()` handles both.
 3. **Nested symlinks:** Some knowledge repos contain internal symlinks (e.g., {Product} CDP knowledge has `audit/` and `flow-migration/` symlinks). Desktop should resolve these recursively.
 
 ---

--- a/template/knowledge/public/hq-core/hq-desktop/terminal-session-audit.md
+++ b/template/knowledge/public/hq-core/hq-desktop/terminal-session-audit.md
@@ -8,7 +8,7 @@ Comprehensive audit of the HQ Desktop terminal subsystem: PTY implementation, co
 
 | Command | Signature | Behavior |
 |---------|-----------|----------|
-| `spawn_pty` | `(cmd, cwd, cols, rows) -> session_id` | Spawns PTY via `portable_pty`. Defaults to `$SHELL -l` (login shell), cwd defaults to `~/Documents/HQ`. Inherits full env, sets `TERM=xterm-256color`. Spawns reader thread that emits `pty-output` events. On exit, emits `pty-exit` with exit code and auto-cleans session. |
+| `spawn_pty` | `(cmd, cwd, cols, rows) -> session_id` | Spawns PTY via `portable_pty`. Defaults to `$SHELL -l` (login shell), cwd defaults to `$HQ_ROOT`. Inherits full env, sets `TERM=xterm-256color`. Spawns reader thread that emits `pty-output` events. On exit, emits `pty-exit` with exit code and auto-cleans session. |
 | `write_pty` | `(session_id, data: Vec<u8>)` | Writes raw bytes to PTY master. Flushes after write. |
 | `resize_pty` | `(session_id, cols, rows)` | Resizes PTY via master handle. |
 | `kill_pty` | `(session_id)` | Removes session from HashMap, kills child process. |

--- a/template/knowledge/public/hq-core/hq-desktop/terminal-session-ux-specs.md
+++ b/template/knowledge/public/hq-core/hq-desktop/terminal-session-ux-specs.md
@@ -96,7 +96,7 @@ async function executeInPTY(command: HQCommand, args?: string) {
     sessionStore.addSession({
       id: sessionId,
       type: 'claude',
-      cwd: '~/Documents/HQ',
+      cwd: '$HQ_ROOT',
       status: 'running',
       startedAt: new Date().toISOString(),
       title: `/${command.id}`,

--- a/template/knowledge/public/hq-core/hq-structure-detection.md
+++ b/template/knowledge/public/hq-core/hq-structure-detection.md
@@ -394,27 +394,27 @@ interface HQDetectionResult {
 
 ## 5. Desktop Hardcoded Path Assumptions (Current State)
 
-The current HQ Desktop Rust backend (`files.rs`, `orchestrator.rs`) hardcodes the path `~/Documents/HQ` in every Tauri command:
+The current HQ Desktop Rust backend (`files.rs`, `orchestrator.rs`) hardcodes the path `$HQ_ROOT` in every Tauri command:
 
 | Tauri Command | Hardcoded Path |
 |--------------|---------------|
-| `list_prds()` | `~/Documents/HQ/projects` + `~/Documents/HQ/apps` + `~/Documents/HQ/repos/private` |
+| `list_prds()` | `$HQ_ROOT/projects` + `$HQ_ROOT/apps` + `$HQ_ROOT/repos/private` |
 | `start_prd_watcher()` | Same 3 paths |
-| `read_dir_tree()` | Falls back to `~/Documents/HQ` |
-| `list_workers()` | `~/Documents/HQ/workers/registry.yaml` |
-| `list_threads()` | `~/Documents/HQ/workspace/threads` |
-| `list_checkpoints()` | `~/Documents/HQ/workspace/checkpoints` |
-| `list_companies()` | `~/Documents/HQ/companies` |
-| `list_projects()` | `~/Documents/HQ/projects` |
+| `read_dir_tree()` | Falls back to `$HQ_ROOT` |
+| `list_workers()` | `$HQ_ROOT/workers/registry.yaml` |
+| `list_threads()` | `$HQ_ROOT/workspace/threads` |
+| `list_checkpoints()` | `$HQ_ROOT/workspace/checkpoints` |
+| `list_companies()` | `$HQ_ROOT/companies` |
+| `list_projects()` | `$HQ_ROOT/projects` |
 | `list_claude_sessions()` | `~/.claude/projects/-Users-{your-name}-Documents-HQ` (user-specific!) |
-| `get_hq_stats()` | `~/Documents/HQ` (multiple sub-paths) |
-| `get_worker_detail()` | `~/Documents/HQ/workers/{id}` (flat, not public/private split) |
-| `get_company_detail()` | `~/Documents/HQ/companies/{id}` |
-| `get_project_detail()` | `~/Documents/HQ/projects/{name}` |
-| `spawn_worker_skill()` | `~/Documents/HQ` |
-| `open_terminal_in_hq()` | `~/Documents/HQ` |
-| `get_orchestrator_state()` | `~/Documents/HQ/workspace/orchestrator/state.json` |
-| `get_checkouts_state()` | `~/Documents/HQ/workspace/orchestrator/checkouts.json` |
+| `get_hq_stats()` | `$HQ_ROOT` (multiple sub-paths) |
+| `get_worker_detail()` | `$HQ_ROOT/workers/{id}` (flat, not public/private split) |
+| `get_company_detail()` | `$HQ_ROOT/companies/{id}` |
+| `get_project_detail()` | `$HQ_ROOT/projects/{name}` |
+| `spawn_worker_skill()` | `$HQ_ROOT` |
+| `open_terminal_in_hq()` | `$HQ_ROOT` |
+| `get_orchestrator_state()` | `$HQ_ROOT/workspace/orchestrator/state.json` |
+| `get_checkouts_state()` | `$HQ_ROOT/workspace/orchestrator/checkouts.json` |
 
 ### Type Mismatches (Preview for US-003)
 

--- a/template/knowledge/public/hq-core/starter-kit-compatibility-contract.md
+++ b/template/knowledge/public/hq-core/starter-kit-compatibility-contract.md
@@ -273,7 +273,7 @@ This section is the formal contract that Desktop code MUST adhere to.
 ### MUST NOT
 
 1. Desktop MUST NOT crash or show unhandled errors when any optional structure is missing.
-2. Desktop MUST NOT hardcode `~/Documents/HQ` as the HQ path (currently 17 places do this -- see US-001 Section 5).
+2. Desktop MUST NOT hardcode `$HQ_ROOT` as the HQ path (currently 17 places do this -- see US-001 Section 5).
 3. Desktop MUST NOT assume `companies/` exists (it is optional, not present in starter-kit).
 4. Desktop MUST NOT assume `workers/public/` or `workers/private/` layout (starter-kit uses flat `workers/`).
 5. Desktop MUST NOT assume `knowledge/public/` layout (starter-kit uses flat `knowledge/`).
@@ -296,7 +296,7 @@ This section is the formal contract that Desktop code MUST adhere to.
 
 The current Rust backend (see US-001, Section 5) needs these changes to comply with this contract:
 
-1. **Config-based HQ path:** Replace all 17 hardcoded `~/Documents/HQ` references with a config value loaded at startup. The HQ path comes from a config file (e.g., `~/.hq-desktop/config.json`) or the Tauri app's settings store.
+1. **Config-based HQ path:** Replace all 17 hardcoded `$HQ_ROOT` references with a config value loaded at startup. The HQ path comes from a config file (e.g., `~/.hq-desktop/config.json`) or the Tauri app's settings store.
 
 2. **Validation command:** Add a `validate_hq_instance(path: String)` Tauri command that runs the 7-item check and returns the `HQDetectionResult` (see US-001 detection algorithm).
 

--- a/template/knowledge/public/hq-core/thread-schema.md
+++ b/template/knowledge/public/hq-core/thread-schema.md
@@ -30,7 +30,7 @@ Example: `T-20260123-143052-mrr-report`
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:35:00.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {
@@ -80,7 +80,7 @@ Auto-checkpoints are created automatically by PostToolUse hooks after git commit
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:30:52.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {

--- a/template/knowledge/public/hq/desktop-claude-code-integration.md
+++ b/template/knowledge/public/hq/desktop-claude-code-integration.md
@@ -14,7 +14,7 @@ relates_to: []
 
 ### Current State
 
-Desktop and Claude Code share the same HQ filesystem (`~/Documents/HQ/`). Today there is **no file locking** on either side:
+Desktop and Claude Code share the same HQ filesystem (`$HQ_ROOT/`). Today there is **no file locking** on either side:
 
 - **Desktop reads**: All Rust commands (`list_prds`, `list_workers`, `list_threads`, `get_empire_data`, `read_file_content`, `read_json`, `read_yaml`) use `std::fs::read_to_string` with no locking, advisory or otherwise.
 - **Claude Code writes**: Claude Code (via its tools) writes files atomically using temp-file-then-rename, but does not acquire locks visible to other processes.

--- a/template/knowledge/public/hq/hq-desktop/knowledge-system-mapping.md
+++ b/template/knowledge/public/hq/hq-desktop/knowledge-system-mapping.md
@@ -141,7 +141,7 @@ The `@tauri-apps/plugin-fs` `readDir()` also follows symlinks transparently. The
 ### Edge Cases
 
 1. **Broken symlinks:** If a repo is deleted but the symlink remains, `fs::read_dir()` will fail. Desktop should catch this and show a "broken link" indicator.
-2. **Relative vs absolute symlinks:** HQ uses both relative (`../../repos/public/knowledge-hq-core`) and absolute (`~/Documents/HQ/repos/public/knowledge-curious-minds`) symlinks. `fs::canonicalize()` handles both.
+2. **Relative vs absolute symlinks:** HQ uses both relative (`../../repos/public/knowledge-hq-core`) and absolute (`$HQ_ROOT/repos/public/knowledge-curious-minds`) symlinks. `fs::canonicalize()` handles both.
 3. **Nested symlinks:** Some knowledge repos contain internal symlinks (e.g., {Product} CDP knowledge has `audit/` and `flow-migration/` symlinks). Desktop should resolve these recursively.
 
 ---

--- a/template/knowledge/public/hq/hq-desktop/terminal-session-audit.md
+++ b/template/knowledge/public/hq/hq-desktop/terminal-session-audit.md
@@ -8,7 +8,7 @@ Comprehensive audit of the HQ Desktop terminal subsystem: PTY implementation, co
 
 | Command | Signature | Behavior |
 |---------|-----------|----------|
-| `spawn_pty` | `(cmd, cwd, cols, rows) -> session_id` | Spawns PTY via `portable_pty`. Defaults to `$SHELL -l` (login shell), cwd defaults to `~/Documents/HQ`. Inherits full env, sets `TERM=xterm-256color`. Spawns reader thread that emits `pty-output` events. On exit, emits `pty-exit` with exit code and auto-cleans session. |
+| `spawn_pty` | `(cmd, cwd, cols, rows) -> session_id` | Spawns PTY via `portable_pty`. Defaults to `$SHELL -l` (login shell), cwd defaults to `$HQ_ROOT`. Inherits full env, sets `TERM=xterm-256color`. Spawns reader thread that emits `pty-output` events. On exit, emits `pty-exit` with exit code and auto-cleans session. |
 | `write_pty` | `(session_id, data: Vec<u8>)` | Writes raw bytes to PTY master. Flushes after write. |
 | `resize_pty` | `(session_id, cols, rows)` | Resizes PTY via master handle. |
 | `kill_pty` | `(session_id)` | Removes session from HashMap, kills child process. |

--- a/template/knowledge/public/hq/hq-desktop/terminal-session-ux-specs.md
+++ b/template/knowledge/public/hq/hq-desktop/terminal-session-ux-specs.md
@@ -96,7 +96,7 @@ async function executeInPTY(command: HQCommand, args?: string) {
     sessionStore.addSession({
       id: sessionId,
       type: 'claude',
-      cwd: '~/Documents/HQ',
+      cwd: '$HQ_ROOT',
       status: 'running',
       startedAt: new Date().toISOString(),
       title: `/${command.id}`,

--- a/template/knowledge/public/hq/hq-structure-detection.md
+++ b/template/knowledge/public/hq/hq-structure-detection.md
@@ -394,27 +394,27 @@ interface HQDetectionResult {
 
 ## 5. Desktop Hardcoded Path Assumptions (Current State)
 
-The current HQ Desktop Rust backend (`files.rs`, `orchestrator.rs`) hardcodes the path `~/Documents/HQ` in every Tauri command:
+The current HQ Desktop Rust backend (`files.rs`, `orchestrator.rs`) hardcodes the path `$HQ_ROOT` in every Tauri command:
 
 | Tauri Command | Hardcoded Path |
 |--------------|---------------|
-| `list_prds()` | `~/Documents/HQ/projects` + `~/Documents/HQ/apps` + `~/Documents/HQ/repos/private` |
+| `list_prds()` | `$HQ_ROOT/projects` + `$HQ_ROOT/apps` + `$HQ_ROOT/repos/private` |
 | `start_prd_watcher()` | Same 3 paths |
-| `read_dir_tree()` | Falls back to `~/Documents/HQ` |
-| `list_workers()` | `~/Documents/HQ/workers/registry.yaml` |
-| `list_threads()` | `~/Documents/HQ/workspace/threads` |
-| `list_checkpoints()` | `~/Documents/HQ/workspace/checkpoints` |
-| `list_companies()` | `~/Documents/HQ/companies` |
-| `list_projects()` | `~/Documents/HQ/projects` |
+| `read_dir_tree()` | Falls back to `$HQ_ROOT` |
+| `list_workers()` | `$HQ_ROOT/workers/registry.yaml` |
+| `list_threads()` | `$HQ_ROOT/workspace/threads` |
+| `list_checkpoints()` | `$HQ_ROOT/workspace/checkpoints` |
+| `list_companies()` | `$HQ_ROOT/companies` |
+| `list_projects()` | `$HQ_ROOT/projects` |
 | `list_claude_sessions()` | `~/.claude/projects/-Users-{your-name}-Documents-HQ` (user-specific!) |
-| `get_hq_stats()` | `~/Documents/HQ` (multiple sub-paths) |
-| `get_worker_detail()` | `~/Documents/HQ/workers/{id}` (flat, not public/private split) |
-| `get_company_detail()` | `~/Documents/HQ/companies/{id}` |
-| `get_project_detail()` | `~/Documents/HQ/projects/{name}` |
-| `spawn_worker_skill()` | `~/Documents/HQ` |
-| `open_terminal_in_hq()` | `~/Documents/HQ` |
-| `get_orchestrator_state()` | `~/Documents/HQ/workspace/orchestrator/state.json` |
-| `get_checkouts_state()` | `~/Documents/HQ/workspace/orchestrator/checkouts.json` |
+| `get_hq_stats()` | `$HQ_ROOT` (multiple sub-paths) |
+| `get_worker_detail()` | `$HQ_ROOT/workers/{id}` (flat, not public/private split) |
+| `get_company_detail()` | `$HQ_ROOT/companies/{id}` |
+| `get_project_detail()` | `$HQ_ROOT/projects/{name}` |
+| `spawn_worker_skill()` | `$HQ_ROOT` |
+| `open_terminal_in_hq()` | `$HQ_ROOT` |
+| `get_orchestrator_state()` | `$HQ_ROOT/workspace/orchestrator/state.json` |
+| `get_checkouts_state()` | `$HQ_ROOT/workspace/orchestrator/checkouts.json` |
 
 ### Type Mismatches (Preview for US-003)
 

--- a/template/knowledge/public/hq/starter-kit-compatibility-contract.md
+++ b/template/knowledge/public/hq/starter-kit-compatibility-contract.md
@@ -273,7 +273,7 @@ This section is the formal contract that Desktop code MUST adhere to.
 ### MUST NOT
 
 1. Desktop MUST NOT crash or show unhandled errors when any optional structure is missing.
-2. Desktop MUST NOT hardcode `~/Documents/HQ` as the HQ path (currently 17 places do this -- see US-001 Section 5).
+2. Desktop MUST NOT hardcode `$HQ_ROOT` as the HQ path (currently 17 places do this -- see US-001 Section 5).
 3. Desktop MUST NOT assume `companies/` exists (it is optional, not present in starter-kit).
 4. Desktop MUST NOT assume `workers/public/` or `workers/private/` layout (starter-kit uses flat `workers/`).
 5. Desktop MUST NOT assume `knowledge/public/` layout (starter-kit uses flat `knowledge/`).
@@ -296,7 +296,7 @@ This section is the formal contract that Desktop code MUST adhere to.
 
 The current Rust backend (see US-001, Section 5) needs these changes to comply with this contract:
 
-1. **Config-based HQ path:** Replace all 17 hardcoded `~/Documents/HQ` references with a config value loaded at startup. The HQ path comes from a config file (e.g., `~/.hq-desktop/config.json`) or the Tauri app's settings store.
+1. **Config-based HQ path:** Replace all 17 hardcoded `$HQ_ROOT` references with a config value loaded at startup. The HQ path comes from a config file (e.g., `~/.hq-desktop/config.json`) or the Tauri app's settings store.
 
 2. **Validation command:** Add a `validate_hq_instance(path: String)` Tauri command that runs the 7-item check and returns the `HQDetectionResult` (see US-001 detection algorithm).
 

--- a/template/knowledge/public/hq/thread-schema.md
+++ b/template/knowledge/public/hq/thread-schema.md
@@ -30,7 +30,7 @@ Example: `T-20260123-143052-mrr-report`
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:35:00.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {
@@ -80,7 +80,7 @@ Auto-checkpoints are created automatically by PostToolUse hooks after git commit
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:30:52.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {

--- a/template/workers/gemini-designer/skills/design-audit.md
+++ b/template/workers/gemini-designer/skills/design-audit.md
@@ -20,7 +20,7 @@ Optional:
 
 2. **Pipe to Gemini for Audit**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find {scope:-src/components} -name "*.tsx" -o -name "*.css" | head -50 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Comprehensive design audit. Evaluate these dimensions:
 

--- a/template/workers/gemini-designer/skills/design-system-check.md
+++ b/template/workers/gemini-designer/skills/design-system-check.md
@@ -23,7 +23,7 @@ Optional:
 
 3. **Check Consistency via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat .impeccable.md tailwind.config.* 2>/dev/null && find {scope:-src/components} -name "*.tsx" | head -40 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Design system consistency check. Compare every component against the design system.
 

--- a/template/workers/gemini-designer/skills/design-tokens.md
+++ b/template/workers/gemini-designer/skills/design-tokens.md
@@ -18,7 +18,7 @@ Optional:
 
 2. **Extract via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat tailwind.config.* src/styles/*.{css,ts} 2>/dev/null && find src/components -name "*.tsx" | head -30 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Extract all design tokens from this codebase. Identify:
 

--- a/template/workers/gemini-designer/skills/visual-diff.md
+++ b/template/workers/gemini-designer/skills/visual-diff.md
@@ -18,7 +18,7 @@ Optional:
 
 2. **Compare via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {file1} {file2} {design_tokens} | GEMINI_API_KEY=$KEY \
      gemini -p "Visual diff analysis. Compare these two components for inconsistencies:
 

--- a/template/workers/gemini-stylist/skills/add-animation.md
+++ b/template/workers/gemini-stylist/skills/add-animation.md
@@ -20,7 +20,7 @@ Optional:
 
 2. **Generate Animation via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {file} package.json | GEMINI_API_KEY=$KEY \
      gemini -p "Add a {type} animation to this component using {framework}.
 

--- a/template/workers/gemini-stylist/skills/css-refactor.md
+++ b/template/workers/gemini-stylist/skills/css-refactor.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Refactor via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {files} | GEMINI_API_KEY=$KEY \
      gemini -p "CSS refactor. Goals: {goals:-reduce duplication, modernize patterns}.
 

--- a/template/workers/gemini-stylist/skills/dark-mode.md
+++ b/template/workers/gemini-stylist/skills/dark-mode.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Generate Dark Mode via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {files} tailwind.config.* src/styles/globals.css 2>/dev/null | GEMINI_API_KEY=$KEY \
      gemini -p "Add dark mode support using {strategy}.
 

--- a/template/workers/gemini-stylist/skills/responsive-polish.md
+++ b/template/workers/gemini-stylist/skills/responsive-polish.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Analyze via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {files} tailwind.config.* 2>/dev/null | GEMINI_API_KEY=$KEY \
      gemini -p "Responsive analysis and fix. Check each breakpoint ({breakpoints}):
 

--- a/template/workers/gemini-ux-auditor/skills/competitive-scan.md
+++ b/template/workers/gemini-ux-auditor/skills/competitive-scan.md
@@ -18,7 +18,7 @@ Optional:
 
 2. **Analyze via Gemini (with Google Search grounding)**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find src/app src/components -name "*.tsx" 2>/dev/null | head -30 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Competitive UX analysis for: {product}.
 

--- a/template/workers/gemini-ux-auditor/skills/copy-review.md
+++ b/template/workers/gemini-ux-auditor/skills/copy-review.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Review via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find {scope:-src} -name "*.tsx" | head -40 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Microcopy review. Focus: {focus}. Target tone: {tone:-professional}.
 

--- a/template/workers/gemini-ux-auditor/skills/flow-review.md
+++ b/template/workers/gemini-ux-auditor/skills/flow-review.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Analyze via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find src -name "*.tsx" | xargs grep -l "{flow}" | head -20 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "User flow analysis for the {flow} flow. Persona: {persona:-general user}.
 

--- a/template/workers/gemini-ux-auditor/skills/ux-audit.md
+++ b/template/workers/gemini-ux-auditor/skills/ux-audit.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Evaluate via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY $HQ_ROOT/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find src/app src/components src/pages -name "*.tsx" 2>/dev/null | head -50 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "UX heuristic evaluation. Apply Nielsen's 10 usability heuristics:
 

--- a/template/workers/public/sample-worker/worker.yaml
+++ b/template/workers/public/sample-worker/worker.yaml
@@ -54,7 +54,7 @@ An orchestrator needs to execute the `generate-report` skill on a Node.js projec
     "include_charts": true,
     "output_path": "workspace/reports/q1-performance.md"
   },
-  "cwd": "~/Documents/HQ",
+  "cwd": "$HQ_ROOT",
   "files_context": [
     "workspace/data/q1-metrics.json",
     "knowledge/public/analytics/reporting-style.md"

--- a/template/workers/sample-worker/worker.yaml
+++ b/template/workers/sample-worker/worker.yaml
@@ -54,7 +54,7 @@ An orchestrator needs to execute the `generate-report` skill on a Node.js projec
     "include_charts": true,
     "output_path": "workspace/reports/q1-performance.md"
   },
-  "cwd": "~/Documents/HQ",
+  "cwd": "$HQ_ROOT",
   "files_context": [
     "workspace/data/q1-metrics.json",
     "knowledge/public/analytics/reporting-style.md"


### PR DESCRIPTION
## Summary
- **Removes all 92 instances** of hardcoded `~/Documents/HQ` across `template/` and `packages/create-hq/hq2/`
  - Shell scripts (hooks, run-project.sh): `~/Documents/HQ` → `${HQ_ROOT:-$HOME/hq}` (dynamic with fallback)
  - Markdown docs/commands: `~/Documents/HQ` → `$HQ_ROOT` (references the env var)
  - Fixes hooks silently failing due to tilde not expanding in double quotes (`HQ="~/Documents/HQ"` stores literal string)
- **Adds `context-meter.sh`** Stop hook — tracks context window usage per response
  - Reads transcript `input_tokens` + `cache_read_input_tokens` to compute % used
  - Writes `CTX: {pct}% ({tokens}/{window})` to `/tmp/.hq-context-meter`
  - CLAUDE.md instructs model to output this at end of every response
  - Warns HANDOFF SOON at 75%+
  - Added to `settings.json` Stop hooks in both template and packages

## Files changed
- **8 shell scripts** — hook/script path fixes
- **54 markdown/yaml files** — doc path references
- **2 settings.json** — context-meter hook registration
- **2 CLAUDE.md** — Context Meter section
- **2 new files** — `context-meter.sh` (template + packages)

## Test plan
- [ ] Verify `grep -r '~/Documents/HQ' template/ packages/` returns 0 matches
- [ ] Validate JSON: `python3 -m json.tool template/.claude/settings.json`
- [ ] Fresh `npx create-hq` install: hooks should not error on git commands
- [ ] Context meter: verify CTX line appears in model responses after Stop hook fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)