### PR TITLE
fix(create-hq): add --yes flag and harden smoke-test report generation

### DIFF
--- a/packages/create-hq/src/index.ts
+++ b/packages/create-hq/src/index.ts
@@ -18,6 +18,7 @@ program
   .option("--skip-cli", "don't install @indigoai-us/hq-cli globally")
   .option("--skip-sync", "don't prompt for cloud sync setup")
   .option("--skip-packages", "don't prompt for package discovery and installation")
+  .option("-y, --yes", "non-interactive mode — implies all --skip-* flags; safe for CI / smoke tests with /dev/null stdin")
   .option("--tag <version>", "fetch a specific HQ version tag (e.g. v9.1.0)")
   .option("--local-template <path>", "use a local template directory instead of fetching from GitHub")
   .option("--join <token>", "join a team with an invite token after scaffolding")

--- a/packages/create-hq/src/scaffold.ts
+++ b/packages/create-hq/src/scaffold.ts
@@ -29,6 +29,7 @@ interface ScaffoldOptions {
   skipCli?: boolean;
   skipSync?: boolean;
   skipPackages?: boolean;
+  yes?: boolean;
   tag?: string;
   localTemplate?: string;
   join?: string;
@@ -56,6 +57,16 @@ export async function scaffold(
   directory: string,
   options: ScaffoldOptions
 ): Promise<void> {
+  // Non-interactive mode: --yes implies skipping every prompt-driven side flow.
+  // We treat --yes as "personal HQ, no account, no package discovery" so the
+  // scaffold can run end-to-end against /dev/null stdin (CI, smoke tests).
+  if (options.yes) {
+    options.skipPackages = true;
+    options.skipCli = true;
+    options.skipSync = true;
+    options.skipDeps = true;
+  }
+
   // Show banner with installer version; hqVersion will be added after template fetch
   banner(pkg.version);
 

--- a/packages/create-hq/test/run-smoke-tests.sh
+++ b/packages/create-hq/test/run-smoke-tests.sh
@@ -70,22 +70,54 @@ for image in "${IMAGES[@]}"; do
   JSON_LINE=$(echo "$OUTPUT" | sed -n '/^JSON_REPORT_START$/,/^JSON_REPORT_END$/p' | grep -v '^JSON_REPORT_' || echo "")
 
   if [ -z "$JSON_LINE" ]; then
-    # No JSON report — container likely crashed
-    JSON_LINE="{\"image\":\"${image}\",\"passed\":false,\"pass_count\":0,\"fail_count\":1,\"duration_ms\":0,\"assertions\":[{\"name\":\"container-run\",\"passed\":false,\"duration_ms\":0,\"message\":\"Container exited without producing a report\"}],\"logs_on_failure\":$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" 2>/dev/null || echo '""')}"
+    # No JSON report — container likely crashed.
+    # Write logs to a temp file and let python read it (never interpolate
+    # untrusted output into a python -c source string).
+    LOGS_FILE=$(mktemp)
+    printf '%s' "$OUTPUT" > "$LOGS_FILE"
+    JSON_LINE=$(IMAGE="$image" LOGS_FILE="$LOGS_FILE" python3 -c '
+import json, os
+with open(os.environ["LOGS_FILE"], "r", errors="replace") as f:
+    logs = f.read()
+print(json.dumps({
+    "image": os.environ["IMAGE"],
+    "passed": False,
+    "pass_count": 0,
+    "fail_count": 1,
+    "duration_ms": 0,
+    "assertions": [{
+        "name": "container-run",
+        "passed": False,
+        "duration_ms": 0,
+        "message": "Container exited without producing a report",
+    }],
+    "logs_on_failure": logs,
+}))
+')
+    rm -f "$LOGS_FILE"
     ALL_PASSED=false
   else
     # Check if this image passed
     PASSED=$(echo "$JSON_LINE" | python3 -c "import sys,json; print(json.load(sys.stdin)['passed'])" 2>/dev/null || echo "False")
     if [ "$PASSED" != "True" ]; then
       ALL_PASSED=false
-      # Add logs on failure
-      LOGS=$(echo "$OUTPUT" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))" 2>/dev/null || echo '""')
-      JSON_LINE=$(echo "$JSON_LINE" | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-d['logs_on_failure'] = $LOGS
+      # Add logs on failure — use temp files to avoid bash → python source interpolation,
+      # which crashed on quotes/newlines/dollar signs in container output and left
+      # latest.json un-updated on failed runs.
+      LOGS_FILE=$(mktemp)
+      JSON_FILE=$(mktemp)
+      printf '%s' "$OUTPUT" > "$LOGS_FILE"
+      printf '%s' "$JSON_LINE" > "$JSON_FILE"
+      JSON_LINE=$(LOGS_FILE="$LOGS_FILE" JSON_FILE="$JSON_FILE" python3 -c '
+import json, os
+with open(os.environ["LOGS_FILE"], "r", errors="replace") as f:
+    logs = f.read()
+with open(os.environ["JSON_FILE"], "r", errors="replace") as f:
+    d = json.load(f)
+d["logs_on_failure"] = logs
 print(json.dumps(d))
-" 2>/dev/null || echo "$JSON_LINE")
+' 2>/dev/null || echo "$JSON_LINE")
+      rm -f "$LOGS_FILE" "$JSON_FILE"
     fi
   fi
 
@@ -102,18 +134,32 @@ echo "Removed tarball: $TARBALL_NAME"
 echo ""
 echo "=== Step 5: Generating report ==="
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-IMAGES_JSON=$(printf '%s,' "${IMAGE_RESULTS[@]}" | sed 's/,$//')
 
-REPORT=$(python3 -c "
-import json
-images = json.loads('[${IMAGES_JSON}]')
+# Write per-image JSON lines to a temp file (one per line). Reading them from
+# disk avoids the shell → python source interpolation that crashed when image
+# results contained quotes/newlines (e.g. logs_on_failure embedded text).
+IMAGES_FILE=$(mktemp)
+for img_json in "${IMAGE_RESULTS[@]}"; do
+  printf '%s\n' "$img_json" >> "$IMAGES_FILE"
+done
+
+REPORT=$(TIMESTAMP="$TIMESTAMP" IMAGES_FILE="$IMAGES_FILE" python3 -c '
+import json, os
+images = []
+with open(os.environ["IMAGES_FILE"], "r", errors="replace") as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        images.append(json.loads(line))
 report = {
-    'timestamp': '${TIMESTAMP}',
-    'passed': all(i['passed'] for i in images),
-    'images': images
+    "timestamp": os.environ["TIMESTAMP"],
+    "passed": all(i["passed"] for i in images),
+    "images": images,
 }
 print(json.dumps(report, indent=2))
-" 2>/dev/null)
+')
+rm -f "$IMAGES_FILE"
 
 echo "$REPORT" > "$RESULTS_DIR/latest.json"
 echo "Report written to: $RESULTS_DIR/latest.json"

--- a/packages/create-hq/test/smoke-test.sh
+++ b/packages/create-hq/test/smoke-test.sh
@@ -110,12 +110,10 @@ echo ""
 # tools like claude, qmd, yq). In a headless container with /dev/null stdin,
 # prompts auto-accept but npm install -g fails as non-root. Dep install is
 # for real users at a terminal — the smoke test validates the scaffold output.
-echo "Running: create-hq ${TEST_DIR} --local-template ${TEMPLATE_DIR} --skip-deps --skip-cli --skip-sync"
+echo "Running: create-hq ${TEST_DIR} --local-template ${TEMPLATE_DIR} --yes"
 "$CREATE_HQ_BIN" "${TEST_DIR}" \
   --local-template "${TEMPLATE_DIR}" \
-  --skip-deps \
-  --skip-cli \
-  --skip-sync \
+  --yes \
   < /dev/null 2>&1 || {
   echo "FATAL: create-hq exited with non-zero status"
   exit 1


### PR DESCRIPTION
## Summary

Fixes two independent bugs in `packages/create-hq` that have been failing the daily smoke test for two consecutive days.

### Bug 1 — Interactive prompt blocks headless runs
`scaffold.ts` calls `confirm("Do you have an HQ account?")` inside the `!skipPackages` package-discovery branch. The smoke test runs `create-hq` with stdin redirected to `/dev/null`, so the readline call hangs forever. The container exits before any of the 9 structural assertions (`dir-exists:.claude`, `dir-exists:workers`, etc.) can run.

**Fix:** Add an umbrella `-y / --yes` flag to `create-hq` that implies all the existing `--skip-*` flags. Standard non-interactive convention (matches `apt`, `npm`, etc.) and gives CI a single switch instead of four. `smoke-test.sh` now passes `--yes`.

### Bug 2 — `run-smoke-tests.sh` Step 5 never wrote `latest.json`
Two `python3 -c` heredocs interpolated bash variables (`$LOGS`, `$IMAGES_JSON`) directly into Python source code. Once the smoke test actually started failing assertions and producing real output, those variables held JSON-encoded log strings containing quotes, newlines, and `$`-signs — which made the resulting Python source invalid. The process crashed under `2>/dev/null`, the surrounding `set -e` was suppressed, and `latest.json` was never updated. The stale report from a previous run kept being read by the morning monitor, masking the failure.

**Fix:** Replace both interpolation sites with the temp-file-then-read pattern. Write per-image JSON / container logs to a `mktemp` file, pass the path through an env var, read inside Python. No more shell-to-Python source injection. There were two such sites — the failure path inside the per-image loop, and the final report assembly in Step 5.

## Verification

Both Docker images now run end-to-end:

```
blank-slate                  FAIL  1562ms
pre-deps                     FAIL  1671ms
```

13 out of 14 assertions PASS in each image — every assertion that the prompt was previously blocking. `latest.json` is now overwritten on every run with `logs_on_failure` correctly embedded.

```
$ ls -la packages/create-hq/test/results/latest.json
-rw-r--r--  1 stefanjohnson  staff  15630 Apr  8 07:24 latest.json
```

## Out of scope (separate follow-up)

The remaining 1 failing assertion is `no-placeholders-in-core-files`. This is a **template content** issue, not a `create-hq` bug — the assertion was previously masked by Bug 1 (the CLI never finished scaffolding, so the assertion never ran). Three template files contain `{your-username}` / `{your-name}` strings outside the assertion's exempt list:

- `template/.claude/CLAUDE.md`
- `template/USER-GUIDE.md`
- `template/.claude/skills/run/SKILL.md`

The fix is either (a) substitute the placeholders during template install, or (b) extend the assertion's exempt list if these are intentional documentation references. Worth a separate PR with someone who knows the template policy intent.

## Test plan

- [x] `npm run build` clean (TypeScript)
- [x] `bash packages/create-hq/test/run-smoke-tests.sh` runs to completion
- [x] `latest.json` is overwritten with current timestamp
- [x] `latest.json` contains `logs_on_failure` for failing images
- [x] All 13 structural assertions (`dir-exists:*`, `file-exists:*`, git, CLI) pass in both `blank-slate` and `pre-deps` images
- [ ] Reviewer to confirm the `--yes` semantics (umbrella for all `--skip-*` flags) match team preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)