### PR TITLE
fix: skip teams prompt in non-interactive CI

### DIFF
--- a/packages/create-hq/src/scaffold.ts
+++ b/packages/create-hq/src/scaffold.ts
@@ -91,9 +91,15 @@ export async function scaffold(
 ): Promise<void> {
   banner(pkg.version);
 
-  // 1. Entry mode — if --invite or --join is provided, force teams-existing
+  // 1. Entry mode — if --invite or --join is provided, force teams-existing.
+  //    If stdin is not a TTY (headless CI, piped /dev/null), skip prompts → personal.
   const inviteToken = options.invite || options.join;
-  const mode = inviteToken ? "teams-existing" as EntryMode : await chooseEntryMode();
+  const isInteractive = process.stdin.isTTY ?? false;
+  const mode = inviteToken
+    ? "teams-existing" as EntryMode
+    : isInteractive
+      ? await chooseEntryMode()
+      : "personal" as EntryMode;
   if (mode === "exit") {
     console.log();
     info("No problem — come back any time with: npx create-hq");


### PR DESCRIPTION
## Summary
- Container smoke tests hang because the teams entry-mode prompts auto-accept via `/dev/null` stdin, triggering the GitHub device auth flow which polls forever
- Detect non-interactive stdin (`process.stdin.isTTY`) and default to `personal` mode, skipping teams prompts entirely

## Test plan
- [ ] CI pipeline passes (container smoke tests no longer hang)
- [ ] Unit tests pass (39/39)
- [ ] Interactive `npx create-hq` still shows teams prompts in a real terminal