### PR TITLE
fix: remove hardcoded PATH that broke subagent tool detection

### DIFF
--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -13,7 +13,6 @@
     ]
   },
   "env": {
-    "PATH": "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     "MAX_THINKING_TOKENS": "31999",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "60",

--- a/template/core.yaml
+++ b/template/core.yaml
@@ -1,6 +1,6 @@
 version: 1
 hqVersion: "10.5.0"
-updatedAt: "2026-04-11T12:37:53Z"
+updatedAt: "2026-04-13T14:30:53Z"
 rules:
   locked:
     - .claude/CLAUDE.md
@@ -22,14 +22,14 @@ rules:
   open:
     - "**"
 checksums:
-  .claude/CLAUDE.md: 118475be637de85b710d6e9510c45d96d50657c6196f0bd64c806a70806de2c0
-  .claude/hooks: aadcbaa79a77cfb2e7f43fb0404c9eef70bbe323e649513adc67d8aa3b4b33e4
-  .claude/policies: 968a85874ba1861cb204c0e2a40c820d1f5e600a05f95f774e1c4f397b9a4cab
-  .claude/settings.json: 9dda864e4c462d6cfb88549ce6c75e2b014ce5391b9913408052cda3ab4578f8
-  CHANGELOG.md: 2869e0d837c2f3b3458568a7d9aa844415e510639eca75dfcf8d0824b88d0ef7
-  companies/_template: 82de3103e2fee44daccad652896946090106907a454b93346342238466ecae3c
-  companies/manifest.yaml: c9a664bb510b5c4b40e2d327f51b1d962b1bc52edfc6b3bab8bb2bf8b3b9092d
-  MIGRATION.md: 16d72e5c4bff347577b172772fb2caab0964d390a68028085555ffb02c6d5cbc
-  modules: 9614c88a604f7a2529682265c7abe6a402bc995544ec473af15c53b6b9bb04d2
-  scripts: 7a1e01f93bdc9de8f941c23804dda75593cb0c6fdc7bf98061645290aad9e3a8
-  workers/registry.yaml: 1ef3af2a22e40f932376f5f67b43bf20afebcdef643d71e3febbf24e6ed1b07a
+  .claude/CLAUDE.md: 23c7e1c93d775ff4647a024975555df2063af68287e0ab3f425dc3bfc34e886c
+  .claude/hooks: 4ca89ab083029489f7f95acfd24566badd4312153895da763904c1a49d02038e
+  .claude/policies: 6f29062f7c0962a5b8934360aaea208a640f649357095101ea62777556c8e463
+  .claude/settings.json: 2d28b49e644f4dca28ae8dc8465f2fec160fbb8dc09cf5b8b2e81b49df9c2631
+  CHANGELOG.md: e320581ecb21a2427bae70737824b08f3fd61c05fa39e5b316f228ca2f3a6513
+  MIGRATION.md: eacc1b42e8c952ea793404d51e12c9cc724b764bf04a0c8b0a464d0760cc8dca
+  companies/_template: 989a2d928de46bd5933d2f9d803bb9b5d58cb33dfb65d88f8b2fbd7f1b553d6a
+  companies/manifest.yaml: 61b9cc98d7f3f80361f59affc3f50dab3d2dfe2da332ee5d6d44e948ae75802c
+  modules: 41b1ea0ea7bac0a5fcb227bc9e5041845f949d0bfdeb2b9267b831b7824698cc
+  scripts: cbc1d97735ac31e922fe267d332e46f4ece4775a47cf988379422928525f44e4
+  workers/registry.yaml: bdece889ccfb5772ecc25f968b79ee0372f6a665afae973f8070f42eaada0130

--- a/template/setup.sh
+++ b/template/setup.sh
@@ -94,6 +94,25 @@ find "$REPO_ROOT/tools" -name '*.sh' -exec chmod +x {} \;
 find "$REPO_ROOT/scripts" -name '*.sh' -exec chmod +x {} \; 2>/dev/null || true
 ok "scripts marked executable"
 
+# ── 3b. Snapshot user's PATH into settings.json ────────────────────────────
+# Claude Code's env block does literal assignment (no $PATH expansion).
+# Subagents (claude -p) run non-interactive bash that never sources .zshrc,
+# so they'd only see the system PATH. We snapshot the user's current PATH
+# (which includes nvm, bun, pnpm, pyenv, ~/.local/bin, etc.) at install time.
+
+echo ""
+echo "Configuring PATH for subagents…"
+
+SETTINGS_FILE="$REPO_ROOT/.claude/settings.json"
+if [[ -f "$SETTINGS_FILE" ]]; then
+  CURRENT_PATH="$PATH"
+  UPDATED="$(jq --arg p "$CURRENT_PATH" '.env.PATH = $p' "$SETTINGS_FILE")"
+  printf '%s\n' "$UPDATED" > "$SETTINGS_FILE"
+  ok "PATH snapshot written to settings.json"
+else
+  skip "settings.json not found — PATH not configured"
+fi
+
 # ── 4. Create company structure ──────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary
- Removed hardcoded minimal `env.PATH` from `template/.claude/settings.json` that replaced the user's shell PATH, stripping `~/.local/bin` (claude), nvm node bins (qmd), bun, pnpm, pyenv, etc.
- Added PATH snapshot step to `setup.sh` — at install time, captures the user's current shell PATH (with all toolchains resolved) and writes it into `settings.json`
- Subagents spawned via `claude -p` now inherit the user's full PATH instead of a bare system PATH

## Root cause
Claude Code's `settings.json` `env` block does **literal assignment** (no `$PATH` expansion). The hardcoded `PATH` completely replaced whatever the user's shell provided. Non-interactive bash doesn't source `.zshrc`/`.bashrc`, so the only PATH available to subagents was the hardcoded minimal one — missing `claude`, `qmd`, and everything else installed via nvm/bun/pnpm/pyenv.

## Changes
1. **`template/.claude/settings.json`** — Removed `"PATH": "/opt/homebrew/bin:..."` from env block
2. **`template/setup.sh`** — New step 3b: snapshots user's current `$PATH` into `settings.json` at install time via `jq`

## Test plan
- [ ] Run `./setup.sh` and verify `.claude/settings.json` has full PATH with nvm, bun, etc.
- [ ] Run `claude -p "which claude && which qmd"` from an HQ repo — both should resolve
- [ ] Verify existing users who re-run setup.sh get the fix
- [ ] Confirm no regression in hook execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)