### PR TITLE
feat: context meter Stop hook

### DIFF
--- a/template/.claude/CLAUDE.md
+++ b/template/.claude/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Personal OS for orchestrating work across companies, workers, and AI.
 
+## Context Meter (mandatory)
+
+A Stop hook writes context window usage to `/tmp/.hq-context-meter`. **At the END of every response, output the contents of this file as the last line of your message.** Format: `CTX: {pct}% ({tokens}/{window})`. If it says HANDOFF SOON, warn the user. Do NOT use a tool to read it — just output the value from the system-reminder injected by the hook.
+
 ## Key Files
 
 - `INDEX.md` - Directory map (load only for HQ infra tasks or when disoriented)

--- a/template/.claude/hooks/context-meter.sh
+++ b/template/.claude/hooks/context-meter.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Context meter — fires on Stop hook, reads transcript to estimate context usage.
+# Writes a one-line CTX report to /tmp/.hq-context-meter.
+# CLAUDE.md instructs the model to output this at the end of every response.
+
+set -euo pipefail
+
+INPUT=$(cat)
+TRANSCRIPT=$(echo "$INPUT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('transcript_path',''))" 2>/dev/null) || exit 0
+
+[ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ] && exit 0
+
+# Get the last assistant message's input_tokens (= current context size)
+TOKENS=$(tail -20 "$TRANSCRIPT" | grep -o '"input_tokens":[0-9]*' | tail -1 | cut -d: -f2) || exit 0
+[ -z "$TOKENS" ] && exit 0
+
+# Also grab cache_read tokens
+CACHE=$(tail -20 "$TRANSCRIPT" | grep -o '"cache_read_input_tokens":[0-9]*' | tail -1 | cut -d: -f2) || true
+CACHE=${CACHE:-0}
+TOTAL=$((TOKENS + CACHE))
+
+# Context window is 200K (Claude Code effective limit)
+WINDOW=200000
+PCT=$((TOTAL * 100 / WINDOW))
+
+# Write to file AND stdout (stdout → system-reminder for model to repeat)
+METER_FILE="/tmp/.hq-context-meter"
+if [ "$PCT" -ge 75 ]; then
+  MSG="⚠️ CTX: ${PCT}% (${TOTAL}/${WINDOW}) — HANDOFF SOON"
+elif [ "$PCT" -ge 50 ]; then
+  MSG="📊 CTX: ${PCT}% (${TOTAL}/${WINDOW})"
+else
+  MSG="CTX: ${PCT}% (${TOTAL}/${WINDOW})"
+fi
+echo "$MSG" > "$METER_FILE"
+echo "$MSG"
+
+exit 0

--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -154,6 +154,11 @@
             "type": "command",
             "command": ".claude/hooks/hook-gate.sh cleanup-mcp-processes .claude/hooks/cleanup-mcp-processes.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/hook-gate.sh context-meter .claude/hooks/context-meter.sh",
+            "timeout": 3
           }
         ]
       }

--- a/template/core.yaml
+++ b/template/core.yaml
@@ -1,6 +1,6 @@
 version: 1
 hqVersion: "10.5.0"
-updatedAt: "2026-04-13T14:30:53Z"
+updatedAt: "2026-04-13T15:44:02Z"
 rules:
   locked:
     - .claude/CLAUDE.md
@@ -22,10 +22,10 @@ rules:
   open:
     - "**"
 checksums:
-  .claude/CLAUDE.md: 23c7e1c93d775ff4647a024975555df2063af68287e0ab3f425dc3bfc34e886c
-  .claude/hooks: 4ca89ab083029489f7f95acfd24566badd4312153895da763904c1a49d02038e
+  .claude/CLAUDE.md: 2c5eb98d2ffd77c8f933ea3a1872e6bbfc84e0e6120e95b550012b113eaf4798
+  .claude/hooks: 689e20e4795072f323e6cea8a556f89698b6e299d20e9e00ca3ab19c7d5a40c9
   .claude/policies: 6f29062f7c0962a5b8934360aaea208a640f649357095101ea62777556c8e463
-  .claude/settings.json: 2d28b49e644f4dca28ae8dc8465f2fec160fbb8dc09cf5b8b2e81b49df9c2631
+  .claude/settings.json: f0a1ba000ffa47fbe83c0576fc9026f19dc49981abda9f80f18d1f8a337a90c5
   CHANGELOG.md: e320581ecb21a2427bae70737824b08f3fd61c05fa39e5b316f228ca2f3a6513
   MIGRATION.md: eacc1b42e8c952ea793404d51e12c9cc724b764bf04a0c8b0a464d0760cc8dca
   companies/_template: 989a2d928de46bd5933d2f9d803bb9b5d58cb33dfb65d88f8b2fbd7f1b553d6a


### PR DESCRIPTION
## Summary
Adds a context window usage meter that fires on every Stop hook.

- **`context-meter.sh`** — reads transcript `input_tokens` + `cache_read_input_tokens`, computes % of 200K window, writes to `/tmp/.hq-context-meter`
- **CLAUDE.md** — instructs the model to output the CTX line at the end of every response
- **settings.json** — registers the hook in the Stop hooks array (via hook-gate, 3s timeout)

Warns `HANDOFF SOON` at 75%+. The model reads the value from the system-reminder injected by the hook — no tool call needed.

Cherry-picked from #42. The path fixes in that PR (`~/Documents/HQ` → `$HQ_ROOT`) are already on main — this extracts only the context meter work. #42 can be closed after this merges.

## Test plan
- [ ] Run a session — verify `CTX: X% (N/200000)` appears at end of responses
- [ ] Verify `/tmp/.hq-context-meter` file is written after each response
- [ ] Verify 75%+ threshold shows warning emoji + HANDOFF SOON text
- [ ] `python3 -m json.tool template/.claude/settings.json` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)