### PR TITLE
fix: replace hardcoded ~/Documents/HQ paths with $HQ_ROOT

### DIFF
--- a/template/.claude/commands/audit.md
+++ b/template/.claude/commands/audit.md
@@ -37,7 +37,7 @@ Based on flags parsed above, choose one of three modes:
 
 **If no `--since` and no `--company` flags**, call the script's built-in summary:
 ```bash
-cd ~/Documents/HQ && bash scripts/audit-log.sh summary 2>/dev/null
+cd ${HQ_ROOT:-$HOME/hq} && bash scripts/audit-log.sh summary 2>/dev/null
 ```
 Display the output directly — it already includes by-project and by-worker tables.
 
@@ -45,7 +45,7 @@ Display the output directly — it already includes by-project and by-worker tab
 
 Compute `SINCE_DATE`: if `--since` was provided use that value, otherwise use 7 days ago in `YYYY-MM-DD` format.
 ```bash
-cd ~/Documents/HQ && \
+cd ${HQ_ROOT:-$HOME/hq} && \
   SINCE="$(date -v-7d +%Y-%m-%d 2>/dev/null || date -d '7 days ago' +%Y-%m-%d)" && \
   bash scripts/audit-log.sh query --since "$SINCE" 2>/dev/null
 ```
@@ -114,7 +114,7 @@ Sort by tasks descending.
 
 Run:
 ```bash
-cd ~/Documents/HQ && \
+cd ${HQ_ROOT:-$HOME/hq} && \
   bash scripts/audit-log.sh query --event task_failed 2>/dev/null
 ```
 
@@ -147,7 +147,7 @@ If zero results: print `No task failures found.`
 
 Build query:
 ```bash
-cd ~/Documents/HQ && \
+cd ${HQ_ROOT:-$HOME/hq} && \
   bash scripts/audit-log.sh query --project <name> 2>/dev/null
 ```
 

--- a/template/.claude/commands/harness-audit.md
+++ b/template/.claude/commands/harness-audit.md
@@ -193,8 +193,8 @@ CATEGORY SCORES:
 TOTAL: 63/70 (A grade)
 
 TOP 3 IMPROVEMENTS:
-1. Add missing hook: ~/Documents/HQ/.claude/hooks/observe-patterns.sh (S)
-2. Write security policy: ~/Documents/HQ/.claude/policies/company-isolation-validation.md (M)
+1. Add missing hook: $HQ_ROOT/.claude/hooks/observe-patterns.sh (S)
+2. Write security policy: $HQ_ROOT/.claude/policies/company-isolation-validation.md (M)
 3. Add /tdd command to .claude/commands/ (S)
 
 NOTES:

--- a/template/.claude/commands/pr.md
+++ b/template/.claude/commands/pr.md
@@ -20,7 +20,7 @@ Dispatch PR tasks to {company}-agent for autonomous execution. Results appear at
 Run the agent locally with Bash:
 
 ```bash
-cd ~/Documents/HQ/repos/private/{company}-agent && node dist/entry.js agent --local -m "{message}"
+cd ${HQ_ROOT:-$HOME/hq}/repos/private/{company}-agent && node dist/entry.js agent --local -m "{message}"
 ```
 
 The `--local` flag runs the embedded agent (uses model provider API keys from shell). The `-m` flag passes the task message. The agent auto-loads the relevant skill based on the message content.

--- a/template/.claude/commands/recover-session.md
+++ b/template/.claude/commands/recover-session.md
@@ -269,7 +269,7 @@ Build thread in HQ format:
 
 Use the death timestamp (not current time) for the thread ID — represents when work happened.
 
-Relativize file paths: strip `~/Documents/HQ/` prefix.
+Relativize file paths: strip `$HQ_ROOT/` prefix.
 
 If `--dry-run`, display what would be written and stop here. Do NOT write any files.
 

--- a/template/.claude/commands/run-pipeline.md
+++ b/template/.claude/commands/run-pipeline.md
@@ -48,7 +48,7 @@ Display: `Loaded N policies (H hard, S soft)`
 Run triage via the bash script in dry-run mode:
 
 ```bash
-cd ~/Documents/HQ && bash scripts/run-pipeline.sh {company} {prd1} [prd2...] --dry-run
+cd ${HQ_ROOT:-$HOME/hq} && bash scripts/run-pipeline.sh {company} {prd1} [prd2...] --dry-run
 ```
 
 Display the triage table output to the user. This shows: project sequence, risk levels, story counts, repo grouping, dependency order.
@@ -65,7 +65,7 @@ If `--dry-run` was in the original args: stop after showing triage (do not launc
 Run the bash script in background:
 
 ```bash
-cd ~/Documents/HQ && \
+cd ${HQ_ROOT:-$HOME/hq} && \
   nohup bash scripts/run-pipeline.sh {company} {prd1} [prd2...] {passthrough_flags} \
   > workspace/orchestrator/_pipeline/{pipeline_id}/claude-session.log 2>&1 &
 echo "PID:$!"
@@ -138,7 +138,7 @@ When `pending_gate` is detected in pipeline-state.json:
 
 3. **Write resolution** to pipeline-state.json:
    ```bash
-   cd ~/Documents/HQ && \
+   cd ${HQ_ROOT:-$HOME/hq} && \
    jq '.pending_gate.resolution = "{choice}"' \
      workspace/orchestrator/_pipeline/{pipeline_id}/pipeline-state.json > /tmp/ps-tmp.json && \
    mv /tmp/ps-tmp.json workspace/orchestrator/_pipeline/{pipeline_id}/pipeline-state.json
@@ -193,7 +193,7 @@ When `--resume <pipeline_id>` is provided:
    - PID alive → resume poll loop (Step 5)
    - PID dead + status `in_progress` → offer to relaunch:
      ```bash
-     cd ~/Documents/HQ && \
+     cd ${HQ_ROOT:-$HOME/hq} && \
        nohup bash scripts/run-pipeline.sh --resume {pipeline_id} \
        > workspace/orchestrator/_pipeline/{pipeline_id}/claude-session.log 2>&1 &
      ```
@@ -204,7 +204,7 @@ When `--resume <pipeline_id>` is provided:
 When `--status` is provided:
 
 ```bash
-cd ~/Documents/HQ && bash scripts/run-pipeline.sh --status
+cd ${HQ_ROOT:-$HOME/hq} && bash scripts/run-pipeline.sh --status
 ```
 
 Display the formatted output and stop.

--- a/template/.claude/commands/run-project.md
+++ b/template/.claude/commands/run-project.md
@@ -53,7 +53,7 @@ Parse `$ARGUMENTS` into project name + passthrough flags:
 
 ```bash
 # Bash tool with run_in_background: true
-cd ~/Documents/HQ && \
+cd ${HQ_ROOT:-$HOME/hq} && \
   nohup bash scripts/run-project.sh {project} {passthrough_flags} --no-permissions \
   > workspace/orchestrator/{project}/run.log 2>&1 &
 echo "PID:$!"

--- a/template/.claude/commands/search-reindex.md
+++ b/template/.claude/commands/search-reindex.md
@@ -17,15 +17,15 @@ Run `qmd status` for live counts. Default collections:
 
 | Collection | Path | Pattern |
 |---|---|---|
-| `hq` | `~/Documents/HQ` | `**/*.{md,json,yaml,yml}` |
-| `{product}` | `~/Documents/HQ/repos/private/{product}` | `**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,css,prisma}` |
-| `personal` | `~/Documents/HQ/companies/personal/knowledge` | `**/*.md` |
+| `hq` | `$HQ_ROOT` | `**/*.{md,json,yaml,yml}` |
+| `{product}` | `$HQ_ROOT/repos/private/{product}` | `**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,css,prisma}` |
+| `personal` | `$HQ_ROOT/companies/personal/knowledge` | `**/*.md` |
 
 Each company added via `/newcompany` gets its own collection:
 
 | Collection | Path | Pattern |
 |---|---|---|
-| `{company-slug}` | `~/Documents/HQ/companies/{company-slug}/knowledge` | `**/*.md` |
+| `{company-slug}` | `$HQ_ROOT/companies/{company-slug}/knowledge` | `**/*.md` |
 
 ## Process
 
@@ -82,7 +82,7 @@ To completely rebuild all collections:
 qmd cleanup
 
 # HQ collection
-qmd collection add ~/Documents/HQ --name hq --mask "**/*.{md,json,yaml,yml}"
+qmd collection add $HQ_ROOT --name hq --mask "**/*.{md,json,yaml,yml}"
 qmd context add qmd://hq "HQ knowledge base: company knowledge, AI worker definitions, project PRDs, slash commands, reports, social drafts, and session threads."
 qmd context add qmd://hq/knowledge "HQ-level knowledge bases: Ralph coding methodology, worker framework patterns, dev-team practices, design styles, security framework, project templates."
 qmd context add qmd://hq/.claude/commands "Claude Code slash commands: 44 agent skills for session management, worker execution, project management, content creation, design, deployment."
@@ -92,7 +92,7 @@ qmd context add qmd://hq/projects "Project PRDs and READMEs for active and plann
 qmd context add qmd://hq/workspace "Runtime workspace: session threads, checkpoints, orchestrator state, reports, social drafts, content ideas, metrics."
 
 # {PRODUCT} collection
-qmd collection add ~/Documents/HQ/repos/private/{product} --name {product} --mask "**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,css,prisma}"
+qmd collection add $HQ_ROOT/repos/private/{product} --name {product} --mask "**/*.{ts,tsx,js,jsx,md,json,yaml,yml,sql,css,prisma}"
 qmd context add qmd://{product} "{PRODUCT} monorepo: Nx monorepo for {Product}/{Product}. Apps (web-admin, web-client, web-front, function, {company}, cdp) + libs (core, db, ui, web, util, schema). Next.js, React 19, TypeScript, SST, Prisma, PostgreSQL."
 qmd context add qmd://{product}/apps "Application code: Next.js web apps, AWS Lambda functions, {Product} SMS platform, CDP."
 qmd context add qmd://{product}/libs "Shared libraries: db/Prisma schemas, core feature modules (auth, billing, brand, conversation, ai, workflow), UI components, utilities."
@@ -100,7 +100,7 @@ qmd context add qmd://{product}/libs "Shared libraries: db/Prisma schemas, core 
 # Company collections (one per company knowledge base)
 # Add each company slug from companies/manifest.yaml:
 for co in personal {your-company-1} {your-company-2}; do
-  qmd collection add ~/Documents/HQ/companies/$co/knowledge --name $co --mask "**/*.md"
+  qmd collection add $HQ_ROOT/companies/$co/knowledge --name $co --mask "**/*.md"
   qmd context add qmd://$co "$co company knowledge base"
 done
 

--- a/template/.claude/commands/search.md
+++ b/template/.claude/commands/search.md
@@ -85,11 +85,11 @@ If `--full` flag, after listing results, read top result file with Read tool.
 If qmd errors or isn't installed:
 
 ```bash
-grep -rl "$QUERY" ~/Documents/HQ/knowledge/ \
-  ~/Documents/HQ/companies/ \
-  ~/Documents/HQ/workers/ \
-  ~/Documents/HQ/.claude/commands/ \
-  ~/Documents/HQ/workspace/ 2>/dev/null | head -20
+grep -rl "$QUERY" ${HQ_ROOT:-$HOME/hq}/knowledge/ \
+  ${HQ_ROOT:-$HOME/hq}/companies/ \
+  ${HQ_ROOT:-$HOME/hq}/workers/ \
+  ${HQ_ROOT:-$HOME/hq}/.claude/commands/ \
+  ${HQ_ROOT:-$HOME/hq}/workspace/ 2>/dev/null | head -20
 ```
 
 Display: "qmd unavailable, falling back to grep"

--- a/template/.claude/hooks/auto-checkpoint-trigger.sh
+++ b/template/.claude/hooks/auto-checkpoint-trigger.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-HQ="~/Documents/HQ"
+HQ="${HQ_ROOT:-$HOME/hq}"
 INPUT=$(cat)
 
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')

--- a/template/.claude/hooks/observe-patterns.sh
+++ b/template/.claude/hooks/observe-patterns.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-HQ="~/Documents/HQ"
+HQ="${HQ_ROOT:-$HOME/hq}"
 INPUT=$(cat)
 
 # Ensure learnings directory exists

--- a/template/.claude/hooks/screenshot-resize-trigger.sh
+++ b/template/.claude/hooks/screenshot-resize-trigger.sh
@@ -5,7 +5,7 @@
 
 set -euo pipefail
 
-HQ="~/Documents/HQ"
+HQ="${HQ_ROOT:-$HOME/hq}"
 RESIZE="$HQ/scripts/resize-screenshot.sh"
 COUNT_FILE="/tmp/hq-screenshot-count-${PPID}"
 WARN_THRESHOLD=30

--- a/template/.claude/policies/hook-macos-case-paths.md
+++ b/template/.claude/policies/hook-macos-case-paths.md
@@ -14,7 +14,7 @@ source: debugging
 
 When writing bash hooks that compare file paths (e.g. checking if a path is inside `repos/`), always use case-insensitive matching or pattern-based checks (e.g. `*/repos/private/*`) instead of prefix matching against a hardcoded `HQ_ROOT`.
 
-macOS is case-insensitive but `pwd` may return a different casing than the hardcoded path. Example: `pwd` returns `~/Documents/hq` but `HQ_ROOT` is set to `~/Documents/HQ` — string comparison fails silently.
+macOS is case-insensitive but `pwd` may return a different casing than the hardcoded path. Example: `pwd` returns `~/Documents/hq` but `HQ_ROOT` is set to `$HOME/hq` — string comparison fails silently.
 
 **Safe pattern:** lowercase both sides with `tr '[:upper:]' '[:lower:]'` before comparing, or match on a case-stable segment like `*/repos/private/*`.
 

--- a/template/.claude/scripts/run-project.sh
+++ b/template/.claude/scripts/run-project.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 #   --tmux              Launch in tmux session with Remote Control
 # =============================================================================
 
-HQ_ROOT="~/Documents/HQ"
+HQ_ROOT="${HQ_ROOT:-$HOME/hq}"
 export PATH="/opt/homebrew/bin:$HOME/.bun/bin:$HOME/.cargo/bin:$HOME/.local/bin:$PATH"
 ORCH_DIR="$HQ_ROOT/workspace/orchestrator"
 REGRESSION_INTERVAL=3

--- a/template/.claude/skills/execute-task/SKILL.md
+++ b/template/.claude/skills/execute-task/SKILL.md
@@ -754,7 +754,7 @@ After task completion (or failure), write a thread checkpoint file:
   "type": "auto-checkpoint",
   "created_at": "{ISO8601}",
   "updated_at": "{ISO8601}",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "{current working directory}",
   "git": {
     "branch": "{current branch from git branch --show-current}",

--- a/template/.claude/skills/handoff/SKILL.md
+++ b/template/.claude/skills/handoff/SKILL.md
@@ -34,7 +34,7 @@ Check `workspace/threads/` for a recent thread file. If none exists, write a bas
   "type": "handoff",
   "created_at": "ISO8601",
   "updated_at": "ISO8601",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "current/working/dir",
   "git": {
     "branch": "current-branch",
@@ -74,7 +74,7 @@ done
 ### 3b. Commit HQ Changes
 
 ```bash
-cd ~/Documents/HQ
+cd ${HQ_ROOT:-$HOME/hq}
 if [ -n "$(git status --porcelain)" ]; then
   git add -A
   git commit -m "checkpoint: auto-commit before handoff"

--- a/template/.claude/skills/run-project/SKILL.md
+++ b/template/.claude/skills/run-project/SKILL.md
@@ -36,7 +36,7 @@ If no arguments: error — project name required.
 ## Step 3 — Launch Background
 
 ```bash
-cd ~/Documents/HQ && \
+cd ${HQ_ROOT:-$HOME/hq} && \
   nohup bash scripts/run-project.sh {project} {passthrough_flags} --no-permissions \
   > workspace/orchestrator/{project}/run.log 2>&1 &
 echo "PID:$!"

--- a/template/.claude/skills/run/SKILL.md
+++ b/template/.claude/skills/run/SKILL.md
@@ -194,7 +194,7 @@ After skill completion, write a thread checkpoint file:
   "type": "auto-checkpoint",
   "created_at": "{ISO8601}",
   "updated_at": "{ISO8601}",
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "{current working directory}",
   "git": {
     "branch": "{current branch from git branch --show-current}",

--- a/template/.claude/skills/search/SKILL.md
+++ b/template/.claude/skills/search/SKILL.md
@@ -100,11 +100,11 @@ Display: "qmd unavailable, falling back to Grep"
 
 If Grep is also unavailable, run:
 ```bash
-grep -rl "$QUERY" ~/Documents/HQ/knowledge/ \
-  ~/Documents/HQ/companies/ \
-  ~/Documents/HQ/workers/ \
-  ~/Documents/HQ/.claude/commands/ \
-  ~/Documents/HQ/workspace/ 2>/dev/null | head -20
+grep -rl "$QUERY" ${HQ_ROOT:-$HOME/hq}/knowledge/ \
+  ${HQ_ROOT:-$HOME/hq}/companies/ \
+  ${HQ_ROOT:-$HOME/hq}/workers/ \
+  ${HQ_ROOT:-$HOME/hq}/.claude/commands/ \
+  ${HQ_ROOT:-$HOME/hq}/workspace/ 2>/dev/null | head -20
 ```
 
 ## Examples

--- a/template/MIGRATION.md
+++ b/template/MIGRATION.md
@@ -1310,7 +1310,7 @@ Copy these directories to your `knowledge/`:
 go install github.com/tobi/qmd@latest
 
 # Index your HQ
-cd ~/Documents/HQ
+cd $HQ_ROOT
 qmd update && qmd embed
 ```
 

--- a/template/knowledge/gemini-cli/patterns.md
+++ b/template/knowledge/gemini-cli/patterns.md
@@ -3,7 +3,7 @@
 ## Loading API Key
 
 ```bash
-KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
 ```
 
 ## One-Shot Generation

--- a/template/knowledge/hq-core/thread-schema.md
+++ b/template/knowledge/hq-core/thread-schema.md
@@ -30,7 +30,7 @@ Example: `T-20260123-143052-mrr-report`
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:35:00.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {
@@ -80,7 +80,7 @@ Auto-checkpoints are created automatically by PostToolUse hooks after git commit
   "created_at": "2026-01-23T14:30:52.000Z",
   "updated_at": "2026-01-23T14:30:52.000Z",
 
-  "workspace_root": "~/Documents/HQ",
+  "workspace_root": "$HQ_ROOT",
   "cwd": "repos/private/{company}",
 
   "git": {

--- a/template/workers/gemini-designer/skills/design-audit.md
+++ b/template/workers/gemini-designer/skills/design-audit.md
@@ -20,7 +20,7 @@ Optional:
 
 2. **Pipe to Gemini for Audit**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find {scope:-src/components} -name "*.tsx" -o -name "*.css" | head -50 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Comprehensive design audit. Evaluate these dimensions:
 

--- a/template/workers/gemini-designer/skills/design-system-check.md
+++ b/template/workers/gemini-designer/skills/design-system-check.md
@@ -23,7 +23,7 @@ Optional:
 
 3. **Check Consistency via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat .impeccable.md tailwind.config.* 2>/dev/null && find {scope:-src/components} -name "*.tsx" | head -40 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Design system consistency check. Compare every component against the design system.
 

--- a/template/workers/gemini-designer/skills/design-tokens.md
+++ b/template/workers/gemini-designer/skills/design-tokens.md
@@ -18,7 +18,7 @@ Optional:
 
 2. **Extract via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat tailwind.config.* src/styles/*.{css,ts} 2>/dev/null && find src/components -name "*.tsx" | head -30 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Extract all design tokens from this codebase. Identify:
 

--- a/template/workers/gemini-designer/skills/visual-diff.md
+++ b/template/workers/gemini-designer/skills/visual-diff.md
@@ -18,7 +18,7 @@ Optional:
 
 2. **Compare via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {file1} {file2} {design_tokens} | GEMINI_API_KEY=$KEY \
      gemini -p "Visual diff analysis. Compare these two components for inconsistencies:
 

--- a/template/workers/gemini-stylist/skills/add-animation.md
+++ b/template/workers/gemini-stylist/skills/add-animation.md
@@ -20,7 +20,7 @@ Optional:
 
 2. **Generate Animation via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {file} package.json | GEMINI_API_KEY=$KEY \
      gemini -p "Add a {type} animation to this component using {framework}.
 

--- a/template/workers/gemini-stylist/skills/css-refactor.md
+++ b/template/workers/gemini-stylist/skills/css-refactor.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Refactor via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {files} | GEMINI_API_KEY=$KEY \
      gemini -p "CSS refactor. Goals: {goals:-reduce duplication, modernize patterns}.
 

--- a/template/workers/gemini-stylist/skills/dark-mode.md
+++ b/template/workers/gemini-stylist/skills/dark-mode.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Generate Dark Mode via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {files} tailwind.config.* src/styles/globals.css 2>/dev/null | GEMINI_API_KEY=$KEY \
      gemini -p "Add dark mode support using {strategy}.
 

--- a/template/workers/gemini-stylist/skills/responsive-polish.md
+++ b/template/workers/gemini-stylist/skills/responsive-polish.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Analyze via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && cat {files} tailwind.config.* 2>/dev/null | GEMINI_API_KEY=$KEY \
      gemini -p "Responsive analysis and fix. Check each breakpoint ({breakpoints}):
 

--- a/template/workers/gemini-ux-auditor/skills/competitive-scan.md
+++ b/template/workers/gemini-ux-auditor/skills/competitive-scan.md
@@ -18,7 +18,7 @@ Optional:
 
 2. **Analyze via Gemini (with Google Search grounding)**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find src/app src/components -name "*.tsx" 2>/dev/null | head -30 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Competitive UX analysis for: {product}.
 

--- a/template/workers/gemini-ux-auditor/skills/copy-review.md
+++ b/template/workers/gemini-ux-auditor/skills/copy-review.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Review via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find {scope:-src} -name "*.tsx" | head -40 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "Microcopy review. Focus: {focus}. Target tone: {tone:-professional}.
 

--- a/template/workers/gemini-ux-auditor/skills/flow-review.md
+++ b/template/workers/gemini-ux-auditor/skills/flow-review.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Analyze via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find src -name "*.tsx" | xargs grep -l "{flow}" | head -20 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "User flow analysis for the {flow} flow. Persona: {persona:-general user}.
 

--- a/template/workers/gemini-ux-auditor/skills/ux-audit.md
+++ b/template/workers/gemini-ux-auditor/skills/ux-audit.md
@@ -19,7 +19,7 @@ Optional:
 
 2. **Evaluate via Gemini**
    ```bash
-   KEY=$(grep GEMINI_API_KEY ~/Documents/HQ/settings/gemini/credentials.env | cut -d= -f2)
+   KEY=$(grep GEMINI_API_KEY ${HQ_ROOT:-$HOME/hq}/settings/gemini/credentials.env | cut -d= -f2)
    cd {cwd} && find src/app src/components src/pages -name "*.tsx" 2>/dev/null | head -50 | xargs cat | GEMINI_API_KEY=$KEY \
      gemini -p "UX heuristic evaluation. Apply Nielsen's 10 usability heuristics:
 

--- a/template/workers/public/sample-worker/worker.yaml
+++ b/template/workers/public/sample-worker/worker.yaml
@@ -54,7 +54,7 @@ An orchestrator needs to execute the `generate-report` skill on a Node.js projec
     "include_charts": true,
     "output_path": "workspace/reports/q1-performance.md"
   },
-  "cwd": "~/Documents/HQ",
+  "cwd": "$HQ_ROOT",
   "files_context": [
     "workspace/data/q1-metrics.json",
     "knowledge/public/analytics/reporting-style.md"

--- a/template/workers/sample-worker/worker.yaml
+++ b/template/workers/sample-worker/worker.yaml
@@ -54,7 +54,7 @@ An orchestrator needs to execute the `generate-report` skill on a Node.js projec
     "include_charts": true,
     "output_path": "workspace/reports/q1-performance.md"
   },
-  "cwd": "~/Documents/HQ",
+  "cwd": "$HQ_ROOT",
   "files_context": [
     "workspace/data/q1-metrics.json",
     "knowledge/public/analytics/reporting-style.md"


### PR DESCRIPTION
## Summary
Replaces all 59 prescriptive instances of `~/Documents/HQ` across 35 template files with the correct dynamic path:

- **Shell scripts** (`.sh`): `${HQ_ROOT:-$HOME/hq}`
- **Shell in markdown**: `${HQ_ROOT:-$HOME/hq}` or `$HQ_ROOT`
- **JSON examples**: `$HQ_ROOT`
- **Documentation refs**: `$HQ_ROOT`

### What's NOT changed (intentionally)
6 Desktop documentation files that describe Desktop's *current hardcoded behavior* are left as-is:
- `knowledge/hq-core/hq-structure-detection.md` (16 instances)
- `knowledge/hq-core/hq-desktop/*.md` (3 files)
- `knowledge/hq-core/starter-kit-compatibility-contract.md`
- `knowledge/hq-core/desktop-claude-code-integration.md`

These should be updated when Desktop itself moves off hardcoded paths.

### Relation to other PRs
- Supersedes the path-fix portion of #42 (context meter portion is now #63)
- #42 and #48 can both be closed after this and #63 merge

## Test plan
- [x] `grep -r '~/Documents/HQ' template/` returns only Desktop documentation files
- [ ] `npm run build` passes
- [ ] Hooks run correctly with `HQ_ROOT` unset (falls back to `$HOME/hq`)
- [ ] Hooks run correctly with `HQ_ROOT` set to custom path

🤖 Generated with [Claude Code](https://claude.com/claude-code)