### PR TITLE
feat(create-hq): graft team into existing HQ + manifest registration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20990,7 +20990,7 @@
       }
     },
     "packages/create-hq": {
-      "version": "10.9.0",
+      "version": "10.10.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/packages/create-hq/package.json
+++ b/packages/create-hq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-hq",
-  "version": "10.9.0",
+  "version": "10.10.0",
   "description": "Create a new HQ by Indigo — Personal OS for AI Workers",
   "bin": {
     "create-hq": "./dist/index.js"

--- a/packages/create-hq/src/admin-onboarding.ts
+++ b/packages/create-hq/src/admin-onboarding.ts
@@ -2,14 +2,15 @@
  * Admin onboarding flow — for users creating a brand new HQ team.
  *
  * Steps:
- *   1. List user's GitHub orgs (only those where they can create repos)
- *   2. Let user pick an existing org or create a new one (browser hand-off)
- *   3. Verify the HQ App is installed on the chosen org (browser hand-off if not)
- *   4. Prompt for team name (default = org display name)
- *   5. Create the {org}/hq private repo
- *   6. Seed the repo locally with the company template + push
- *   7. Clone the repo into companies/{slug}/ as a nested git
- *   8. Return team metadata for the orientation summary
+ *   1. Ensure a `gh` CLI token for org discovery (prompt login if needed)
+ *   2. List ALL user's GitHub orgs via gh token (full visibility)
+ *   3. Let user pick an existing org or create a new one (browser hand-off)
+ *   4. Verify the HQ App is installed on the chosen org (browser hand-off if not)
+ *   5. Prompt for team name (default = org display name)
+ *   6. Create the {org}/hq private repo
+ *   7. Seed the repo locally with the company template + push
+ *   8. Clone the repo into companies/{slug}/ as a nested git
+ *   9. Return team metadata for the orientation summary
  */
 
 import * as fs from "fs";
@@ -24,6 +25,9 @@ import {
   HQ_GITHUB_APP_SLUG,
   githubApi,
   openBrowser,
+  getGhCliToken,
+  fetchAdminOrgsWithToken,
+  startGitHubDeviceFlow,
 } from "./auth.js";
 import { writeCompanyTemplate, type TeamMetadata } from "./company-template.js";
 import { stepStatus, success, warn, info } from "./ui.js";
@@ -39,16 +43,6 @@ import {
 } from "./invite.js";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
-
-interface GitHubOrgMembership {
-  state: string;
-  role: string;
-  organization: {
-    login: string;
-    id: number;
-    avatar_url?: string;
-  };
-}
 
 interface GitHubOrg {
   login: string;
@@ -109,30 +103,60 @@ function pause(message: string): Promise<void> {
 // ─── GitHub helpers ─────────────────────────────────────────────────────────
 
 /**
- * Fetch the orgs the user is an active admin of. Uses
- * /user/memberships/orgs which (unlike /user/orgs) tells us our role.
+ * Ensure we have a `gh` CLI token for org discovery.
  *
- * Requires the App's "Organization > Members: Read" permission. If the App
- * isn't permitted, this returns an empty array (and we tell the user to
- * check their App permissions).
+ * The GitHub App user-to-server token can only see orgs where the App is
+ * already installed — a chicken-and-egg problem when the user wants to pick
+ * an org to install the App on. The `gh` CLI token (OAuth with `read:org`)
+ * sees ALL the user's orgs regardless of App installations.
+ *
+ * Flow:
+ *   1. Try `gh auth token` — if it works, we're done
+ *   2. If `gh` isn't installed or not logged in, prompt the user to log in
+ *   3. Retry after they confirm — if still no token, return null (caller
+ *      will guide user to create an org or abort)
  */
-async function fetchAdminOrgs(auth: GitHubAuth): Promise<GitHubOrg[]> {
-  try {
-    const memberships = await githubApi<GitHubOrgMembership[]>(
-      "/user/memberships/orgs?state=active&per_page=100",
-      auth
-    );
-    return memberships
-      .filter((m) => m.role === "admin")
-      .map((m) => ({
-        login: m.organization.login,
-        id: m.organization.id,
-      }));
-  } catch (err) {
-    // Permission errors come back as 403/404 — surface as empty list, the
-    // caller will guide the user to fix App permissions or create an org.
-    return [];
-  }
+async function ensureGhToken(): Promise<string | null> {
+  const existing = getGhCliToken();
+  if (existing) return existing;
+
+  // gh not available or not logged in — guide the user
+  console.log();
+  info("HQ needs access to your GitHub organizations to continue.");
+  info("The fastest way is to sign into the GitHub CLI:");
+  console.log();
+  console.log(chalk.cyan("    gh auth login"));
+  console.log();
+
+  await pause("Run that command in another terminal, then press Enter...");
+
+  // Retry after user says they logged in
+  const token = getGhCliToken();
+  if (token) return token;
+
+  // Still no luck — one more attempt with installation help
+  console.log();
+  info("Still can't detect a GitHub CLI session.");
+  info("If you don't have the GitHub CLI installed:");
+  console.log(chalk.cyan("    https://cli.github.com"));
+  console.log();
+
+  const retry = await prompt("Try again after installing/logging in? (Y/n)", "y");
+  if (!retry.toLowerCase().startsWith("y")) return null;
+
+  await pause("Press Enter when ready...");
+  return getGhCliToken();
+}
+
+/**
+ * Fetch the orgs the user is an active admin of, using their `gh` CLI token.
+ *
+ * Always uses a user-scoped token (from `gh auth token`) so we see ALL
+ * the user's orgs — not just orgs where the HQ App is installed.
+ * Returns an empty array if the token is unavailable or the user has no orgs.
+ */
+async function fetchAdminOrgs(ghToken: string): Promise<GitHubOrg[]> {
+  return fetchAdminOrgsWithToken(ghToken);
 }
 
 async function fetchInstallations(auth: GitHubAuth): Promise<GitHubInstallation[]> {
@@ -269,12 +293,13 @@ export function slugify(input: string): string {
 /**
  * Run the admin onboarding flow.
  *
- * @param auth          - Authenticated GitHub user
+ * @param preAuth       - Pre-existing App auth (from "existing" path), or null
+ *                        if coming from the "new" path (auth deferred until after org selection)
  * @param hqRoot        - Local HQ root directory (where companies/ lives)
  * @param hqVersion     - HQ template version (for team metadata)
  */
 export async function runAdminOnboarding(
-  auth: GitHubAuth,
+  preAuth: GitHubAuth | null,
   hqRoot: string,
   hqVersion: string
 ): Promise<AdminOnboardingResult | null> {
@@ -282,13 +307,22 @@ export async function runAdminOnboarding(
   console.log(chalk.bold("  Create a new HQ team"));
   console.log();
 
-  // 1. Fetch admin orgs
+  // 1. Get a gh CLI token for org discovery (sees ALL user's orgs)
+  const ghToken = await ensureGhToken();
+  if (!ghToken) {
+    warn("GitHub CLI is needed to list your organizations.");
+    info("Install it from " + chalk.cyan("https://cli.github.com") + " then run " + chalk.cyan("gh auth login"));
+    info("After that, run create-hq again.");
+    return null;
+  }
+
+  // 2. Fetch admin orgs using the gh token
   const orgsLabel = "Looking up your GitHub organizations";
   stepStatus(orgsLabel, "running");
-  let orgs = await fetchAdminOrgs(auth);
+  let orgs = await fetchAdminOrgs(ghToken);
   stepStatus(orgsLabel, "done");
 
-  // 2. Pick or create org
+  // 3. Pick or create org
   let chosenOrg: GitHubOrg | null = null;
   while (!chosenOrg) {
     if (orgs.length === 0) {
@@ -305,7 +339,7 @@ export async function runAdminOnboarding(
       await pause("Press Enter when you have finished creating the org...");
 
       stepStatus("Re-checking organizations", "running");
-      orgs = await fetchAdminOrgs(auth);
+      orgs = await fetchAdminOrgs(ghToken);
       stepStatus("Re-checking organizations", "done");
       continue;
     }
@@ -331,7 +365,7 @@ export async function runAdminOnboarding(
       openBrowser("https://github.com/organizations/new");
       await pause("Press Enter when you have finished creating the org...");
       stepStatus("Re-checking organizations", "running");
-      orgs = await fetchAdminOrgs(auth);
+      orgs = await fetchAdminOrgs(ghToken);
       stepStatus("Re-checking organizations", "done");
       continue;
     }
@@ -344,7 +378,24 @@ export async function runAdminOnboarding(
     chosenOrg = orgs[idx];
   }
 
-  // 3. Verify HQ App is installed on the org
+  // 4. Authenticate with the HQ App (deferred until after org selection)
+  //    The App token is needed for installation checks and repo management.
+  //    By deferring, we avoid the chicken-and-egg: user sees all orgs first
+  //    (via gh token), picks one, THEN authorizes the App for that org.
+  let auth = preAuth;
+  if (!auth) {
+    console.log();
+    info(`Now authorize the HQ App to manage repos in ${chalk.cyan(chosenOrg.login)}.`);
+    try {
+      auth = await startGitHubDeviceFlow();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      warn(`GitHub App authorization failed: ${message}`);
+      return null;
+    }
+  }
+
+  // 5. Verify HQ App is installed on the chosen org
   let installation: GitHubInstallation | null = null;
   while (!installation) {
     const installLabel = `Checking HQ App on ${chosenOrg.login}`;
@@ -363,17 +414,22 @@ export async function runAdminOnboarding(
     info("Installing it gives HQ permission to manage the team workspace repo.");
     console.log();
 
-    const installUrl = `https://github.com/apps/${HQ_GITHUB_APP_SLUG}/installations/new/permissions?target_id=${chosenOrg.id}`;
-    const proceed = await prompt("Open the install page in your browser? (Y/n)", "y");
-    if (!proceed.toLowerCase().startsWith("y")) {
-      warn("HQ App is required to create a team. Aborting team creation.");
-      return null;
+    console.log();
+    info("We'll open the HQ App install page.");
+    info(chalk.bold(`Select "${chosenOrg.login}" from the list of organizations.`));
+    console.log();
+
+    const openIt = await prompt("Open the install page now? (Y/n)", "y");
+    if (openIt.toLowerCase().startsWith("y")) {
+      // /installations/select_target always shows the org picker, even when
+      // the App is already installed on a different org (unlike /installations/new
+      // which redirects to the existing installation's config page).
+      openBrowser(`https://github.com/apps/${HQ_GITHUB_APP_SLUG}/installations/select_target`);
     }
-    openBrowser(installUrl);
     await pause("Press Enter when the App has been installed...");
   }
 
-  // 4. Prompt for team name
+  // 6. Prompt for team name
   console.log();
   const defaultName = chosenOrg.login;
   const teamName = (await prompt("Team name", defaultName)) || defaultName;
@@ -391,7 +447,7 @@ export async function runAdminOnboarding(
     hq_version: hqVersion,
   };
 
-  // 5. Create the {org}/hq-{teamSlug} repo
+  // 7. Create the {org}/hq-{teamSlug} repo
   const repoName = `hq-${teamSlug}`;
   const repoLabel = `Creating ${chosenOrg.login}/${repoName} private repo`;
   stepStatus(repoLabel, "running");
@@ -430,7 +486,7 @@ export async function runAdminOnboarding(
     }
   }
 
-  // 6. Seed locally and push
+  // 8. Seed locally and push
   const seedLabel = "Seeding team workspace";
   stepStatus(seedLabel, "running");
 
@@ -473,7 +529,7 @@ export async function runAdminOnboarding(
     }
   }
 
-  // 7. Clone into companies/{slug}/
+  // 9. Clone into companies/{slug}/
   const companiesDir = path.join(hqRoot, "companies");
   if (!fs.existsSync(companiesDir)) {
     fs.mkdirSync(companiesDir, { recursive: true });
@@ -535,7 +591,7 @@ export async function runAdminOnboarding(
   console.log();
   success(`Team "${teamName}" created — ${repo.html_url}`);
 
-  // 8. Offer to generate member invites
+  // 10. Offer to generate member invites
   await inviteLoop(auth, meta, repo.clone_url);
 
   return {

--- a/packages/create-hq/src/auth.ts
+++ b/packages/create-hq/src/auth.ts
@@ -21,7 +21,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { exec } from "child_process";
+import { exec, execSync } from "child_process";
 import chalk from "chalk";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
@@ -373,6 +373,75 @@ export async function startGitHubDeviceFlow(): Promise<GitHubAuth> {
   }
 
   throw new Error("GitHub device flow timed out — please try again");
+}
+
+// ─── gh CLI token (opportunistic) ──────────────────────────────────────────
+
+/**
+ * Try to get the user's `gh` CLI OAuth token.
+ *
+ * Returns the token string if `gh` is installed, the user is logged in, and
+ * `gh auth token` succeeds. Returns null otherwise — this is purely
+ * opportunistic and never throws.
+ *
+ * The gh CLI token typically has `read:org` scope, which lets us enumerate
+ * ALL the user's org memberships — not just orgs where our GitHub App is
+ * installed. This gives us a better org picker during admin onboarding.
+ */
+export function getGhCliToken(): string | null {
+  try {
+    const token = execSync("gh auth token", {
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5_000,
+    })
+      .toString()
+      .trim();
+    // Sanity check — gh tokens start with gho_ or ghp_ (OAuth / PAT)
+    if (token && token.length > 10) return token;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch orgs where the user is an admin, using a raw bearer token.
+ *
+ * Works with both gh CLI tokens (PAT/OAuth) and GitHub App user tokens.
+ * The difference: a gh CLI token with `read:org` scope sees ALL orgs,
+ * while an App token only sees orgs where the App is installed.
+ *
+ * Returns an empty array on any error (permissions, network, etc.).
+ */
+export async function fetchAdminOrgsWithToken(
+  token: string
+): Promise<{ login: string; id: number }[]> {
+  try {
+    const res = await fetch(
+      "https://api.github.com/user/memberships/orgs?state=active&per_page=100",
+      {
+        headers: {
+          Authorization: `token ${token}`,
+          Accept: "application/vnd.github+json",
+          "User-Agent": "create-hq",
+        },
+        signal: AbortSignal.timeout(15_000),
+      }
+    );
+    if (!res.ok) return [];
+    const memberships = (await res.json()) as Array<{
+      role: string;
+      organization: { login: string; id: number };
+    }>;
+    return memberships
+      .filter((m) => m.role === "admin")
+      .map((m) => ({
+        login: m.organization.login,
+        id: m.organization.id,
+      }));
+  } catch {
+    return [];
+  }
 }
 
 // ─── GitHub API helpers used by downstream flows ────────────────────────────

--- a/packages/create-hq/src/join-flow.ts
+++ b/packages/create-hq/src/join-flow.ts
@@ -198,7 +198,18 @@ export async function runJoinByInvite(
   const companyDir = path.join(companiesDir, payload.slug);
 
   if (fs.existsSync(companyDir) && fs.readdirSync(companyDir).length > 0) {
-    info(`companies/${payload.slug}/ already exists — skipping clone.`);
+    // Company directory already exists — just ensure the git remote is set
+    // so the user can sync later from within Claude. Don't clone over their files.
+    const remoteLabel = `Configuring remote for existing companies/${payload.slug}`;
+    stepStatus(remoteLabel, "running");
+    try {
+      ensureGitRemote(companyDir, payload.cloneUrl);
+      stepStatus(remoteLabel, "done");
+      info(`companies/${payload.slug}/ already exists — configured git remote (sync later with /team-sync)`);
+    } catch {
+      stepStatus(remoteLabel, "done");
+      info(`companies/${payload.slug}/ already exists — remote already configured`);
+    }
   } else {
     const cloneLabel = `Cloning ${payload.teamName} into companies/${payload.slug}`;
     stepStatus(cloneLabel, "running");
@@ -234,6 +245,9 @@ export async function runJoinByInvite(
     }
   }
 
+  // Register the company in manifest.yaml so HQ routing (search, /startwork, workers) can find it
+  registerInManifest(hqRoot, payload);
+
   // Install bundled team commands (invite, sync, promote)
   const installed = installTeamCommands(hqRoot);
   if (installed.length > 0) {
@@ -257,4 +271,112 @@ export async function runJoinByInvite(
     companyDir,
     repoUrl,
   };
+}
+
+// ─── Manifest registration ─────────────────────────────────────────────────
+
+/**
+ * Register a joined team in companies/manifest.yaml so HQ's routing system
+ * (search scoping, /startwork, workers, /run-project) can discover it.
+ *
+ * Appends a minimal entry if the slug isn't already present. Uses string
+ * manipulation to avoid adding a YAML parser dependency to create-hq.
+ */
+function registerInManifest(hqRoot: string, payload: InvitePayload): void {
+  const manifestPath = path.join(hqRoot, "companies", "manifest.yaml");
+
+  // If manifest doesn't exist yet (fresh HQ), create a minimal one
+  if (!fs.existsSync(manifestPath)) {
+    const initial = [
+      "# Companies Manifest",
+      '# Maps each company to its repos, workers, knowledge, deploy targets, and infrastructure.',
+      "",
+      'version: "1.1"',
+      `updated: "${new Date().toISOString().slice(0, 10)}"`,
+      "",
+      "companies:",
+      ...formatManifestEntry(payload),
+      "",
+    ].join("\n");
+    fs.writeFileSync(manifestPath, initial, "utf-8");
+    return;
+  }
+
+  // Check if slug is already registered
+  const existing = fs.readFileSync(manifestPath, "utf-8");
+  const slugPattern = new RegExp(`^  ${escapeRegex(payload.slug)}:`, "m");
+  if (slugPattern.test(existing)) {
+    return; // Already in manifest
+  }
+
+  // Append the new entry at the end of the companies block
+  const entry = formatManifestEntry(payload).join("\n");
+  const updated = existing.trimEnd() + "\n\n" + entry + "\n";
+  fs.writeFileSync(updated.includes("updated:") ? manifestPath : manifestPath, updated, "utf-8");
+
+  // Update the "updated" date
+  const dateUpdated = updated.replace(
+    /^updated: ".*"$/m,
+    `updated: "${new Date().toISOString().slice(0, 10)}"`
+  );
+  fs.writeFileSync(manifestPath, dateUpdated, "utf-8");
+}
+
+function formatManifestEntry(payload: InvitePayload): string[] {
+  return [
+    `  ${payload.slug}:`,
+    `    github_org: ${payload.org}`,
+    `    repos: []`,
+    `    settings: []`,
+    `    workers: []`,
+    `    knowledge: companies/${payload.slug}/knowledge/`,
+    `    deploy: []`,
+    `    vercel_projects: []`,
+    `    qmd_collections:`,
+    `      - ${payload.slug}`,
+    `    services: []`,
+  ];
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ─── Git remote helper ─────────────────────────────────────────────────────
+
+/**
+ * Ensure an existing directory has a git remote pointing to the team repo.
+ * If it's not a git repo, initializes one. If 'origin' exists with a different
+ * URL, adds 'team' as the remote name instead.
+ */
+function ensureGitRemote(dir: string, cloneUrl: string): void {
+  // Initialize git if not already a repo
+  const gitDir = path.join(dir, ".git");
+  if (!fs.existsSync(gitDir)) {
+    execSync("git init", { cwd: dir, stdio: "pipe" });
+  }
+
+  // Check existing remotes
+  let existingOrigin: string | null = null;
+  try {
+    existingOrigin = execSync("git remote get-url origin", { cwd: dir, stdio: "pipe" })
+      .toString()
+      .trim();
+  } catch {
+    // No origin remote
+  }
+
+  if (!existingOrigin) {
+    // No origin — add it
+    execSync(`git remote add origin "${cloneUrl}"`, { cwd: dir, stdio: "pipe" });
+  } else if (existingOrigin !== cloneUrl) {
+    // Origin exists but points elsewhere — add as 'team' remote
+    try {
+      execSync(`git remote add team "${cloneUrl}"`, { cwd: dir, stdio: "pipe" });
+    } catch {
+      // 'team' remote might already exist
+      execSync(`git remote set-url team "${cloneUrl}"`, { cwd: dir, stdio: "pipe" });
+    }
+  }
+  // If origin already matches cloneUrl, nothing to do
 }

--- a/packages/create-hq/src/scaffold.ts
+++ b/packages/create-hq/src/scaffold.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as os from "os";
 import fs from "fs-extra";
 import { createInterface } from "readline";
 import { createRequire } from "node:module";
@@ -59,6 +60,57 @@ async function confirm(question: string, defaultYes = true): Promise<boolean> {
   return answer.toLowerCase().startsWith("y");
 }
 
+// ─── Existing HQ detection ─────────────────────────────────────────────────
+
+/**
+ * Check whether a directory is an existing HQ installation.
+ * Requires CLAUDE.md + .claude/ + companies/ — three markers to avoid false positives.
+ */
+function isExistingHQ(dir: string): boolean {
+  return (
+    fs.existsSync(path.join(dir, "CLAUDE.md")) &&
+    fs.existsSync(path.join(dir, ".claude")) &&
+    fs.existsSync(path.join(dir, "companies"))
+  );
+}
+
+/** Display path with ~ for home directory. */
+function friendlyPath(absPath: string): string {
+  const home = os.homedir();
+  if (absPath === home) return "~";
+  if (absPath.startsWith(home + path.sep)) {
+    return "~/" + path.relative(home, absPath);
+  }
+  return absPath;
+}
+
+/** Resolve ~/... to an absolute path. */
+function resolveTildePath(p: string): string {
+  if (p.startsWith("~/") || p === "~") {
+    return path.join(os.homedir(), p.slice(2));
+  }
+  return path.resolve(p);
+}
+
+/**
+ * Search common locations for an existing HQ installation.
+ * Priority: explicit CLI arg > $HQ_HOME > ~/hq
+ */
+function detectExistingHQ(cliDir?: string): string | null {
+  const candidates = [
+    cliDir ? path.resolve(cliDir) : null,
+    process.env.HQ_HOME ? path.resolve(process.env.HQ_HOME) : null,
+    path.join(os.homedir(), "hq"),
+  ].filter((c): c is string => c !== null);
+
+  for (const dir of candidates) {
+    if (fs.existsSync(dir) && isExistingHQ(dir)) {
+      return dir;
+    }
+  }
+  return null;
+}
+
 /**
  * Cascading entry-mode selection:
  *   1. HQ Teams account?      yes → teams-existing
@@ -104,9 +156,11 @@ export async function scaffold(
     process.exit(0);
   }
 
-  // 2. Authenticate immediately if teams (pure HTTP — no local deps needed)
+  // 2. Authenticate immediately for "existing" teams path (need App token for discovery).
+  //    For "new" teams path, defer auth — admin onboarding uses `gh` CLI for org
+  //    discovery first, then triggers App auth after org selection.
   let teamsAuth: GitHubAuth | null = null;
-  if (mode === "teams-existing" || mode === "teams-new") {
+  if (mode === "teams-existing") {
     teamsAuth = await authenticate();
     if (!teamsAuth) {
       console.log();
@@ -117,6 +171,61 @@ export async function scaffold(
         process.exit(0);
       }
       // Fall through to personal mode
+    }
+  }
+
+  // 2b. Graft detection — if we have an invite token, check for an existing HQ
+  //     before asking about directory. Grafting adds the team to the existing
+  //     HQ without re-scaffolding template, git init, etc.
+  if (inviteToken && teamsAuth) {
+    const autoDetected = detectExistingHQ(directory);
+
+    if (autoDetected) {
+      // Found an existing HQ automatically — offer to graft into it
+      const displayExisting = friendlyPath(autoDetected);
+
+      console.log();
+      info(`Detected existing HQ at ${chalk.cyan(displayExisting)}`);
+
+      const graftChoice = await prompt(
+        `Join team in existing HQ? ${chalk.dim("(Y = use existing / n = create new)")}`,
+        "Y"
+      );
+
+      if (graftChoice.toLowerCase() !== "n") {
+        return graftTeamIntoExistingHQ(autoDetected, displayExisting, teamsAuth, inviteToken);
+      }
+      // "n" — fall through to normal fresh scaffold
+    } else {
+      // No auto-detected HQ — ask the user if they already have one
+      console.log();
+      const hasExisting = await confirm(
+        chalk.bold("Do you already have an existing HQ installed?"),
+        false
+      );
+
+      if (hasExisting) {
+        const existingPath = await prompt(
+          "Where is your existing HQ?",
+          path.join(os.homedir(), "hq")
+        );
+        const resolvedPath = resolveTildePath(existingPath);
+
+        if (fs.existsSync(resolvedPath) && isExistingHQ(resolvedPath)) {
+          return graftTeamIntoExistingHQ(resolvedPath, friendlyPath(resolvedPath), teamsAuth, inviteToken);
+        }
+
+        // Directory exists but isn't an HQ, or doesn't exist
+        if (!fs.existsSync(resolvedPath)) {
+          warn(`Directory not found: ${existingPath}`);
+        } else {
+          warn(`That directory doesn't look like an HQ installation (missing CLAUDE.md or .claude/).`);
+        }
+        info("Setting up a fresh HQ instead...");
+        // Fall through to normal scaffold, pre-fill directory to their path
+        directory = existingPath;
+      }
+      // No existing HQ — fall through to normal fresh scaffold
     }
   }
 
@@ -280,14 +389,14 @@ export async function scaffold(
     success("Cloud sync already configured — skipping setup");
   }
 
-  // 8. Teams flow (only if auth succeeded earlier)
+  // 8. Teams flow (existing: only if auth succeeded; new: auth happens inside)
   let teamsResult: TeamsFlowResult | null = null;
-  if (teamsAuth && (mode === "teams-existing" || mode === "teams-new")) {
+  if ((mode === "teams-existing" && teamsAuth) || mode === "teams-new") {
     teamsResult = await runTeamsFlow(
       mode === "teams-existing" ? "existing" : "new",
       targetDir,
       hqVersion,
-      teamsAuth,
+      teamsAuth ?? undefined,
       inviteToken
     );
     if (!teamsResult) {
@@ -370,5 +479,79 @@ export async function scaffold(
     });
   } else {
     nextSteps(displayDir);
+  }
+}
+
+// ─── Graft path ────────────────────────────────────────────────────────────
+
+/**
+ * Add a team to an existing HQ installation without re-scaffolding.
+ *
+ * Skips: template fetch, git init, governance bootstrap, cloud sync, qmd full-index.
+ * Runs:  teams flow (join-by-invite) → manifest registration → orientation.
+ *
+ * This is the fast path for users who already have a working HQ and just need
+ * to accept a team invite. Takes ~5 seconds instead of ~30.
+ */
+async function graftTeamIntoExistingHQ(
+  hqRoot: string,
+  displayDir: string,
+  auth: GitHubAuth,
+  inviteToken: string
+): Promise<void> {
+  console.log();
+  step("Adding team to existing HQ (skipping scaffold)...");
+
+  const teamsResult = await runTeamsFlow(
+    "existing",
+    hqRoot,
+    "", // hqVersion not needed for graft — we're not seeding a new template
+    auth,
+    inviteToken
+  );
+
+  if (!teamsResult) {
+    console.log();
+    warn("Team setup did not complete — your existing HQ is unchanged.");
+    return;
+  }
+
+  // Index only the new company directory, not the entire HQ
+  if (teamsResult.joinedByInvite) {
+    const companyDir = teamsResult.joinedByInvite.companyDir;
+    const indexLabel = `Indexing companies/${teamsResult.joinedByInvite.slug}`;
+    stepStatus(indexLabel, "running");
+    try {
+      await execAsync(`qmd index "${companyDir}"`, { cwd: hqRoot });
+      stepStatus(indexLabel, "done");
+    } catch {
+      stepStatus(indexLabel, "failed");
+    }
+  }
+
+  // Orientation
+  console.log();
+  if (teamsResult.joinedByInvite) {
+    teamOrientation({
+      mode: "member",
+      displayDir,
+      teams: [{
+        name: teamsResult.joinedByInvite.teamName,
+        slug: teamsResult.joinedByInvite.slug,
+        repoUrl: teamsResult.joinedByInvite.repoUrl,
+      }],
+    });
+  } else if (teamsResult.member && teamsResult.member.joined.length > 0) {
+    teamOrientation({
+      mode: "member",
+      displayDir,
+      teams: teamsResult.member.joined.map((t) => ({
+        name: t.name,
+        slug: t.slug,
+        repoUrl: t.repoHtmlUrl,
+      })),
+    });
+  } else {
+    info("No teams were joined. Your existing HQ is unchanged.");
   }
 }

--- a/packages/create-hq/src/team-setup.ts
+++ b/packages/create-hq/src/team-setup.ts
@@ -13,9 +13,13 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { fileURLToPath } from "url";
 import { execSync } from "child_process";
 import { createInterface } from "readline";
 import chalk from "chalk";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 import {
   type GitHubAuth,
   HQ_GITHUB_APP_SLUG,

--- a/packages/create-hq/src/teams-flow.ts
+++ b/packages/create-hq/src/teams-flow.ts
@@ -133,12 +133,13 @@ export async function runTeamsFlow(
   preAuth?: GitHubAuth,
   joinToken?: string
 ): Promise<TeamsFlowResult | null> {
-  const auth = preAuth ?? await authenticate();
-  if (!auth) return null;
-
-  const result: TeamsFlowResult = { auth, member: null, admin: null, joinedByInvite: null };
-
   if (mode === "existing") {
+    // "existing" path requires App auth upfront for discovery + invite flows
+    const auth = preAuth ?? await authenticate();
+    if (!auth) return null;
+
+    const result: TeamsFlowResult = { auth, member: null, admin: null, joinedByInvite: null };
+
     // Check for a pre-supplied token (--join flag) or prompt for one
     let token = joinToken;
 
@@ -174,7 +175,7 @@ export async function runTeamsFlow(
     result.member = await runMemberJoin(auth, hqRoot);
 
     if (result.member === null) {
-      // No teams found at all
+      // No teams found at all — offer to create a team
       console.log();
       info("No HQ teams are linked to your GitHub account yet.");
       const create = await confirm(
@@ -182,6 +183,8 @@ export async function runTeamsFlow(
         false
       );
       if (create) {
+        // Admin onboarding handles its own auth sequence:
+        // gh CLI for org discovery → App device flow after org selection
         result.admin = await runAdminOnboarding(auth, hqRoot, hqVersion);
       }
     }
@@ -189,6 +192,18 @@ export async function runTeamsFlow(
   }
 
   // mode === "new"
-  result.admin = await runAdminOnboarding(auth, hqRoot, hqVersion);
+  // Admin onboarding handles its own auth sequence:
+  //   1. gh CLI token for org discovery (prompt gh auth login if needed)
+  //   2. User picks org
+  //   3. App device flow auth (for installations + repo management)
+  // This avoids the chicken-and-egg problem where the App token can only
+  // see orgs it's already installed on.
+  const result: TeamsFlowResult = { auth: null as unknown as GitHubAuth, member: null, admin: null, joinedByInvite: null };
+  result.admin = await runAdminOnboarding(null, hqRoot, hqVersion);
+  if (result.admin) {
+    // Admin onboarding completed — load the auth it persisted
+    const auth = loadGitHubAuth();
+    if (auth) result.auth = auth;
+  }
   return result;
 }


### PR DESCRIPTION
## Summary
- Detects existing HQ installations when accepting an invite (`~/hq`, `$HQ_HOME`, or user-provided path)
- Graft path: adds team to existing HQ without re-scaffolding (skips template fetch, git init, governance — ~5s vs ~30s)
- Registers joined teams in `manifest.yaml` after clone — fixes bug where HQ routing was blind to invite-joined companies
- If `companies/{slug}/` already exists, adds git remote only (sync deferred to Claude session)

## Changes
- `scaffold.ts`: `detectExistingHQ()`, `graftTeamIntoExistingHQ()`, existing-HQ prompt flow
- `join-flow.ts`: `registerInManifest()`, `ensureGitRemote()`, existing company dir handling
- `package.json`: bump to 10.10.0
- Includes prior session's org-discovery auth fixes (admin-onboarding, auth, team-setup, teams-flow)

## Test plan
- [ ] `npx create-hq --invite <token>` with existing `~/hq` → detects and offers graft
- [ ] Graft path joins team, registers in manifest, skips template
- [ ] Fresh install path unchanged when user says "n" to existing HQ
- [ ] `companies/{slug}/` shows in manifest after invite accept
- [ ] Existing company dir gets git remote added without clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)