### PR TITLE
feat(template): per-company people folder + agent guidance

### DIFF
--- a/template/.claude/CLAUDE.md
+++ b/template/.claude/CLAUDE.md
@@ -58,6 +58,10 @@ Top-level: `.claude/commands/`, `agents.md`, `companies/`, `knowledge/{public,pr
 
 Listed in `companies/manifest.yaml` (source of truth). Each is self-contained: `settings/` (creds), `data/` (exports), `knowledge/` (embedded git repo), `workers/` (company-scoped), `repos/` (symlinks to canonical clones), `projects/` (PRDs). Details: `knowledge/public/hq-core/quick-reference.md`
 
+## People
+
+Per-company contact records at `companies/{co}/people/{slug}/meta.yaml` (template: `companies/_template/people/_example/meta.yaml`). Whenever a person is mentioned (by name, email, or handle), check the active company's `people/` folder first — match against `name`, `email`, and any entry under `handles`. If no match, create a new `companies/{co}/people/{slug}/meta.yaml` from the template — minimally `name` + `type` (`internal` for HQ team members, `external` for clients/vendors/partners; external entries also set `relationship` and `organization`). Append new observations to `notes[]` rather than overwriting existing fields.
+
 ## Company Isolation
 
 Manifest: `companies/manifest.yaml` — maps companies to repos, workers, knowledge, deploy targets. Fields: `services`, `vercel_team`, `aws_profile`, `dns_zones`.

--- a/template/companies/_template/people/_example/meta.yaml
+++ b/template/companies/_template/people/_example/meta.yaml
@@ -1,0 +1,55 @@
+# People File — Example
+# One folder per person at companies/{company}/people/{slug}/
+# This meta.yaml holds basic contact + role info for the person.
+# Additional files (notes, meeting transcripts, contracts, etc.) can live
+# alongside this file inside the same folder.
+#
+# Required: name, type
+#   type: "internal" | "external"
+#     - internal: HQ team member (employee, co-founder, core staff)
+#     - external: client, vendor, partner, prospect, contractor, advisor, etc.
+#
+# Everything else is optional and added as discovered or provided.
+
+name: Jane Smith
+slug: jane-smith
+type: internal                 # "internal" | "external"
+
+# Role/title inside the company
+role: Head of Engineering
+
+# External-only fields — uncomment and fill when type: external
+# relationship: client         # client | vendor | partner | prospect | contractor | advisor
+# organization: Acme Corp      # the external party's company
+# primary_contact: true        # is this the main point-of-contact at their org?
+
+# Basic contact info
+email: jane@example.com
+phone: "+1XXXXXXXXXX"
+location: "San Francisco, CA"
+timezone: America/Los_Angeles
+
+# Service handles — used by integrations (Slack, Linear, GitHub, Cognito, etc.)
+# Added automatically on first interaction or manually.
+handles:
+  slack: U08EXAMPLE1
+  linear: abc123-def456
+  github: janesmith
+  linkedin: jane-smith-123
+  # x: janesmith
+  cognito_sub: "a1b2c3d4-5678-90ab-cdef-1234567890ab"   # internal only — Cognito subject UUID (immutable, not the email)
+
+# Tags — for quick filtering and search
+tags: [engineering, leadership]
+
+# Timestamps
+added: "2026-01-15"
+updated: "2026-01-20"
+
+# Notes — freeform, append-only, newest first.
+# The agent adds notes when it learns something useful about this person.
+notes:
+  - date: "2026-01-20"
+    text: "Prefers Slack over email. Usually responds within an hour during business hours."
+  - date: "2026-01-15"
+    text: "Met at kickoff meeting. Leading the platform migration project."

--- a/template/core.yaml
+++ b/template/core.yaml
@@ -1,6 +1,6 @@
 version: 1
 hqVersion: "10.10.0"
-updatedAt: "2026-04-14T05:20:15Z"
+updatedAt: "2026-04-16T01:56:07Z"
 rules:
   locked:
     - .claude/CLAUDE.md
@@ -22,13 +22,13 @@ rules:
   open:
     - "**"
 checksums:
-  .claude/CLAUDE.md: bbb9f97bff06256b3a45c07e375bb0d8b04f2a6ffde3e59ba93b8e9751149d93
+  .claude/CLAUDE.md: 7a8f67e6bfa488979f21e0d7098bf3db2ea703e2020c2deb4536b089c1081e9e
   .claude/hooks: a01bb35302070667cc38fd8c11c92a476282f35ce48c60c5345a2f0b66a8ad16
   .claude/policies: 902e26f85d172dff8c90fcb12357bc1a6d733ae5d4e4133268b6ff4998d37913
-  .claude/settings.json: 57a59dc2b82f03d159b51330e2f4c369cb055f4adc9ecf722b994235ae0661dd
+  .claude/settings.json: d2ef5f101a43f6772a18f13c647b0d87fab6663666cdd5ce2e7c94ae2abe9da2
   CHANGELOG.md: 1eb1327385c56e0b3daeb59e3b7c3c10dfc8d5be01ee1a3cd83ef0948223b7a7
   MIGRATION.md: 87678506a3fde8b90929ae6c4c1730dbfc6a41450d5c953cb5af35d9227156dd
-  companies/_template: 989a2d928de46bd5933d2f9d803bb9b5d58cb33dfb65d88f8b2fbd7f1b553d6a
+  companies/_template: 6ddd9a211b8ce1edfafa77d5b56a06f43237fd304a526b727ef9641ef6dcc88c
   companies/manifest.yaml: 61b9cc98d7f3f80361f59affc3f50dab3d2dfe2da332ee5d6d44e948ae75802c
   modules: 5ff6ea453f0e8b3e3d81c2f46c87c5bdebb7d3d96d143ebb289d58a3a77e2351
   scripts: ea9b41d608390170fad0f08250bbac6de36e96960d6d7df8de06fb956bf2cca6


### PR DESCRIPTION
## Summary

- Adds `companies/{co}/people/{slug}/meta.yaml` as the canonical shape for tracking people (HQ team members + external clients/vendors/partners). A folder per person, so notes, contracts, and transcripts can sit alongside `meta.yaml`.
- New scaffold at `companies/_template/people/_example/meta.yaml` with a documented schema: `name`, `type` (`internal` | `external`), `role`, `email`, `phone`, `handles` (slack, linear, github, linkedin, `cognito_sub`), `tags`, `notes[]`, plus external-only `relationship` / `organization`.
- `handles.cognito_sub` is internal-only and holds the Cognito **subject UUID** (not the email — Cognito's primary identifier is the immutable `sub`).
- New `## People` section in `template/.claude/CLAUDE.md` directs agents to check the active company's `people/` folder whenever a person is mentioned (matching on `name`, `email`, and any `handles` entry), and to create a new entry from the template when no match is found. Observations are appended to `notes[]` rather than overwriting fields.

## Commits

1. `fix: recompute stale checksums in template/core.yaml` — governance drift on nine locked paths (content already on `main`, just checksums out of sync). No file content changes.
2. `feat(template): add per-company people folder + agent guidance` — the feature itself; only `.claude/CLAUDE.md` and `companies/_template` checksums move in `core.yaml`.

## Test plan

- [x] `scripts/core-integrity.sh` → `All locked files unmodified — kernel integrity intact.`
- [x] `yq . companies/_template/people/_example/meta.yaml` parses.
- [ ] Manually spot-check the CLAUDE.md placement reads naturally after `## Companies`.
- [ ] Confirm nothing downstream assumes `companies/_template/` has only `policies/` as a child.