### PR TITLE
feat(template): add resource registry skill, hook, and command

### DIFF
--- a/template/.claude/CLAUDE.md
+++ b/template/.claude/CLAUDE.md
@@ -155,6 +155,31 @@ Knowledge folders use three patterns — all valid, none being migrated:
 
 When adding new knowledge: pick pattern 1 for company knowledge that will grow, pattern 2 if you want a shared clone, pattern 3 for small/shared content. Register in `modules/modules.yaml`. Taxonomy: `knowledge/public/hq-core/knowledge-taxonomy.md`.
 
+## Resource Registry
+
+Some companies maintain a **resource registry** — a plain folder inside the company directory (`companies/{co}/registry/`) holding YAML topology files, one per persistent resource (repos, apps, services, databases, infra, packages). The registry is declared by setting `registry: companies/{co}/registry` on the company's entry in `companies/manifest.yaml`.
+
+**Detection:** Check `companies.{co}.registry` in `manifest.yaml`. If set, the company has a registry.
+
+**Before creating** a new repo/app/service/DB, consult the registry first:
+```bash
+yq '.resources[] | "  " + .id + " - " + .name + " (" + .type + ")"' companies/{co}/registry/registry.yaml
+```
+If a matching resource exists, reuse it rather than silently duplicating.
+
+**After creating/renaming/deprecating** a resource, update the registry:
+- Add/edit `companies/{co}/registry/resources/{id}.yaml`
+- Regenerate the index: `cd companies/{co}/registry && bash scripts/generate-index.sh` (or `/sync-registry {co}`)
+
+**Credentials never go in the shared topology** — they live in `companies/{co}/settings/resource-overrides/` (gitignored). The `resources/*.yaml` files carry topology only — no `op://` refs, no API keys, no endpoints.
+
+**Sync across machines** is handled by `hq-sync`, not by git. The registry is not a standalone repo — it's part of the company filesystem and rides the same reconciliation path as everything else under `companies/{co}/`.
+
+**Skill:** `.claude/skills/registry/SKILL.md` — full protocol (detect, list, pre-flight, update, deprecate, bootstrap).
+**Bootstrap templates:** `.claude/skills/registry/templates/` — schema + generate-index script + README, copied into `companies/{co}/registry/` when a new registry is created.
+**Command:** `/sync-registry [company]` — regenerates `registry.yaml` from `resources/*.yaml`. Runs no git actions.
+**Hook (optional):** `.claude/hooks/auto-capture-registry.sh` — when `HQ_HOOK_PROFILE=standard`, writes stub resources on `gh repo create` (matched by `companies.{co}.github_org`) and `vercel deploy` (matched by `companies.{co}.vercel_team`). No-op for companies without a `registry:` declaration.
+
 ## Skills
 
 `.claude/skills/` is the canonical skill tree. Codex bridge: `scripts/codex-skill-bridge.sh install`. Dual-format: `command.md` (Claude Code) + `SKILL.md` (Codex). 12 promoted skills (Codex-ready). Coverage: `bash scripts/codex-skill-bridge.sh status`. Full pattern: `knowledge/public/hq-core/codex-skill-pattern.md`.

--- a/template/.claude/commands/sync-registry.md
+++ b/template/.claude/commands/sync-registry.md
@@ -1,0 +1,60 @@
+---
+description: Regenerate a company's resource-registry index (registry.yaml) from its resources/*.yaml files
+allowed-tools: Bash, Read
+argument-hint: [company-slug]
+visibility: public
+---
+
+# /sync-registry — Regenerate registry index
+
+Regenerates `companies/{co}/registry/registry.yaml` from the per-resource YAMLs in `companies/{co}/registry/resources/`. The registry is a plain folder synced across machines by `hq-sync` — this command does **not** push, pull, commit, or touch git. It only makes sure the flat index matches the per-resource files.
+
+**Args:** $ARGUMENTS — optional company slug. If omitted, resolved from cwd/context.
+
+## 1. Resolve active company
+
+1. If an arg was provided and matches a key under `companies.*` in `companies/manifest.yaml`, use that.
+2. Otherwise, infer from cwd: if `$(pwd)` starts with `companies/{slug}/`, use `{slug}`.
+3. Otherwise, read `workspace/threads/handoff.json` and use the last company touched, if any.
+4. Otherwise, report: `"Couldn't resolve active company. Pass one as an argument: /sync-registry my-co"` and stop.
+
+## 2. Verify the registry exists
+
+```bash
+REG_DIR="companies/{co}/registry"
+[ -d "$REG_DIR" ] || { echo "No registry at $REG_DIR"; exit 1; }
+[ -x "$REG_DIR/scripts/generate-index.sh" ] || { echo "$REG_DIR/scripts/generate-index.sh not found or not executable"; exit 1; }
+```
+
+If missing:
+- Folder doesn't exist → suggest bootstrapping with the `registry` skill (`.claude/skills/registry/SKILL.md` Step 6).
+- Script missing → suggest copying `scripts/generate-index.sh` from the skill's templates (`.claude/skills/registry/templates/generate-index.sh`).
+
+## 3. Regenerate the index
+
+```bash
+cd "$REG_DIR" && bash scripts/generate-index.sh
+```
+
+The script prints `Indexed: N resource(s)` on success.
+
+## 4. Report
+
+Summarize:
+
+```
+Registry index regenerated
+  Company:   {co}
+  Path:      {REG_DIR}/registry.yaml
+  Resources: {count}
+```
+
+Cross-machine sync happens via `hq-sync`, independent of this command. No git actions are run.
+
+---
+
+## Rules
+
+- **No git.** The registry is a plain folder in the company filesystem. Never `git add`, `git commit`, `git push`, or `git pull` from this command.
+- **Per-company.** Always scope to one company at a time. Don't walk all companies looking for registries.
+- **Non-destructive.** The generator script never touches `resources/*.yaml` — it only rewrites `registry.yaml`. Safe to run repeatedly.

--- a/template/.claude/hooks/auto-capture-registry.sh
+++ b/template/.claude/hooks/auto-capture-registry.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+# Auto-capture registry hook — detects resource-creation events in PostToolUse Bash
+# output and writes resource stubs into the matching company's registry folder.
+#
+# Detected events:
+#   - `gh repo create {org}/{name}` → creates resources/repo-{name}.yaml
+#   - `vercel deploy ... --scope team_XXX` → creates/updates resources/vercel-{project}.yaml
+#
+# The matching company is determined by:
+#   - gh repo create: `companies.{co}.github_org` equals the org in the command
+#   - vercel deploy:  `companies.{co}.vercel_team` equals the team id in the command
+#
+# Only companies with a `registry:` path declared in companies/manifest.yaml are
+# considered. All write operations are local-only — the hook never runs git.
+#
+# Non-blocking: failures are logged but never interrupt the user's command.
+# Gated behind HQ_HOOK_PROFILE=standard (not minimal).
+
+set -uo pipefail
+
+HQ_ROOT="${HQ_ROOT:-$HOME/hq}"
+MANIFEST="$HQ_ROOT/companies/manifest.yaml"
+LOG_FILE="/tmp/hq-auto-capture-registry.log"
+
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] auto-capture-registry: $*" >> "$LOG_FILE"
+}
+
+# Read tool input from stdin (PostToolUse provides JSON with tool_input)
+INPUT=$(cat)
+
+COMMAND=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    print(data.get('tool_input', {}).get('command', ''))
+except Exception:
+    print('')
+" 2>/dev/null)
+
+[ -z "$COMMAND" ] && exit 0
+[ ! -f "$MANIFEST" ] && exit 0
+command -v yq >/dev/null 2>&1 || { log "yq not available — skipping"; exit 0; }
+
+# Resolve company by predicate (github_org or vercel_team) via yq.
+# Returns the company slug whose $field equals $value, or empty string.
+resolve_company() {
+  local field="$1"
+  local value="$2"
+  yq -r ".companies | to_entries[] | select(.value.${field} == \"${value}\") | .key" "$MANIFEST" 2>/dev/null | head -1
+}
+
+# Returns the registry path for a company, or empty string if none.
+registry_path_for() {
+  local slug="$1"
+  yq -r ".companies.\"${slug}\".registry // \"\"" "$MANIFEST" 2>/dev/null
+}
+
+regen_index_if_possible() {
+  local reg_dir="$1"
+  local script="$reg_dir/scripts/generate-index.sh"
+  if [ -x "$script" ]; then
+    bash "$script" >> "$LOG_FILE" 2>&1 || true
+    log "regenerated $reg_dir/registry.yaml"
+  fi
+}
+
+# --- Detect: gh repo create {org}/{name} ---
+if echo "$COMMAND" | grep -qE 'gh\s+repo\s+create\s+[A-Za-z0-9._-]+/[A-Za-z0-9._-]+'; then
+  ORG=$(echo "$COMMAND" | grep -oE 'gh\s+repo\s+create\s+[A-Za-z0-9._-]+/' \
+    | sed -E 's|gh[[:space:]]+repo[[:space:]]+create[[:space:]]+||; s|/$||' | head -1)
+  REPO_NAME=$(echo "$COMMAND" | grep -oE "${ORG}/[A-Za-z0-9._-]+" | head -1 | sed "s|${ORG}/||")
+
+  if [ -z "$ORG" ] || [ -z "$REPO_NAME" ]; then
+    log "detected gh repo create but could not extract org/name from: $COMMAND"
+    exit 0
+  fi
+
+  CO=$(resolve_company "github_org" "$ORG")
+  if [ -z "$CO" ]; then
+    log "gh repo create for org '$ORG' — no company matches in manifest.github_org; skipping"
+    exit 0
+  fi
+
+  REG_PATH=$(registry_path_for "$CO")
+  if [ -z "$REG_PATH" ] || [ "$REG_PATH" = "null" ]; then
+    log "company '$CO' matched for org '$ORG' but has no registry declared; skipping"
+    exit 0
+  fi
+
+  REG_DIR="$HQ_ROOT/$REG_PATH"
+  RESOURCES_DIR="$REG_DIR/resources"
+  if [ ! -d "$RESOURCES_DIR" ]; then
+    log "registry '$REG_DIR' declared but resources/ dir missing for company '$CO'; skipping"
+    exit 0
+  fi
+
+  RESOURCE_ID="repo-${REPO_NAME}"
+  RESOURCE_FILE="$RESOURCES_DIR/${RESOURCE_ID}.yaml"
+  if [ -f "$RESOURCE_FILE" ]; then
+    log "resource file already exists: $RESOURCE_FILE — skipping"
+    exit 0
+  fi
+
+  IS_PRIVATE="false"
+  echo "$COMMAND" | grep -qE '\-\-private' && IS_PRIVATE="true"
+  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  cat > "$RESOURCE_FILE" <<YAML
+# Auto-captured from: gh repo create
+# Event: $COMMAND
+id: ${RESOURCE_ID}
+name: "${REPO_NAME}"
+type: repo
+purpose: "Auto-captured repository — update this description"
+owner: ${CO}-engineering
+status: active
+dependencies: []
+used_by: []
+constraints:
+  - "private: ${IS_PRIVATE}"
+tags:
+  - auto-captured
+repo_url: "https://github.com/${ORG}/${REPO_NAME}"
+created_at: "${NOW}"
+updated_at: "${NOW}"
+YAML
+
+  log "created $RESOURCE_FILE for company '$CO' (from gh repo create)"
+  regen_index_if_possible "$REG_DIR"
+  exit 0
+fi
+
+# --- Detect: vercel deploy with a known company team ---
+if echo "$COMMAND" | grep -qE 'vercel\s+deploy'; then
+  TEAM=$(echo "$COMMAND" | grep -oE 'team_[A-Za-z0-9]+' | head -1)
+  if [ -z "$TEAM" ]; then
+    log "vercel deploy detected but no team_ id in command; skipping"
+    exit 0
+  fi
+
+  CO=$(resolve_company "vercel_team" "$TEAM")
+  if [ -z "$CO" ]; then
+    log "vercel deploy with team '$TEAM' — no company matches in manifest.vercel_team; skipping"
+    exit 0
+  fi
+
+  REG_PATH=$(registry_path_for "$CO")
+  if [ -z "$REG_PATH" ] || [ "$REG_PATH" = "null" ]; then
+    log "company '$CO' matched team '$TEAM' but has no registry declared; skipping"
+    exit 0
+  fi
+
+  REG_DIR="$HQ_ROOT/$REG_PATH"
+  RESOURCES_DIR="$REG_DIR/resources"
+  if [ ! -d "$RESOURCES_DIR" ]; then
+    log "registry '$REG_DIR' declared but resources/ dir missing for company '$CO'; skipping"
+    exit 0
+  fi
+
+  PROJECT_NAME=$(echo "$COMMAND" | grep -oE '\-\-project\s+[A-Za-z0-9._-]+' | awk '{print $2}' | head -1)
+  if [ -z "$PROJECT_NAME" ]; then
+    log "vercel deploy for company '$CO' but --project name missing; skipping (avoid phantom stubs)"
+    exit 0
+  fi
+
+  RESOURCE_ID="vercel-${PROJECT_NAME}"
+  RESOURCE_FILE="$RESOURCES_DIR/${RESOURCE_ID}.yaml"
+  NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  if [ -f "$RESOURCE_FILE" ]; then
+    yq -i ".updated_at = \"${NOW}\"" "$RESOURCE_FILE" 2>/dev/null || true
+    log "touched $RESOURCE_FILE (existing, bumped updated_at)"
+    exit 0
+  fi
+
+  cat > "$RESOURCE_FILE" <<YAML
+# Auto-captured from: vercel deploy
+# Event: $COMMAND
+id: ${RESOURCE_ID}
+name: "${PROJECT_NAME} (Vercel)"
+type: app
+purpose: "Auto-captured Vercel deployment — update this description"
+owner: ${CO}-engineering
+status: active
+dependencies: []
+used_by: []
+constraints:
+  - "platform: vercel"
+  - "team: ${TEAM}"
+tags:
+  - auto-captured
+  - vercel
+created_at: "${NOW}"
+updated_at: "${NOW}"
+YAML
+
+  log "created $RESOURCE_FILE for company '$CO' (from vercel deploy)"
+  regen_index_if_possible "$REG_DIR"
+  exit 0
+fi
+
+exit 0

--- a/template/.claude/settings.json
+++ b/template/.claude/settings.json
@@ -110,6 +110,11 @@
             "type": "command",
             "command": ".claude/hooks/hook-gate.sh screenshot-resize-trigger .claude/hooks/screenshot-resize-trigger.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/hook-gate.sh auto-capture-registry .claude/hooks/auto-capture-registry.sh",
+            "timeout": 5
           }
         ]
       },

--- a/template/.claude/skills/registry/SKILL.md
+++ b/template/.claude/skills/registry/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: registry
+description: Detect and work with a company's resource registry — check what exists before creating, update after creating or changing a resource. The registry lives as a local folder inside the company (`companies/{co}/registry/`) and is reconciled across machines by hq-sync, not git.
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash(qmd:*), Bash(ls:*), Bash(yq:*), Bash(cat:*), Bash(date:*), Bash(bash:*), Bash(gh:*), Bash(grep:*)
+---
+
+# Company Resource Registry
+
+A company's resource registry is the shared inventory of its persistent infrastructure (repos, apps, services, databases, infra, packages). This skill teaches HQ to:
+
+1. **Detect** whether the active company has a registry.
+2. **Reference** it before creating new resources (avoid duplicates, understand topology).
+3. **Update** it when resources are created, renamed, or deprecated.
+
+**User's argument:** $ARGUMENTS — one of: `check`, `list`, `show <id>`, `add`, `update <id>`, `deprecate <id>`, `help`. Default when no arg: `check`.
+
+---
+
+## Core concept
+
+A registry is a **plain folder inside the company directory** containing YAML topology files — one file per resource plus an auto-generated index. The folder is provisioned by the HQ installer when a company is created and kept in sync across machines by `hq-sync` (the same mechanism that syncs the rest of the company filesystem). The skill never touches git.
+
+**Registry layout** (inside a company folder):
+
+```
+companies/{co}/registry/
+├── schema/resource.schema.yaml     # Field spec, version 1.0.0
+├── resources/{id}.yaml             # One file per resource (source of truth)
+├── registry.yaml                   # Auto-generated flat index (don't edit by hand)
+├── scripts/generate-index.sh       # Regenerates registry.yaml
+└── README.md                       # Registry-level notes
+```
+
+**Companion HQ paths:**
+
+- `companies/{co}/settings/resource-overrides/` — gitignored; per-machine credentials/paths (the **only** place `op://` refs, endpoints, or local clone paths live)
+- `companies/manifest.yaml` → company entry has `registry: companies/{co}/registry` when declared
+
+---
+
+## Step 1 — Detect the registry
+
+Determine the active company from context (cwd, recent edits, user's message). Then check in order:
+
+```bash
+# 1. Manifest declaration (soft hint)
+yq ".companies.\"{co}\".registry // \"none\"" companies/manifest.yaml
+
+# 2. Physical folder (authoritative)
+[ -d "companies/{co}/registry" ] && echo "FOUND" || echo "MISSING"
+```
+
+Outcomes:
+
+- **Folder exists** → registry is active. Continue.
+- **Manifest declares it but folder is missing** → `hq-sync` hasn't reconciled yet on this machine. Report `"Registry declared for {co} but not present locally — run hq-sync, or ask the installer to reprovision the company filesystem."` and stop.
+- **Neither** → no registry for this company. Report `"No registry for {co} — see Step 6 to bootstrap one if desired."` and stop unless the user explicitly asks to create one.
+
+If the folder exists, verify the index is present:
+
+```bash
+[ -f companies/{co}/registry/registry.yaml ] || echo "MISSING_INDEX — regenerate with: cd companies/{co}/registry && bash scripts/generate-index.sh"
+```
+
+---
+
+## Step 2 — Reference (read) the registry
+
+### 2a. List all resources
+
+```bash
+yq '.resources[] | "  " + .id + " — " + .name + " (" + .type + ", " + .status + ")"' \
+  companies/{co}/registry/registry.yaml
+```
+
+Flat table: id, name, type, status. Answers "what do we have?" without loading every full YAML.
+
+### 2b. Look up by type or tag
+
+```bash
+# All active repos
+yq '.resources[] | select(.type == "repo" and .status == "active") | .id' \
+  companies/{co}/registry/registry.yaml
+
+# Full details for a single resource
+cat companies/{co}/registry/resources/{id}.yaml
+```
+
+### 2c. Search semantically (if qmd-indexed)
+
+If the registry has a qmd collection declared in the company's `qmd_collections` list, use qmd:
+
+```bash
+qmd search "<query>" -c {co}-registry --json -n 10
+qmd vsearch "<concept>" -c {co}-registry --json -n 10
+```
+
+Use qmd when the user asks conceptually ("what handles auth?", "any vector DBs?"). Use `yq`/`Read` when you have a specific id or type filter.
+
+### 2d. Inspect local override (if exists)
+
+When you need access details (credentials, endpoints, local paths), read the **local override**, not the shared topology:
+
+```bash
+ls companies/{co}/settings/resource-overrides/{id}.local.yaml 2>/dev/null && \
+  cat companies/{co}/settings/resource-overrides/{id}.local.yaml
+```
+
+Override files are gitignored. They're the **only** place `op://` refs, endpoints, or local clone paths live.
+
+---
+
+## Step 3 — Before creating a new resource (pre-flight check)
+
+When the user asks you to create a new repo, app, service, database, or infra component, **first check the registry**:
+
+1. List resources of that type: `yq '.resources[] | select(.type == "{type}") | .name' companies/{co}/registry/registry.yaml`
+2. Search for similar names: `grep -ri "{keyword}" companies/{co}/registry/resources/`
+3. If a match exists: report it and ask whether to reuse, fork, or genuinely create new. Do not silently duplicate.
+
+**Why this matters:** Registries drift from reality when new resources get created without being registered. The pre-flight check is the counter-force — every creation event funnels through registry awareness.
+
+---
+
+## Step 4 — Update (add / modify / deprecate)
+
+### 4a. Add a new resource
+
+1. **Pick an id.** Convention: `{type}-{slug}` (e.g. `repo-my-service`, `app-marketing-site`, `db-primary-postgres`). Kebab-case, globally unique across the registry.
+2. **Read the schema** at `companies/{co}/registry/schema/resource.schema.yaml` — confirm current field spec.
+3. **Write** `companies/{co}/registry/resources/{id}.yaml` with required fields:
+   - `id`, `name`, `type` (enum: repo/app/service/infra/database/ai/package), `purpose` (1-2 sentences)
+   - `owner`, `status` (active/deprecated/planned)
+   - `created_at`, `updated_at` (YYYY-MM-DD or ISO)
+   - `dependencies: []`, `used_by: []`, `constraints: []`, `tags: []` (optional, default empty)
+   - Type-specific: `repo_url`, `language`, `runtime` (include when known)
+4. **Forbidden fields in topology**: `op://` refs, API keys, passwords, connection strings, IP:port, private keys, `ghp_`/`xoxb-` tokens. If you need to capture credentials, write them to `companies/{co}/settings/resource-overrides/{id}.local.yaml` instead.
+5. **Update cross-refs** on related resources — add this id to their `used_by` or `dependencies` list.
+6. **Regenerate the index:**
+   ```bash
+   cd companies/{co}/registry && bash scripts/generate-index.sh
+   ```
+7. **That's it.** The file sits in the company filesystem; `hq-sync` reconciles it across teammates' machines on the next sync cycle. No git commit, no push — the registry is not a standalone repo.
+
+### 4b. Update an existing resource
+
+- Edit the specific `resources/{id}.yaml`. Bump `updated_at` to today.
+- If the change alters cross-references (renames, new deps), update affected resources' `used_by` / `dependencies`.
+- Regenerate the index.
+
+### 4c. Deprecate a resource
+
+- Change `status: active` → `status: deprecated`. Bump `updated_at`.
+- Optionally add a `constraints` note: `"Scheduled for removal {date} — use {replacement-id} instead."`
+- Remove the deprecated id from other resources' `dependencies` lists (direct deps must resolve to active resources).
+- Regenerate the index.
+
+### 4d. Delete (rare)
+
+Only delete when the resource **never existed** (phantom entry) or was fully removed from infrastructure with no history value. Otherwise prefer `status: deprecated`. If deleting, also grep for the id across `resources/` and remove it from any `dependencies`/`used_by` lists, then regenerate the index.
+
+---
+
+## Step 5 — Sync (hands-off)
+
+The registry folder is part of the company filesystem. Cross-machine sync is handled by `hq-sync` — the same mechanism that reconciles everything else under `companies/{co}/`. This skill does **not** run git commands, push, pull, or commit.
+
+**What this means in practice:**
+
+- After you edit a resource, save the file and regenerate the index. You're done.
+- A teammate's next `hq-sync` pull will bring your changes to their machine.
+- Conflict resolution (if two teammates edit the same file between syncs) happens inside `hq-sync`, not here.
+- If something looks stale on your machine, run the standard `hq-sync` command — the skill has no say in how or when that runs.
+
+If you ever see a `companies/{co}/registry/.git/` directory, you're on a legacy setup (pre-migration). Treat it as read-only for this skill; migration out of the separate-repo model is a one-time operation.
+
+---
+
+## Step 6 — Bootstrap a registry for a new company (rare, on request)
+
+If the active company has no registry and the user wants one, use the templates that ship with this skill:
+
+1. **Confirm scope.** Registries are valuable when a company has ≥3 shared resources AND ≥2 teammates. Single-person companies usually don't need one yet.
+2. **Create the folder structure and copy the templates:**
+   ```bash
+   mkdir -p companies/{co}/registry/{schema,resources,scripts}
+   cp .claude/skills/registry/templates/resource.schema.yaml companies/{co}/registry/schema/
+   cp .claude/skills/registry/templates/generate-index.sh    companies/{co}/registry/scripts/
+   cp .claude/skills/registry/templates/README.md            companies/{co}/registry/
+   chmod +x companies/{co}/registry/scripts/generate-index.sh
+   ```
+3. **Declare in manifest** — add `registry: companies/{co}/registry` to the company's entry in `companies/manifest.yaml`. If the company also has a GitHub org or Vercel team that should drive auto-capture, set `github_org:` / `vercel_team:` on the same entry.
+4. **Populate initial resources** — one YAML under `resources/` per existing repo/app/service the company operates.
+5. **Generate the index:**
+   ```bash
+   cd companies/{co}/registry && bash scripts/generate-index.sh
+   ```
+6. **(Optional) Add a qmd collection** for semantic search — add `{co}-registry` to the company's `qmd_collections` list in `companies/manifest.yaml`, then run `qmd update`.
+
+No separate git repo, no pre-commit hook, no branch protection — the registry lives in the company filesystem and inherits its sync mechanism.
+
+---
+
+## Step 7 — Auto-capture awareness
+
+Some events trigger automatic resource capture via `.claude/hooks/auto-capture-registry.sh`:
+
+| Event | Hook action |
+|---|---|
+| `gh repo create` with a known company org | Writes `companies/{co}/registry/resources/repo-{name}.yaml` stub + regenerates index |
+| `vercel deploy` with a known company scope | Writes/updates `companies/{co}/registry/resources/vercel-{project}.yaml` + regenerates index |
+
+Auto-captured stubs have `purpose: "Auto-captured — update this description"` and tag `auto-captured`. **After auto-capture, enrich the stub** — fill in purpose, owner, dependencies, constraints. Unresolved stubs rot the registry.
+
+Hooks are gated to `HQ_HOOK_PROFILE=standard` (not minimal). Failures are non-blocking. Matching is manifest-driven: the hook resolves the active company by looking up `companies.{co}.github_org` or `companies.{co}.vercel_team` and only writes if that company declares `registry:` in the manifest.
+
+---
+
+## Decision guide — when to invoke this skill
+
+| Signal | Action |
+|---|---|
+| User says "what repos/apps/services does {co} have?" | Step 2a/2c (list/search) |
+| User asks to create a new repo/app/service/DB | Step 3 (pre-flight) → then normal creation → Step 4a (register) |
+| User renames or deprecates a resource | Step 4b/4c |
+| After `gh repo create` or `vercel deploy` | Check if auto-capture fired; enrich stub |
+| User asks "how do we access {resource}?" | Step 2d (read local override — never leak shared topology with creds) |
+| User asks to bootstrap a registry for a new company | Step 6 |
+
+---
+
+## Rules
+
+- **Never write secrets into the shared topology.** Credentials, endpoints, and local paths live only in `companies/{co}/settings/resource-overrides/` (gitignored). Mixing them into `resources/*.yaml` is the failure mode the topology/overrides split is designed to prevent.
+- **One file per resource.** Never merge multiple resources into one YAML (breaks cross-references, makes diffs noisy, causes sync conflicts).
+- **Kebab-case ids, globally unique.** Never change an id after creation — downstream resources reference it.
+- **`registry.yaml` is derived.** Don't edit it by hand — always regenerate via `scripts/generate-index.sh`.
+- **No git in this skill.** The registry is a folder synced by `hq-sync`, not a standalone repo. Don't `git add`, `git commit`, `git push`, or run `/sync-registry` from this skill — they don't apply.
+- **Registry is authoritative over manifest for resource detail.** If `manifest.yaml` says a repo exists but the registry doesn't, either the registry is stale (register it) or the manifest is stale (remove it). Resolve the gap, don't ignore it.
+- **When a company has no registry, say so.** Don't invent one or fall back to manifest as a substitute.

--- a/template/.claude/skills/registry/agents/openai.yaml
+++ b/template/.claude/skills/registry/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Registry"
+  short_description: "Check, update, or sync a company's resource registry — the shared inventory of persistent repos/apps/services."

--- a/template/.claude/skills/registry/templates/README.md
+++ b/template/.claude/skills/registry/templates/README.md
@@ -1,0 +1,46 @@
+# Company Resource Registry
+
+This folder is the shared inventory of a company's persistent infrastructure — repos, apps, services, databases, infra, and packages. It is **topology only** (what exists, why, who owns it, what depends on what). Credentials, endpoints, and local clone paths live in `companies/{co}/settings/resource-overrides/` (gitignored) — never in this folder.
+
+## Layout
+
+```
+registry/
+├── schema/resource.schema.yaml     Field spec (v1.0.0 — do not edit lightly)
+├── resources/{id}.yaml             One file per resource (source of truth)
+├── registry.yaml                   Auto-generated flat index — do NOT edit by hand
+├── scripts/generate-index.sh       Regenerates registry.yaml
+└── README.md                       This file
+```
+
+## Adding a resource
+
+1. Create `resources/{id}.yaml`. Pick a kebab-case id of the form `{type}-{slug}` (e.g. `repo-api-server`, `app-marketing-site`, `db-primary-postgres`). Ids are globally unique within this registry and **never change** — other resources reference them.
+2. Fill the required fields per `schema/resource.schema.yaml`: `id`, `name`, `type`, `purpose`, `owner`, `status`, `created_at`, `updated_at`. Optional: `dependencies`, `used_by`, `constraints`, `tags`, `repo_url`, `language`, `runtime`.
+3. Update cross-references — add this id to the `used_by` or `dependencies` field of any related resource.
+4. Regenerate the index:
+   ```bash
+   bash scripts/generate-index.sh
+   ```
+
+## Do not put here
+
+- `op://` references, API keys, tokens, passwords
+- Database connection strings or full URLs with auth
+- Internal IP addresses, port assignments
+- Environment variable values
+- PEM blocks, private keys, certificates
+
+These live in the matching local override at `companies/{co}/settings/resource-overrides/{id}.local.yaml` — gitignored, per-machine.
+
+## Syncing across teammates
+
+This folder rides the same reconciliation path as the rest of the company filesystem — `hq-sync` handles propagation. This folder is **not** its own git repo. Don't `git add` inside it; save your changes and `hq-sync` will bring them to the rest of the team on the next cycle.
+
+## In-session helpers
+
+When working inside HQ with Claude or Codex:
+
+- The `registry` skill (`.claude/skills/registry/`) detects this folder, lists resources, and walks you through add/update/deprecate flows.
+- `/sync-registry [company]` regenerates this registry's index. It never touches git.
+- The `auto-capture-registry` hook writes stub entries for `gh repo create` and `vercel deploy` events when the company declares `github_org` / `vercel_team` in `companies/manifest.yaml`.

--- a/template/.claude/skills/registry/templates/generate-index.sh
+++ b/template/.claude/skills/registry/templates/generate-index.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# scripts/generate-index.sh
+# Reads all resources/*.yaml files and produces registry.yaml at the repo root.
+#
+# Usage:
+#   ./scripts/generate-index.sh
+#
+# Output:
+#   registry.yaml — index of all resources (id, name, type, status, path)
+#
+# Requirements:
+#   yq v4+ (https://github.com/mikefarah/yq) — brew install yq
+#
+# The registry.yaml follows the same pattern as workers/registry.yaml in HQ:
+# a flat list of lightweight index entries, each pointing to the full resource
+# file for detailed fields.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESOURCES_DIR="${REPO_ROOT}/resources"
+OUTPUT_FILE="${REPO_ROOT}/registry.yaml"
+
+# ---------------------------------------------------------------------------
+# Dependency check
+# ---------------------------------------------------------------------------
+if ! command -v yq &>/dev/null; then
+  echo "ERROR: yq is required but not found." >&2
+  echo "Install with: brew install yq" >&2
+  exit 1
+fi
+
+YQ_VERSION=$(yq --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
+YQ_MAJOR=$(echo "$YQ_VERSION" | cut -d. -f1)
+if [[ "$YQ_MAJOR" -lt 4 ]]; then
+  echo "ERROR: yq v4+ is required (found v${YQ_VERSION})." >&2
+  echo "Install with: brew install yq" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Collect resource files
+# ---------------------------------------------------------------------------
+if [[ ! -d "$RESOURCES_DIR" ]]; then
+  echo "ERROR: resources/ directory not found at ${RESOURCES_DIR}" >&2
+  exit 1
+fi
+
+readarray_compat() {
+  # Portable alternative to mapfile/readarray for bash 3.x (macOS system bash)
+  local line
+  RESOURCE_FILES=()
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && RESOURCE_FILES+=("$line")
+  done < <(find "$RESOURCES_DIR" -maxdepth 1 -name "*.yaml" | sort)
+}
+readarray_compat
+
+if [[ ${#RESOURCE_FILES[@]} -eq 0 ]]; then
+  echo "WARNING: No resource files found in resources/. Writing empty registry." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Build registry.yaml
+# ---------------------------------------------------------------------------
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+ENTRY_COUNT=${#RESOURCE_FILES[@]}
+
+{
+  echo "# registry.yaml"
+  echo "# Auto-generated index of all resources in this company's registry."
+  echo "# DO NOT edit by hand — regenerate with: ./scripts/generate-index.sh"
+  echo "#"
+  echo "# Generated: ${TIMESTAMP}"
+  echo "# Resources: ${ENTRY_COUNT}"
+  echo ""
+  echo "generated_at: \"${TIMESTAMP}\""
+  echo "resource_count: ${ENTRY_COUNT}"
+  echo "resources:"
+} > "$OUTPUT_FILE"
+
+ERRORS=0
+
+for file in "${RESOURCE_FILES[@]}"; do
+  # Relative path from repo root (for portability)
+  rel_path="${file#${REPO_ROOT}/}"
+
+  # Extract required index fields using yq
+  id=$(yq '.id // ""' "$file" 2>/dev/null || true)
+  name=$(yq '.name // ""' "$file" 2>/dev/null || true)
+  type=$(yq '.type // ""' "$file" 2>/dev/null || true)
+  status=$(yq '.status // ""' "$file" 2>/dev/null || true)
+
+  # Validate required fields are present
+  missing=()
+  [[ -z "$id" || "$id" == "null" ]]     && missing+=("id")
+  [[ -z "$name" || "$name" == "null" ]] && missing+=("name")
+  [[ -z "$type" || "$type" == "null" ]] && missing+=("type")
+  [[ -z "$status" || "$status" == "null" ]] && missing+=("status")
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "WARNING: Skipping ${rel_path} — missing required fields: ${missing[*]}" >&2
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  # Append index entry
+  {
+    echo "  - id: ${id}"
+    echo "    name: ${name}"
+    echo "    type: ${type}"
+    echo "    status: ${status}"
+    echo "    path: ${rel_path}"
+  } >> "$OUTPUT_FILE"
+done
+
+echo "" >> "$OUTPUT_FILE"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+INDEXED=$((ENTRY_COUNT - ERRORS))
+echo "Generated ${OUTPUT_FILE}"
+echo "  Indexed: ${INDEXED} resource(s)"
+[[ $ERRORS -gt 0 ]] && echo "  Skipped: ${ERRORS} file(s) with missing required fields" >&2
+
+exit 0

--- a/template/.claude/skills/registry/templates/resource.schema.yaml
+++ b/template/.claude/skills/registry/templates/resource.schema.yaml
@@ -1,0 +1,264 @@
+# schema/resource.schema.yaml
+# Resource schema for a company resource registry.
+# Defines the structure, types, required/optional markers, and constraints
+# for all resource files in resources/*.yaml.
+#
+# VERSION: 1.0.0
+# Every resource file must conform to this schema.
+
+# ---------------------------------------------------------------------------
+# SECURITY EXCLUSIONS
+# ---------------------------------------------------------------------------
+# The following fields are EXPLICITLY EXCLUDED from this schema and must
+# NEVER appear in any resource file:
+#
+#   - credential references    (op:// URIs, secret IDs, vault paths)
+#   - API keys / tokens        (bearer tokens, service account keys, PATs)
+#   - connection strings       (postgres://, mysql://, mongodb:// with auth)
+#   - internal IP addresses    (10.x.x.x, 172.16.x.x, 192.168.x.x with port)
+#   - port numbers             (standalone port assignments for services)
+#   - passwords / secrets      (any key whose value is a credential)
+#   - environment variables    (.env values or resolved secret values)
+#   - certificate data         (PEM blocks, private keys, certificates)
+#
+# This registry describes TOPOLOGY (what exists, why, who owns it, what
+# it connects to by name). Access and connectivity details live in your
+# secret store (1Password, AWS Secrets Manager, etc.) and runtime
+# configuration only.
+# ---------------------------------------------------------------------------
+
+schema_version: "1.0.0"
+
+# ---------------------------------------------------------------------------
+# FIELD DEFINITIONS
+# ---------------------------------------------------------------------------
+# Each field definition includes:
+#   type        - YAML scalar or collection type
+#   required    - whether the field must be present
+#   description - human-readable explanation
+#   enum        - allowed values (when applicable)
+#   example     - one or more example values
+# ---------------------------------------------------------------------------
+
+fields:
+
+  # ── Identity ──────────────────────────────────────────────────────────────
+
+  id:
+    type: string
+    required: true
+    description: >
+      Unique, stable identifier for this resource. Use kebab-case.
+      Must be unique across all resources in the registry.
+      Once set, do not change — other resources reference this id in
+      dependencies[] and used_by[].
+    pattern: "^[a-z0-9]+(-[a-z0-9]+)*$"
+    example: "api-server"
+
+  name:
+    type: string
+    required: true
+    description: >
+      Human-readable display name for this resource. May include spaces,
+      mixed case, and punctuation. Used in dashboards and reports.
+    example: "API Server"
+
+  type:
+    type: string
+    required: true
+    description: >
+      Resource category. Determines which fields are relevant and how
+      the resource appears in topology views.
+    enum:
+      - repo       # Git repository (source code, config, IaC)
+      - app        # Deployed application or web service
+      - service    # Backend service, API, or daemon
+      - infra      # Infrastructure component (load balancer, CDN, VPC, etc.)
+      - database   # Persistent data store (SQL, NoSQL, object storage)
+      - ai         # AI/ML model, embedding pipeline, or inference service
+      - package    # Reusable library or installable package
+    example: "service"
+
+  # ── Description ───────────────────────────────────────────────────────────
+
+  purpose:
+    type: string
+    required: true
+    description: >
+      One or two sentences explaining what this resource does and why it
+      exists. Write for a new engineer reading the registry for the first time.
+    example: "Handles authentication and session management for all
+      platform clients. Issues JWTs and validates tokens on every API request."
+
+  owner:
+    type: string
+    required: true
+    description: >
+      Team or person responsible for this resource. Used for incident routing
+      and change notifications. Use a team slug or a GitHub username.
+    example: "platform-team"
+
+  # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  status:
+    type: string
+    required: true
+    description: >
+      Current lifecycle state of the resource.
+    enum:
+      - active      # In production use
+      - deprecated  # Scheduled for removal; avoid new dependencies
+      - planned     # Not yet built; reserved for upcoming work
+    example: "active"
+
+  created_at:
+    type: string
+    required: true
+    description: >
+      ISO 8601 date when this resource was first created or registered.
+      Date-only format (YYYY-MM-DD) is acceptable.
+    format: "YYYY-MM-DD"
+    example: "2024-09-15"
+
+  updated_at:
+    type: string
+    required: true
+    description: >
+      ISO 8601 date when this resource file was last updated.
+      Update this field whenever any other field changes.
+    format: "YYYY-MM-DD"
+    example: "2025-03-20"
+
+  # ── Topology ──────────────────────────────────────────────────────────────
+
+  dependencies:
+    type: sequence
+    items: string
+    required: false
+    default: []
+    description: >
+      List of resource ids that this resource depends on. Only reference ids
+      that exist in the registry (resources/*.yaml). This resource cannot
+      function without each listed dependency.
+    example:
+      - postgres-primary
+      - redis-cache
+
+  used_by:
+    type: sequence
+    items: string
+    required: false
+    default: []
+    description: >
+      List of resource ids that depend on this resource. The inverse of
+      dependencies. Maintained to support impact analysis (e.g. "what breaks
+      if I take this down?").
+    example:
+      - web-app
+      - worker-queue
+
+  # ── Operational ───────────────────────────────────────────────────────────
+
+  constraints:
+    type: sequence
+    items: string
+    required: false
+    default: []
+    description: >
+      Non-credential operational notes: region lock, compliance requirements,
+      retention policies, SLA expectations, data classification, or scaling
+      limits. Plain English sentences. Do NOT include IP addresses, port
+      numbers, passwords, or connection strings here.
+    example:
+      - "Must remain in us-east-1 for data residency compliance."
+      - "Contains PII — all writes must be audit-logged."
+      - "Stateless — safe to scale horizontally without coordination."
+
+  # ── Discovery ─────────────────────────────────────────────────────────────
+
+  tags:
+    type: sequence
+    items: string
+    required: false
+    default: []
+    description: >
+      Free-form labels for filtering and grouping in dashboards and search.
+      Use lowercase kebab-case. Common tags: platform, auth, data, ml,
+      customer-facing, internal, critical, experimental.
+    example:
+      - platform
+      - auth
+      - critical
+
+  # ── Optional Supplemental Fields ──────────────────────────────────────────
+  # The fields below are optional and type-specific. Include them when they
+  # add meaningful topology information. Omit when not applicable.
+
+  repo_url:
+    type: string
+    required: false
+    description: >
+      Public or internal GitHub URL for the source repository.
+      Only for type: repo and type: app/service where source is known.
+      Do NOT include authentication tokens in the URL.
+    example: "https://github.com/my-org/my-api"
+
+  language:
+    type: string
+    required: false
+    description: >
+      Primary programming language or runtime. For type: repo and type: package.
+    example: "TypeScript"
+
+  runtime:
+    type: string
+    required: false
+    description: >
+      Execution environment or compute platform. For type: app and type: service.
+      Describes where the code runs, not how to access it.
+    example: "AWS App Runner"
+
+  # ---------------------------------------------------------------------------
+  # NOTE: The following fields are intentionally absent from this schema:
+  #
+  #   host / endpoint / url_with_auth  — reveals internal topology + access path
+  #   port                             — internal networking detail
+  #   connection_string                — contains embedded credentials
+  #   api_key / token / secret         — never stored here; use a secret store
+  #   ip_address                       — internal IP ranges are infra-sensitive
+  #   credentials_ref / op_path        — op:// paths are credential references
+  #   password / passwd                — obvious exclusion
+  #   environment_variables            — resolved env values are secrets
+  #   certificate / private_key        — cryptographic material
+  # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# EXAMPLE RESOURCE FILE (full)
+# ---------------------------------------------------------------------------
+# A complete, valid example is shown below. Copy this template when adding
+# a new resource to resources/.
+#
+# ---
+# id: my-new-service
+# name: My New Service
+# type: service
+# purpose: >
+#   Processes incoming webhook events from third-party integrations and
+#   routes them to the appropriate internal handler queues.
+# owner: platform-team
+# status: active
+# created_at: "2025-01-10"
+# updated_at: "2025-03-15"
+# dependencies:
+#   - postgres-primary
+#   - redis-cache
+# used_by:
+#   - web-app
+# constraints:
+#   - "Idempotent — duplicate events are safe to replay."
+#   - "Must not store raw webhook payloads longer than 24 hours."
+# tags:
+#   - platform
+#   - integrations
+# runtime: "AWS App Runner"
+# ---------------------------------------------------------------------------

--- a/template/core.yaml
+++ b/template/core.yaml
@@ -1,6 +1,6 @@
 version: 1
 hqVersion: "11.1.1"
-updatedAt: "2026-04-17T05:13:58Z"
+updatedAt: "2026-04-19T18:59:07Z"
 rules:
   locked:
     - .claude/CLAUDE.md
@@ -22,10 +22,10 @@ rules:
   open:
     - "**"
 checksums:
-  .claude/CLAUDE.md: 0c0c53ceecfcc4e4af31236787c5c54bd8a48277616e25616558a4d2d1bbfec4
-  .claude/hooks: 3c2abcc0db37c17a09366d5d9a0cd5e1880e1ffb869e9f94c45ede0c37a3e64a
-  .claude/policies: 42677f5183fdc96474eb51f2916dadf66cb4f8b1790ab0549891ea15e075bd30
-  .claude/settings.json: 80331b4b73288d0704ae1924f83dbef7b104c590b3e7681eecbd56a6f7ef9eda
+  .claude/CLAUDE.md: 83641e159b2f4176e205cffec42271139ac84304d4961eb7af5577a2a37e2879
+  .claude/hooks: 1c5e17e0bb31a9909e87300501b061b39c938a8422a4515f426710d5e6acb879
+  .claude/policies: d709feb6f5bba7233353043cd83c59b0aa9a253eb964e131a62209b54cf1b92b
+  .claude/settings.json: a2f8271b3a3ffd129d933272c4a70e285f37b48b602096e1122b071113de0a8a
   CHANGELOG.md: c16225189ecb7c02690a12f1371ce26268f53fefb6f17d650454d07aad063152
   MIGRATION.md: a98e522e8c930e8949346f2985b10cb15c6b9851c08efb9c78e37e4f31832e0a
   companies/_template: 6ddd9a211b8ce1edfafa77d5b56a06f43237fd304a526b727ef9641ef6dcc88c


### PR DESCRIPTION
## Summary

Adds infrastructure for an opt-in **per-company resource registry** — a shared YAML inventory of persistent infrastructure (repos, apps, services, databases, infra, packages) that lives at `companies/{co}/registry/` as a plain folder reconciled by `hq-sync`.

The motivation: as a company adds repos/apps/services, agents (and humans) drift from reality — they create duplicates, lose track of who owns what, and miss cross-references when changing things. A registry gives every session a single source of truth to consult before creating anything new and to update after.

## What's added

All under `template/.claude/` (so it ships to every fresh `npx create-hq` install):

| Path | Purpose |
|---|---|
| `skills/registry/SKILL.md` | Detect / list / pre-flight / add / update / deprecate / bootstrap protocol |
| `skills/registry/agents/openai.yaml` | Codex bridge so the skill is discoverable from Codex too |
| `skills/registry/templates/resource.schema.yaml` | Field spec v1.0.0 — copied into a new registry on bootstrap |
| `skills/registry/templates/generate-index.sh` | Reads `resources/*.yaml`, writes `registry.yaml` index. Requires `yq v4+` |
| `skills/registry/templates/README.md` | Per-registry README, copied into a new registry on bootstrap |
| `hooks/auto-capture-registry.sh` | PostToolUse Bash hook — writes resource stubs on `gh repo create` / `vercel deploy` for companies that declare matching `github_org` / `vercel_team` and a `registry:` path in `companies/manifest.yaml` |
| `commands/sync-registry.md` | `/sync-registry [co]` — regenerates `registry.yaml` from `resources/*.yaml`. Runs no git actions |

Also:
- Registers `auto-capture-registry` in `template/.claude/settings.json` under `PostToolUse > Bash` (gated by the standard hook profile via `hook-gate.sh`).
- Adds a "Resource Registry" section to `template/.claude/CLAUDE.md` explaining detection, the pre-flight check, the update flow, and the topology-vs-credentials split.

## Design notes

- **Plain folder, not a separate repo.** Earlier iteration of this used a standalone git repo per company; that added clone/symlink/pre-commit ceremony for no benefit. Now the registry rides the same `hq-sync` reconciliation as the rest of `companies/{co}/`.
- **Manifest-driven.** The hook resolves the active company by matching `companies.{co}.github_org` and `companies.{co}.vercel_team` against the executed command. Only companies that also declare `registry:` get auto-capture stubs.
- **Topology only.** `resources/*.yaml` carries names, ownership, dependencies, constraints — never `op://` refs, API keys, ports, or connection strings. Per-machine credentials live in `companies/{co}/settings/resource-overrides/{id}.local.yaml` (gitignored). The schema explicitly excludes secret-looking fields.
- **Backwards compatible.** A user whose manifest declares no `github_org` / `vercel_team` / `registry` sees zero behavior change. The hook exits silently when the manifest is missing or unmatched, and registers no resources.

## Test plan

- [x] Templates produce a valid registry from scratch (smoke-tested with one resource → `Indexed: 1 resource(s)`).
- [x] Hook is a no-op when `companies/manifest.yaml` is absent (`exit 0` early).
- [x] Hook skips `gh repo create` when no manifest entry has the matching `github_org`.
- [x] Hook skips `vercel deploy` when no `--project` arg is present (avoids phantom stubs).
- [ ] After merge, install via `npx create-hq` into a scratch directory and confirm:
  - `.claude/skills/registry/` is present with templates
  - `.claude/hooks/auto-capture-registry.sh` is executable
  - `/sync-registry` slash command is recognized
  - Registry section appears in `.claude/CLAUDE.md`
- [ ] Optional follow-up: bootstrap a registry on a personal company and confirm the `gh repo create` auto-capture path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)