### PR TITLE
fix(hq-cloud): honor .gitignore/.hqignore + classify sync errors

### DIFF
--- a/packages/hq-cloud/src/ignore.ts
+++ b/packages/hq-cloud/src/ignore.ts
@@ -1,42 +1,106 @@
 /**
- * Ignore file parser for .hqsyncignore
- * Uses gitignore-compatible syntax
+ * Ignore-file parser for cloud sync.
+ *
+ * Three layers, evaluated in order (later patterns override earlier ones):
+ *   1. Built-in defaults — things that should *never* sync (VCS, node_modules,
+ *      build artifacts, caches, env files). Cover the common stacks so that a
+ *      first-time sync over a random project folder doesn't try to push
+ *      `target/`, `node_modules/`, or `.next/` to S3.
+ *   2. Repo `.gitignore` at hqRoot — reuses the user's existing exclusions so
+ *      we don't re-list every build directory ourselves. Root-level only; we
+ *      do not recurse like real git.
+ *   3. `.hqignore` (preferred) or `.hqsyncignore` (legacy name) at hqRoot —
+ *      sync-specific overrides. Use `!pattern` to re-include something an
+ *      earlier layer excluded.
  */
 
 import * as fs from "fs";
 import * as path from "path";
 import ignore from "ignore";
 
-// Default patterns that should never sync
+// Patterns that must never sync regardless of project type.
+// Grouped by ecosystem so new stacks are easy to add.
 const DEFAULT_IGNORES = [
+  // VCS + OS
   ".git/",
   ".git",
-  "node_modules/",
-  "dist/",
   ".DS_Store",
   "Thumbs.db",
+
+  // Node / JS
+  "node_modules/",
+  "dist/",
+  "build/",
+  ".next/",
+  ".nuxt/",
+  ".svelte-kit/",
+  ".turbo/",
+  ".parcel-cache/",
+  ".vite/",
+  "coverage/",
+
+  // Rust / Tauri
+  "target/",
+
+  // Python
+  "__pycache__/",
+  "*.pyc",
+  ".pytest_cache/",
+  ".mypy_cache/",
+  ".ruff_cache/",
+  ".venv/",
+  "venv/",
+
+  // Go / JVM / other
+  "vendor/",
+  "out/",
+  "*.class",
+
+  // Generic caches / temp
+  ".cache/",
+  "tmp/",
+  ".tmp/",
+
+  // HQ sync internal state (never round-trip these)
   "*.pid",
   ".hq-sync.pid",
   ".hq-sync-journal.json",
   ".hq-sync-state.json",
   "modules.lock",
+
+  // HQ repos directory (managed separately, not synced)
   "repos/",
+
+  // Secrets / env
   ".env",
   ".env.*",
 ];
 
+function readIgnoreFile(filePath: string): string | null {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
 export function createIgnoreFilter(hqRoot: string): (filePath: string) => boolean {
   const ig = ignore();
 
-  // Add defaults
+  // Layer 1: baseline defaults
   ig.add(DEFAULT_IGNORES);
 
-  // Read .hqsyncignore if it exists
-  const ignorePath = path.join(hqRoot, ".hqsyncignore");
-  if (fs.existsSync(ignorePath)) {
-    const content = fs.readFileSync(ignorePath, "utf-8");
-    ig.add(content);
-  }
+  // Layer 2: repo's .gitignore (common case — covers most build dirs already)
+  const gitignore = readIgnoreFile(path.join(hqRoot, ".gitignore"));
+  if (gitignore) ig.add(gitignore);
+
+  // Layer 3: sync-specific overrides. .hqignore is the documented name;
+  // .hqsyncignore is the legacy name we still honor.
+  const hqignore =
+    readIgnoreFile(path.join(hqRoot, ".hqignore")) ??
+    readIgnoreFile(path.join(hqRoot, ".hqsyncignore"));
+  if (hqignore) ig.add(hqignore);
 
   return (filePath: string): boolean => {
     const relative = path.relative(hqRoot, filePath);

--- a/packages/hq-cloud/src/index.ts
+++ b/packages/hq-cloud/src/index.ts
@@ -90,7 +90,68 @@ export async function getStatus(hqRoot: string): Promise<SyncStatus> {
 }
 
 /**
- * Force push all local files to S3
+ * Classify a sync error into a user-friendly top-line message.
+ *
+ * The common failure modes all surface through the AWS SDK or Node's fetch,
+ * with messages that aren't self-explanatory in a CLI ("fetch failed" for a
+ * push operation is especially confusing). This maps the raw error to a
+ * single actionable hint.
+ */
+function classifySyncError(err: unknown): Error {
+  const raw = err instanceof Error ? err : new Error(String(err));
+  const msg = raw.message.toLowerCase();
+  const name = (raw.name || "").toLowerCase();
+
+  let hint: string;
+  if (
+    msg.includes("not authenticated") ||
+    msg.includes("run 'hq sync init'") ||
+    msg.includes("run `hq login`")
+  ) {
+    hint = "Not authenticated. Run `hq login` (or `hq sync init`) first.";
+  } else if (
+    msg.includes("fetch failed") ||
+    msg.includes("econnrefused") ||
+    msg.includes("enotfound") ||
+    msg.includes("unrecognized name") ||
+    msg.includes("network") ||
+    name.includes("fetcherror")
+  ) {
+    hint =
+      "Can't reach HQ cloud (network error). Check your connection, then run `hq login` to refresh credentials.";
+  } else if (
+    msg.includes("expiredtoken") ||
+    msg.includes("invalidaccesskeyid") ||
+    msg.includes("signaturedoesnotmatch") ||
+    msg.includes("401")
+  ) {
+    hint =
+      "HQ cloud credentials expired or invalid. Run `hq login` to sign in again.";
+  } else if (
+    msg.includes("nosuchbucket") ||
+    msg.includes("bucket") && msg.includes("not")
+  ) {
+    hint = "Cloud storage bucket not configured. Run `hq sync init` to provision.";
+  } else if (msg.includes("accessdenied") || msg.includes("403")) {
+    hint = "Permission denied by HQ cloud. Check your account with `hq whoami`.";
+  } else {
+    hint = `Sync failed: ${raw.message}`;
+  }
+
+  const wrapped = new Error(hint);
+  (wrapped as Error & { cause?: unknown }).cause = raw;
+  return wrapped;
+}
+
+// Abort a push/pull loop after this many back-to-back identical failures.
+// Prevents the "525 fetch failed lines" output when auth/network is dead.
+const MAX_CONSECUTIVE_IDENTICAL_FAILURES = 3;
+
+/**
+ * Force push all local files to S3.
+ *
+ * Runs a pre-flight (`listRemoteFiles`) to surface auth/network errors once
+ * instead of per-file, and aborts mid-loop if the same error repeats.
  */
 export async function pushAll(hqRoot: string): Promise<PushResult> {
   const shouldSync = createIgnoreFilter(hqRoot);
@@ -98,7 +159,18 @@ export async function pushAll(hqRoot: string): Promise<PushResult> {
   let filesUploaded = 0;
   let bytesUploaded = 0;
 
+  // Pre-flight: verify we can actually talk to S3 before walking the tree.
+  try {
+    await listRemoteFiles();
+  } catch (err) {
+    throw classifySyncError(err);
+  }
+
   const files = walkDir(hqRoot, hqRoot, shouldSync);
+
+  const failures: { path: string; message: string }[] = [];
+  let lastErrorMessage: string | null = null;
+  let consecutiveIdentical = 0;
 
   for (const { absolutePath, relativePath } of files) {
     if (!isWithinSizeLimit(absolutePath)) continue;
@@ -111,26 +183,60 @@ export async function pushAll(hqRoot: string): Promise<PushResult> {
       updateEntry(journal, relativePath, hash, stat.size, "up");
       filesUploaded++;
       bytesUploaded += stat.size;
+      consecutiveIdentical = 0;
     } catch (err) {
-      console.error(
-        `  Failed: ${relativePath} — ${err instanceof Error ? err.message : err}`
-      );
+      const message = err instanceof Error ? err.message : String(err);
+      failures.push({ path: relativePath, message });
+
+      if (message === lastErrorMessage) {
+        consecutiveIdentical++;
+      } else {
+        consecutiveIdentical = 1;
+        lastErrorMessage = message;
+      }
+
+      if (consecutiveIdentical >= MAX_CONSECUTIVE_IDENTICAL_FAILURES) {
+        writeJournal(hqRoot, journal);
+        const classified = classifySyncError(err);
+        throw new Error(
+          `${classified.message} (${filesUploaded} uploaded, ${failures.length} failed before abort)`
+        );
+      }
     }
   }
 
   writeJournal(hqRoot, journal);
+
+  if (failures.length > 0) {
+    console.error(
+      `  ${failures.length} file(s) failed to upload. First error: ${failures[0].message}`
+    );
+  }
+
   return { filesUploaded, bytesUploaded };
 }
 
 /**
- * Force pull all remote files to local
+ * Force pull all remote files to local.
+ *
+ * `listRemoteFiles` acts as its own pre-flight — if auth/network is dead, it
+ * throws before we touch the local filesystem.
  */
 export async function pullAll(hqRoot: string): Promise<PullResult> {
   const journal = readJournal(hqRoot);
   let filesDownloaded = 0;
   let bytesDownloaded = 0;
 
-  const remoteFiles = await listRemoteFiles();
+  let remoteFiles;
+  try {
+    remoteFiles = await listRemoteFiles();
+  } catch (err) {
+    throw classifySyncError(err);
+  }
+
+  const failures: { path: string; message: string }[] = [];
+  let lastErrorMessage: string | null = null;
+  let consecutiveIdentical = 0;
 
   for (const file of remoteFiles) {
     try {
@@ -141,14 +247,36 @@ export async function pullAll(hqRoot: string): Promise<PullResult> {
       updateEntry(journal, file.relativePath, hash, file.size, "down");
       filesDownloaded++;
       bytesDownloaded += file.size;
+      consecutiveIdentical = 0;
     } catch (err) {
-      console.error(
-        `  Failed: ${file.relativePath} — ${err instanceof Error ? err.message : err}`
-      );
+      const message = err instanceof Error ? err.message : String(err);
+      failures.push({ path: file.relativePath, message });
+
+      if (message === lastErrorMessage) {
+        consecutiveIdentical++;
+      } else {
+        consecutiveIdentical = 1;
+        lastErrorMessage = message;
+      }
+
+      if (consecutiveIdentical >= MAX_CONSECUTIVE_IDENTICAL_FAILURES) {
+        writeJournal(hqRoot, journal);
+        const classified = classifySyncError(err);
+        throw new Error(
+          `${classified.message} (${filesDownloaded} downloaded, ${failures.length} failed before abort)`
+        );
+      }
     }
   }
 
   writeJournal(hqRoot, journal);
+
+  if (failures.length > 0) {
+    console.error(
+      `  ${failures.length} file(s) failed to download. First error: ${failures[0].message}`
+    );
+  }
+
   return { filesDownloaded, bytesDownloaded };
 }
 


### PR DESCRIPTION
## Summary

- `hq sync push` now respects `.gitignore` + `.hqignore` and skips common build dirs by default (Rust `target/`, Python caches, Next/Nuxt/Vite/etc.)
- Replaces per-file "Failed: {path} — fetch failed" spam with a single classified error like `Can't reach HQ cloud — run \`hq login\``
- Pre-flights auth/network once via `listRemoteFiles()` before walking the tree, and aborts mid-loop after 3 identical back-to-back errors

## Why

While debugging hq-sync-menubar, running `hq sync push` from a project directory produced 525+ lines of `Failed: {path} — fetch failed`, because:

1. Legacy `~/.hq/credentials.json` has no `accessKeyId`, so `s3.ts#getClient` re-calls the now-deprecated `https://hq.indigoai.com/api/auth/refresh` endpoint per file (TLS SNI `unrecognized name`)
2. The walker had no knowledge of `.gitignore`, so `src-tauri/target/`, `node_modules/`, etc. were all walked

Root-cause fix for #1 (migrating `s3.ts` to Cognito) is out of scope for this PR — this change just stops the behavior from looking broken to end users, so the menubar app can ship without surfacing the spam.

## What changed

**`packages/hq-cloud/src/ignore.ts`**
- Expand `DEFAULT_IGNORES` to cover Rust/Tauri, Python, JS build tools, generic caches
- Read repo `.gitignore` at hqRoot (root-level only; not recursive)
- Accept `.hqignore` as the documented name; keep `.hqsyncignore` as legacy
- Layer order: defaults → `.gitignore` → `.hqignore` — later patterns override (so `!pattern` works as expected)

**`packages/hq-cloud/src/index.ts`**
- Add `classifySyncError()` mapping raw SDK/fetch errors to actionable hints
- `pushAll`/`pullAll` run a pre-flight `listRemoteFiles()` and `throw classifySyncError(err)` on failure
- Track consecutive identical errors; abort at `MAX_CONSECUTIVE_IDENTICAL_FAILURES = 3` (journal still written)
- Partial-failure summary: one line instead of per-file dump

## Verification

Reproducer (from a repo directory with deprecated creds):

**Before:**
```
  Failed: .claude/CLAUDE.md — fetch failed
  Failed: .gitignore — fetch failed
  Failed: src/App.svelte — fetch failed
  ... (525+ lines)
```

**After:**
```
Error: Can't reach HQ cloud (network error). Check your connection, then run \`hq login\` to refresh credentials.
```

Ignore filter verification (walking `hq-sync` repo with the new filter):
- 72 real source files would sync
- 45 directory trees now excluded: 3× `target/` nodes, 39× `node_modules/`, 1× `.git/`, 2× other `.gitignore`-listed
- Previously: all ~525 files walked

## Follow-ups (not in this PR)

- [ ] `s3.ts#getClient` still calls the deprecated `hq.indigoai.com/api/auth/refresh` endpoint — should migrate to Cognito (`getValidAccessToken`) for the real root-cause fix
- [ ] `findHqRoot()` in `hq-cli/src/utils/manifest.ts` matches any dir with a `.claude/` subdir — so running `hq sync push` from a random repo treats it as HQ root. Should require a more specific marker (e.g. `modules.yaml` + `companies/`)

## Test plan

- [x] `npm run typecheck` passes in `packages/hq-cloud`
- [x] `npm run build` passes in both `hq-cloud` and `hq-cli`
- [x] Repro command surfaces one error line instead of 525+
- [x] Ignore filter correctly excludes `target/`, `node_modules/`, `.git/`, `.gitignore`-listed paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)