### PR TITLE
feat(hq-cloud): per-company journal sharding (ADR-0001 Phase 5)

### DIFF
--- a/packages/hq-cloud/src/cli/share.test.ts
+++ b/packages/hq-cloud/src/cli/share.test.ts
@@ -61,17 +61,25 @@ function setupFetchMock() {
 
 describe("share", () => {
   let tmpDir: string;
+  let stateDir: string;
 
   beforeEach(() => {
     clearContextCache();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hq-share-test-"));
+    // Redirect per-company journal into tmp so share() doesn't write to the
+    // real ~/.hq during tests (ADR-0001 Phase 5).
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "hq-state-test-"));
+    process.env.HQ_STATE_DIR = stateDir;
     setupFetchMock();
     vi.mocked(headRemoteFile).mockResolvedValue(null);
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.HQ_STATE_DIR;
   });
 
   it("shares a single file", async () => {

--- a/packages/hq-cloud/src/cli/share.ts
+++ b/packages/hq-cloud/src/cli/share.ts
@@ -55,7 +55,7 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
   // Resolve entity context (handles STS vending + caching)
   let ctx = await resolveEntityContext(companyRef, vaultConfig);
   const shouldSync = createIgnoreFilter(hqRoot);
-  const journal = readJournal(hqRoot);
+  const journal = readJournal(ctx.slug);
 
   let filesUploaded = 0;
   let bytesUploaded = 0;
@@ -132,7 +132,7 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
     }
   }
 
-  writeJournal(hqRoot, journal);
+  writeJournal(ctx.slug, journal);
 
   return { filesUploaded, bytesUploaded, filesSkipped, aborted: false };
 }

--- a/packages/hq-cloud/src/cli/sync.test.ts
+++ b/packages/hq-cloud/src/cli/sync.test.ts
@@ -75,16 +75,27 @@ function setupFetchMock() {
 
 describe("sync", () => {
   let tmpDir: string;
+  let stateDir: string;
+  let journalPath: string;
 
   beforeEach(() => {
     clearContextCache();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hq-sync-test-"));
+    // Journal moved to ~/.hq/sync-journal.{slug}.json (ADR-0001 Phase 5).
+    // Redirect to a tmp dir via HQ_STATE_DIR so the test doesn't pollute the
+    // user's real ~/.hq. mockEntity.slug is "acme".
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "hq-state-test-"));
+    process.env.HQ_STATE_DIR = stateDir;
+    journalPath = path.join(stateDir, "sync-journal.acme.json");
     setupFetchMock();
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.HQ_STATE_DIR;
   });
 
   it("downloads remote files that don't exist locally", async () => {
@@ -122,7 +133,7 @@ describe("sync", () => {
     fs.writeFileSync(path.join(tmpDir, "docs", "handoff.md"), "local version");
 
     fs.writeFileSync(
-      path.join(tmpDir, ".hq-sync-journal.json"),
+      journalPath,
       JSON.stringify({
         version: "1",
         lastSync: new Date().toISOString(),
@@ -154,7 +165,7 @@ describe("sync", () => {
     fs.writeFileSync(path.join(tmpDir, "docs", "handoff.md"), "local version");
 
     fs.writeFileSync(
-      path.join(tmpDir, ".hq-sync-journal.json"),
+      journalPath,
       JSON.stringify({
         version: "1",
         lastSync: new Date().toISOString(),
@@ -184,7 +195,7 @@ describe("sync", () => {
     fs.writeFileSync(path.join(tmpDir, "docs", "handoff.md"), "local version");
 
     fs.writeFileSync(
-      path.join(tmpDir, ".hq-sync-journal.json"),
+      journalPath,
       JSON.stringify({
         version: "1",
         lastSync: new Date().toISOString(),

--- a/packages/hq-cloud/src/cli/sync.ts
+++ b/packages/hq-cloud/src/cli/sync.ts
@@ -75,7 +75,7 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
   // Resolve entity context
   let ctx = await resolveEntityContext(companyRef, vaultConfig);
   const shouldSync = createIgnoreFilter(hqRoot);
-  const journal = readJournal(hqRoot);
+  const journal = readJournal(ctx.slug);
 
   let filesDownloaded = 0;
   let bytesDownloaded = 0;
@@ -121,7 +121,7 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
         );
 
         if (resolution === "abort") {
-          writeJournal(hqRoot, journal);
+          writeJournal(ctx.slug, journal);
           return { filesDownloaded, bytesDownloaded, filesSkipped, conflicts, aborted: true };
         }
         if (resolution === "keep" || resolution === "skip") {
@@ -176,7 +176,7 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
     }
   }
 
-  writeJournal(hqRoot, journal);
+  writeJournal(ctx.slug, journal);
 
   return { filesDownloaded, bytesDownloaded, filesSkipped, conflicts, aborted: false };
 }

--- a/packages/hq-cloud/src/context.ts
+++ b/packages/hq-cloud/src/context.ts
@@ -52,6 +52,7 @@ export async function resolveEntityContext(
 
   const ctx: EntityContext = {
     uid: entity.uid,
+    slug: entity.slug,
     bucketName: entity.bucketName,
     region: config.region ?? "us-east-1",
     credentials: {

--- a/packages/hq-cloud/src/journal.test.ts
+++ b/packages/hq-cloud/src/journal.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Unit tests for the sync journal (ADR-0001 Phase 5).
+ *
+ * Verifies per-company isolation, HQ_STATE_DIR override, and filename
+ * sanitization — all behaviors that the pre-Phase-5 monolithic journal
+ * didn't need.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  getJournalPath,
+  getStateDir,
+  readJournal,
+  writeJournal,
+  updateEntry,
+} from "./journal.js";
+import type { SyncJournal } from "./types.js";
+
+describe("journal", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "hq-journal-test-"));
+    process.env.HQ_STATE_DIR = stateDir;
+  });
+
+  afterEach(() => {
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    delete process.env.HQ_STATE_DIR;
+  });
+
+  describe("getStateDir", () => {
+    it("honors HQ_STATE_DIR env var", () => {
+      expect(getStateDir()).toBe(stateDir);
+    });
+
+    it("falls back to ~/.hq when env var unset", () => {
+      delete process.env.HQ_STATE_DIR;
+      expect(getStateDir()).toBe(path.join(os.homedir(), ".hq"));
+    });
+  });
+
+  describe("getJournalPath", () => {
+    it("produces a per-slug filename", () => {
+      expect(getJournalPath("indigo")).toBe(
+        path.join(stateDir, "sync-journal.indigo.json"),
+      );
+    });
+
+    it("isolates different slugs into different files", () => {
+      expect(getJournalPath("indigo")).not.toBe(getJournalPath("brandstage"));
+    });
+
+    it("sanitizes path-unsafe characters", () => {
+      expect(getJournalPath("foo/bar")).toBe(
+        path.join(stateDir, "sync-journal.foo_bar.json"),
+      );
+      expect(getJournalPath("../escape")).toBe(
+        path.join(stateDir, "sync-journal.___escape.json"),
+      );
+    });
+
+    it("throws on empty slug", () => {
+      expect(() => getJournalPath("")).toThrow(/slug is required/);
+    });
+
+    it("throws on slug that sanitizes to empty", () => {
+      expect(() => getJournalPath("///")).toThrow(/empty identifier/);
+    });
+  });
+
+  describe("readJournal", () => {
+    it("returns an empty journal when the file doesn't exist", () => {
+      const j = readJournal("indigo");
+      expect(j.version).toBe("1");
+      expect(j.files).toEqual({});
+      expect(j.lastSync).toBe("");
+    });
+
+    it("reads a journal written with writeJournal", () => {
+      const original: SyncJournal = {
+        version: "1",
+        lastSync: "2026-04-19T00:00:00.000Z",
+        files: {
+          "docs/handoff.md": {
+            hash: "abc123",
+            size: 42,
+            syncedAt: "2026-04-19T00:00:00.000Z",
+            direction: "down",
+          },
+        },
+      };
+      writeJournal("indigo", original);
+      const roundTripped = readJournal("indigo");
+      expect(roundTripped).toEqual(original);
+    });
+  });
+
+  describe("writeJournal", () => {
+    it("creates the state directory if it doesn't exist", () => {
+      const nestedDir = path.join(stateDir, "nested", "deep");
+      process.env.HQ_STATE_DIR = nestedDir;
+      expect(fs.existsSync(nestedDir)).toBe(false);
+
+      writeJournal("indigo", { version: "1", lastSync: "", files: {} });
+      expect(fs.existsSync(nestedDir)).toBe(true);
+      expect(
+        fs.existsSync(path.join(nestedDir, "sync-journal.indigo.json")),
+      ).toBe(true);
+    });
+
+    it("keeps per-company journals independent", () => {
+      writeJournal("indigo", {
+        version: "1",
+        lastSync: "",
+        files: { "a.md": { hash: "1", size: 1, syncedAt: "", direction: "up" } },
+      });
+      writeJournal("brandstage", {
+        version: "1",
+        lastSync: "",
+        files: { "b.md": { hash: "2", size: 2, syncedAt: "", direction: "up" } },
+      });
+
+      const indigo = readJournal("indigo");
+      const brandstage = readJournal("brandstage");
+      expect(indigo.files).toHaveProperty("a.md");
+      expect(indigo.files).not.toHaveProperty("b.md");
+      expect(brandstage.files).toHaveProperty("b.md");
+      expect(brandstage.files).not.toHaveProperty("a.md");
+    });
+  });
+
+  describe("updateEntry", () => {
+    it("stamps lastSync and the per-file syncedAt", () => {
+      const j: SyncJournal = { version: "1", lastSync: "", files: {} };
+      updateEntry(j, "foo.md", "hash", 10, "up");
+      expect(j.files["foo.md"]?.hash).toBe("hash");
+      expect(j.files["foo.md"]?.direction).toBe("up");
+      expect(j.lastSync).not.toBe("");
+      expect(j.files["foo.md"]?.syncedAt).not.toBe("");
+    });
+  });
+});

--- a/packages/hq-cloud/src/journal.ts
+++ b/packages/hq-cloud/src/journal.ts
@@ -1,20 +1,61 @@
 /**
- * Sync journal — tracks file state for conflict detection
+ * Sync journal — tracks per-file state (hash, size, last-synced direction) so
+ * sync/share can detect local edits that would be clobbered by a blind pull.
+ *
+ * ADR-0001 Phase 5: the journal is sharded by company slug and lives in
+ * `~/.hq/`, not inside the HQ content root. One monolithic journal per HQ
+ * install conflates state across companies and forces every runner to
+ * serialize through the same file — splitting it lets `hq-sync-runner
+ * --companies` fan out without contention, and a corrupted shard only affects
+ * one company.
+ *
+ * Path: `{stateDir}/sync-journal.{slug}.json`, where `stateDir` resolves to
+ * `HQ_STATE_DIR` (if set) or `~/.hq`.
  */
 
 import * as fs from "fs";
+import * as os from "os";
 import * as path from "path";
 import * as crypto from "crypto";
 import type { SyncJournal, JournalEntry } from "./types.js";
 
-const JOURNAL_FILE = ".hq-sync-journal.json";
+const JOURNAL_FILE_PREFIX = "sync-journal.";
+const JOURNAL_FILE_SUFFIX = ".json";
 
-export function getJournalPath(hqRoot: string): string {
-  return path.join(hqRoot, JOURNAL_FILE);
+/**
+ * Where per-company journals are stored. Honors `HQ_STATE_DIR` for tests and
+ * non-standard installs; otherwise falls back to `~/.hq`.
+ */
+export function getStateDir(): string {
+  return process.env.HQ_STATE_DIR ?? path.join(os.homedir(), ".hq");
 }
 
-export function readJournal(hqRoot: string): SyncJournal {
-  const journalPath = getJournalPath(hqRoot);
+/**
+ * Filename-safe form of a slug. Slugs from vault-service are already
+ * URL-safe, but this guards against paths, dots, or anything the filesystem
+ * might interpret. Empty-or-invalid slugs throw rather than silently writing
+ * to a shared "sync-journal..json" file.
+ */
+function sanitizeSlug(slug: string): string {
+  if (!slug) {
+    throw new Error("journal: slug is required (empty or undefined)");
+  }
+  const cleaned = slug.replace(/[^a-zA-Z0-9_-]/g, "_");
+  if (!cleaned || /^[_-]+$/.test(cleaned)) {
+    throw new Error(`journal: slug "${slug}" sanitizes to an empty identifier`);
+  }
+  return cleaned;
+}
+
+export function getJournalPath(slug: string): string {
+  return path.join(
+    getStateDir(),
+    `${JOURNAL_FILE_PREFIX}${sanitizeSlug(slug)}${JOURNAL_FILE_SUFFIX}`,
+  );
+}
+
+export function readJournal(slug: string): SyncJournal {
+  const journalPath = getJournalPath(slug);
   if (fs.existsSync(journalPath)) {
     const content = fs.readFileSync(journalPath, "utf-8");
     return JSON.parse(content) as SyncJournal;
@@ -22,8 +63,9 @@ export function readJournal(hqRoot: string): SyncJournal {
   return { version: "1", lastSync: "", files: {} };
 }
 
-export function writeJournal(hqRoot: string, journal: SyncJournal): void {
-  const journalPath = getJournalPath(hqRoot);
+export function writeJournal(slug: string, journal: SyncJournal): void {
+  const journalPath = getJournalPath(slug);
+  fs.mkdirSync(path.dirname(journalPath), { recursive: true });
   fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2));
 }
 
@@ -37,7 +79,7 @@ export function updateEntry(
   relativePath: string,
   hash: string,
   size: number,
-  direction: "up" | "down"
+  direction: "up" | "down",
 ): void {
   journal.files[relativePath] = {
     hash,
@@ -50,14 +92,14 @@ export function updateEntry(
 
 export function getEntry(
   journal: SyncJournal,
-  relativePath: string
+  relativePath: string,
 ): JournalEntry | undefined {
   return journal.files[relativePath];
 }
 
 export function removeEntry(
   journal: SyncJournal,
-  relativePath: string
+  relativePath: string,
 ): void {
   delete journal.files[relativePath];
 }

--- a/packages/hq-cloud/src/types.ts
+++ b/packages/hq-cloud/src/types.ts
@@ -65,6 +65,8 @@ export interface DaemonState {
 export interface EntityContext {
   /** Entity UID (cmp_*) */
   uid: string;
+  /** Entity slug (human-readable, stable key for per-company local state). */
+  slug: string;
   /** S3 bucket name for this entity */
   bucketName: string;
   /** AWS region */

--- a/packages/hq-cloud/src/watcher.ts
+++ b/packages/hq-cloud/src/watcher.ts
@@ -98,7 +98,7 @@ export class SyncWatcher {
     const batch = new Map(this.pendingChanges);
     this.pendingChanges.clear();
 
-    const journal = readJournal(this.hqRoot);
+    const journal = readJournal(this.ctx.slug);
 
     for (const [relativePath, change] of batch) {
       try {
@@ -126,7 +126,7 @@ export class SyncWatcher {
       }
     }
 
-    writeJournal(this.hqRoot, journal);
+    writeJournal(this.ctx.slug, journal);
     this.processing = false;
 
     // Process any changes that came in while we were flushing


### PR DESCRIPTION
## Summary
- Shard sync journal per-company: `~/.hq/sync-journal.{slug}.json` instead of monolithic `{hqRoot}/.hq-sync-journal.json`
- Lets `hq-sync-runner --companies` fan out without contention; a corrupted shard only affects one company
- Adds `slug` to `EntityContext` and an `HQ_STATE_DIR` env override for tests/non-standard installs

## Changes
- `journal.ts` — `readJournal`/`writeJournal` take slug, new `getStateDir`/`getJournalPath` helpers, slug sanitization
- `types.ts` — `EntityContext.slug: string`
- `context.ts` — populate `slug` from vault entity response
- `cli/sync.ts`, `cli/share.ts`, `watcher.ts` — pass `ctx.slug` to journal APIs
- `journal.test.ts` (new) — per-slug isolation, env override, path-traversal guard
- `sync.test.ts`, `share.test.ts` — redirect to tmp `HQ_STATE_DIR`; also fixes pre-existing `vi.restoreAllMocks()` teardown that was destroying the module-level `../s3.js` mock after the first test

## Test plan
- [x] `npm test` in packages/hq-cloud — 95/95 pass (was 82/95 on main due to the pre-existing mock teardown bug)
- [x] `npm run typecheck` — clean
- [ ] Smoke: `hq-sync-runner --companies a,b` writes separate shards under `~/.hq/`
- [ ] Smoke: legacy `.hq-sync-journal.json` at hqRoot is still in ignore filter (no accidental upload on upgrade)

Thread: T-20260419-200015-handoff-adr-phase5

🤖 Generated with [Claude Code](https://claude.com/claude-code)