### PR TITLE
fix(hq-cloud): runner entrypoint check handles symlink bins

### DIFF
--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -34,6 +34,8 @@
 
 import * as os from "os";
 import * as path from "path";
+import * as fs from "fs";
+import { fileURLToPath } from "url";
 import {
   getValidAccessToken,
   VaultClient,
@@ -354,11 +356,27 @@ export async function runRunner(
 // Entrypoint — only runs when invoked directly, not when imported for tests
 // ---------------------------------------------------------------------------
 
-const isDirectInvocation =
-  import.meta.url === `file://${process.argv[1]}` ||
-  // Handle the case where the shebang'd dist file is invoked via its
-  // realpath — e.g. a pnpm `bin` symlink resolves to a node_modules path.
-  (process.argv[1] && import.meta.url.endsWith(path.basename(process.argv[1])));
+// Detect whether this module is the entry point. The obvious check
+// (`import.meta.url === file://${argv[1]}`) breaks for every real-world
+// install shape: npm-link'd binaries, global installs via Homebrew, and
+// pnpm's `node_modules/.bin` shims all leave `process.argv[1]` pointing
+// at a symlink named `hq-sync-runner` (no `.js` suffix) while
+// `import.meta.url` always resolves to the underlying `sync-runner.js`.
+//
+// Resolve both sides through realpath before comparing — that's the only
+// way to handle all symlink layouts without false negatives. If realpath
+// fails (argv[1] gone, permissions), fall through to `false` so we
+// don't run twice when imported as a library.
+const isDirectInvocation = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    const modulePath = fs.realpathSync(fileURLToPath(import.meta.url));
+    const argvPath = fs.realpathSync(process.argv[1]);
+    return modulePath === argvPath;
+  } catch {
+    return false;
+  }
+})();
 
 if (isDirectInvocation) {
   runRunner(process.argv.slice(2))


### PR DESCRIPTION
## Summary

- `hq-sync-runner` silently exited 0 with no output when invoked via its installed PATH binary (npm-link, Homebrew Node, pnpm shim — anything that leaves `argv[1]` as a symlink named `hq-sync-runner`).
- The `isDirectInvocation` check compared `import.meta.url` (always `...sync-runner.js`) against `file://${argv[1]}` (symlink path) and `path.basename()` (`hq-sync-runner`). Both checks always false → entrypoint never ran.
- Fix: resolve both sides through `fs.realpathSync` before comparing. Library-import behavior unchanged.

## Why this matters

Blocks the hq-sync menubar app (Tauri). It spawns the runner via PATH and was receiving zero events, so Sync Now silently no-op'd. With this fix the full event stream flows:
```
fanout-plan → progress* → complete → all-complete
```

## Manual smoke

```bash
# Before
$ hq-sync-runner --companies --on-conflict abort --hq-root /tmp/x
(exit 0, no stdout)

# After
$ hq-sync-runner --companies --on-conflict abort --hq-root /tmp/x
{"type":"fanout-plan","companies":[{"uid":"...","slug":"indigo"}]}
{"type":"complete","company":"indigo",...}
{"type":"all-complete",...}
(exit 0)
```

## Tests

- 95/95 existing hq-cloud tests pass (`npm test`)
- No regression test: can't spoof `process.argv[1]` for an ESM import in-process. Relying on manual smoke.

## Test plan

- [ ] CI passes
- [ ] Reviewer verifies by running `hq-sync-runner --companies --on-conflict abort --hq-root /tmp/fake` — should emit ndjson, not silent exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)