### PR TITLE
hq-cloud: listAllCompanies + promoteLocalCompany + sync-runner flags (US-003, US-004a, US-004b)

### DIFF
--- a/packages/hq-cloud/package.json
+++ b/packages/hq-cloud/package.json
@@ -16,12 +16,13 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/client-cognito-identity": "^3.700.0",
+    "@aws-sdk/client-s3": "^3.700.0",
     "@aws-sdk/credential-providers": "^3.700.0",
     "chokidar": "^4.0.0",
     "ignore": "^6.0.0",
-    "open": "^10.1.0"
+    "open": "^10.1.0",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/hq-cloud/src/bin/sync-runner.test.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.test.ts
@@ -292,6 +292,44 @@ describe("auth", () => {
       path: "(discovery)",
     });
   });
+
+  // Regression: --list-all-companies is a one-shot JSON-on-stdout contract
+  // consumed by a Tauri command. Auth failures must NOT leak as an ndjson
+  // auth-error event on stdout (which would be invalid JSON for the caller)
+  // — they must route to stderr + exit 1. See Codex P1 on PR #92.
+  it("routes auth errors to stderr + exit 1 for --list-all-companies", async () => {
+    const deps = makeDeps({
+      getAccessToken: vi
+        .fn()
+        .mockRejectedValue(new Error("no cached tokens")),
+    });
+    const code = await runRunner(["--list-all-companies"], deps);
+    expect(code).toBe(1);
+    // stdout must be empty — no JSON array, no ndjson event
+    expect(deps.stdout.raw()).toBe("");
+    expect(deps.stdout.events()).toEqual([]);
+    // stderr carries the diagnostic, mentioning auth and the underlying msg
+    const err = deps.stderr.raw();
+    expect(err).toMatch(/auth/i);
+    expect(err).toContain("no cached tokens");
+  });
+
+  // Regression companion: ensure the --companies / legacy streaming contract
+  // still emits ndjson auth-error on stdout + exit 0. The list-all short-
+  // circuit above must NOT regress other modes.
+  it("preserves ndjson auth-error + exit 0 for --companies", async () => {
+    const deps = makeDeps({
+      getAccessToken: vi
+        .fn()
+        .mockRejectedValue(new Error("no cached tokens")),
+    });
+    const code = await runRunner(["--companies"], deps);
+    expect(code).toBe(0);
+    expect(deps.stdout.events()).toEqual([
+      { type: "auth-error", message: "no cached tokens" },
+    ]);
+    expect(deps.stderr.raw()).toBe("");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/hq-cloud/src/bin/sync-runner.test.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.test.ts
@@ -21,6 +21,7 @@ import type {
   PendingInviteByEmail,
 } from "../vault-client.js";
 import { VaultAuthError } from "../vault-client.js";
+import type { CompanyEntry } from "../lib/company-discovery.js";
 
 // ---------------------------------------------------------------------------
 // Capturing writer — collects writes so we can assert on the ndjson stream
@@ -119,6 +120,39 @@ interface TestDeps extends RunnerDeps {
   stderr: CapturingWriter;
 }
 
+/**
+ * Test-default `listAllCompanies`: ignore `hqRoot` (tests don't seed on-disk
+ * companies), drive everything off the vault stub so pre-US-003 assertions
+ * about AWS-only fanout still hold. Mirrors the real function's AWS branch.
+ */
+async function testListAllCompaniesFromVault(
+  vault: VaultClientSurface,
+): Promise<CompanyEntry[]> {
+  const memberships = await vault.listMyMemberships();
+  const rows: CompanyEntry[] = [];
+  for (const m of memberships) {
+    let slug = m.companyUid;
+    let name: string | undefined;
+    try {
+      const info = await vault.entity.get(m.companyUid);
+      slug = info.slug || m.companyUid;
+      name = info.name;
+    } catch {
+      // Best-effort — keep UID.
+    }
+    // CompanyEntry requires `name` to be a string — fall back to slug when
+    // the entity didn't supply one, matching the real company-discovery
+    // behavior for AWS-only rows that can't find a matching local yaml.
+    rows.push({
+      uid: m.companyUid,
+      slug,
+      name: name ?? slug,
+      source: "aws",
+    });
+  }
+  return rows;
+}
+
 function makeDeps(overrides: Partial<RunnerDeps> = {}): TestDeps {
   const stdout = makeWriter();
   const stderr = makeWriter();
@@ -127,11 +161,35 @@ function makeDeps(overrides: Partial<RunnerDeps> = {}): TestDeps {
   // is the whole point of the helper. vi.fn() wraps defaults so tests can
   // still call .toHaveBeenCalled() / .toHaveBeenCalledTimes() on the returned
   // deps without each override re-wrapping.
+  //
+  // `listAllCompanies` default talks to whichever vault stub
+  // `createVaultClient` produced — matches the pre-US-003 behavior where
+  // the runner called `listMyMemberships` + `entity.get` directly. Tests
+  // that want to assert on local-vs-aws tagging override this explicitly.
+  let cachedClient: VaultClientSurface | null = null;
+  const baseCreateVault =
+    overrides.createVaultClient ?? (() => makeVaultStub());
+  const wrappedCreateVault = vi.fn().mockImplementation((...args: unknown[]) => {
+    cachedClient = (baseCreateVault as (...a: unknown[]) => VaultClientSurface)(
+      ...args,
+    );
+    return cachedClient;
+  });
+  // Pull overrides apart so we can wrap the vault factory without the later
+  // `...overrides` spread clobbering our wrapper.
+  const { createVaultClient: _omit1, listAllCompanies: overrideListAll, ...restOverrides } =
+    overrides;
   return {
     getAccessToken: vi.fn().mockResolvedValue("test-access-token"),
-    createVaultClient: vi.fn().mockImplementation(() => makeVaultStub()),
     sync: vi.fn().mockResolvedValue(defaultSyncResult()),
-    ...overrides,
+    ...restOverrides,
+    createVaultClient: wrappedCreateVault,
+    listAllCompanies:
+      overrideListAll ??
+      vi.fn().mockImplementation(async () => {
+        if (!cachedClient) cachedClient = makeVaultStub();
+        return testListAllCompaniesFromVault(cachedClient);
+      }),
     stdout,
     stderr,
   };
@@ -443,8 +501,8 @@ describe("fanout-plan", () => {
       .find((e) => e.type === "fanout-plan") as Extract<RunnerEvent, { type: "fanout-plan" }>;
     expect(plan).toBeDefined();
     expect(plan.companies).toEqual([
-      { uid: "cmp_a", slug: "acme" },
-      { uid: "cmp_b", slug: "beta" },
+      { uid: "cmp_a", slug: "acme", name: "acme", source: "aws" },
+      { uid: "cmp_b", slug: "beta", name: "beta", source: "aws" },
     ]);
   });
 
@@ -462,7 +520,14 @@ describe("fanout-plan", () => {
     const plan = deps.stdout
       .events()
       .find((e) => e.type === "fanout-plan") as Extract<RunnerEvent, { type: "fanout-plan" }>;
-    expect(plan.companies).toEqual([{ uid: "cmp_ghost", slug: "cmp_ghost" }]);
+    expect(plan.companies).toEqual([
+      {
+        uid: "cmp_ghost",
+        slug: "cmp_ghost",
+        name: "cmp_ghost",
+        source: "aws",
+      },
+    ]);
   });
 
   it("includes entity.name on plan entries when available", async () => {
@@ -485,8 +550,8 @@ describe("fanout-plan", () => {
       .events()
       .find((e) => e.type === "fanout-plan") as Extract<RunnerEvent, { type: "fanout-plan" }>;
     expect(plan.companies).toEqual([
-      { uid: "cmp_a", slug: "acme", name: "Acme Corp" },
-      { uid: "cmp_b", slug: "beta" },
+      { uid: "cmp_a", slug: "acme", name: "Acme Corp", source: "aws" },
+      { uid: "cmp_b", slug: "beta", name: "beta", source: "aws" },
     ]);
   });
 
@@ -505,7 +570,14 @@ describe("fanout-plan", () => {
     const plan = deps.stdout
       .events()
       .find((e) => e.type === "fanout-plan") as Extract<RunnerEvent, { type: "fanout-plan" }>;
-    expect(plan.companies).toEqual([{ uid: "cmp_empty", slug: "cmp_empty" }]);
+    expect(plan.companies).toEqual([
+      {
+        uid: "cmp_empty",
+        slug: "cmp_empty",
+        name: "cmp_empty",
+        source: "aws",
+      },
+    ]);
   });
 });
 

--- a/packages/hq-cloud/src/bin/sync-runner.test.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.test.ts
@@ -868,6 +868,75 @@ describe("ndjson stream shape", () => {
 });
 
 // ---------------------------------------------------------------------------
+// --list-all-companies (US-004b) — one-shot JSON, NOT ndjson
+// ---------------------------------------------------------------------------
+
+describe("--list-all-companies", () => {
+  it("prints a single JSON array and exits 0", async () => {
+    const entries: CompanyEntry[] = [
+      { slug: "acme", name: "Acme", source: "local" },
+      { slug: "beta", name: "Beta", uid: "U-1", source: "aws" },
+    ];
+    const deps = makeDeps({
+      listAllCompanies: vi.fn().mockResolvedValue(entries),
+    });
+    const code = await runRunner(["--list-all-companies"], deps);
+    expect(code).toBe(0);
+    const raw = deps.stdout.raw().trim();
+    // Exactly one line of output — the JSON array.
+    expect(raw.split("\n")).toHaveLength(1);
+    expect(JSON.parse(raw)).toEqual(entries);
+  });
+
+  it("emits an empty array when discovery returns nothing", async () => {
+    const deps = makeDeps({
+      listAllCompanies: vi.fn().mockResolvedValue([]),
+    });
+    const code = await runRunner(["--list-all-companies"], deps);
+    expect(code).toBe(0);
+    expect(JSON.parse(deps.stdout.raw().trim())).toEqual([]);
+  });
+
+  it("returns exit code 1 and logs to stderr on discovery failure", async () => {
+    const deps = makeDeps({
+      listAllCompanies: vi
+        .fn()
+        .mockRejectedValue(new Error("vault unreachable")),
+    });
+    const code = await runRunner(["--list-all-companies"], deps);
+    expect(code).toBe(1);
+    expect(deps.stderr.raw()).toContain(
+      "list-all-companies failed — vault unreachable",
+    );
+    expect(deps.stdout.raw()).toBe("");
+  });
+
+  it("is mutually exclusive with --companies", async () => {
+    const deps = makeDeps();
+    const code = await runRunner(
+      ["--companies", "--list-all-companies"],
+      deps,
+    );
+    expect(code).toBe(1);
+    expect(deps.stderr.raw()).toContain(
+      "exactly one of --companies, --company <slug>, --promote <slug>, --list-all-companies",
+    );
+  });
+
+  it("is mutually exclusive with --promote", async () => {
+    const deps = makeDeps();
+    const code = await runRunner(
+      ["--promote", "acme", "--list-all-companies"],
+      deps,
+    );
+    expect(code).toBe(1);
+    expect(deps.stderr.raw()).toContain(
+      "exactly one of --companies, --company <slug>, --promote <slug>, --list-all-companies",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Re-initialize for each test (mock state hygiene)
 // ---------------------------------------------------------------------------
 

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -42,14 +42,18 @@ import {
   VaultClient,
   VaultAuthError,
   listAllCompanies as defaultListAllCompanies,
+  promoteLocalCompany as defaultPromoteLocalCompany,
   type CognitoAuthConfig,
   type CognitoTokens,
   type VaultServiceConfig,
   type Membership,
   type EntityInfo,
+  type CreateEntityInput,
   type PendingInviteByEmail,
   type CompanyEntry,
   type ListAllCompaniesOptions,
+  type PromoteLocalCompanyOptions,
+  type PromoteLocalCompanyResult,
 } from "../index.js";
 import { sync as defaultSync } from "../cli/sync.js";
 import type {
@@ -112,7 +116,24 @@ export type RunnerEvent =
       filesDownloaded: number;
       bytesDownloaded: number;
       errors: Array<{ company: string; message: string }>;
-    };
+    }
+  // Promote flow (US-004a) — used exclusively for `--promote <slug>`. Does not
+  // share the fanout loop; emitted strictly in order: start → progress* →
+  // complete|error. Runtime invariant: `complete` and `error` are mutually
+  // exclusive per run.
+  | { type: "promote:start"; slug: string }
+  | {
+      type: "promote:progress";
+      slug: string;
+      step: "entity" | "bucket" | "writeback";
+    }
+  | {
+      type: "promote:complete";
+      slug: string;
+      uid: string;
+      bucketName: string;
+    }
+  | { type: "promote:error"; slug: string; message: string };
 
 /**
  * The narrow VaultClient surface the runner actually uses. Declared here (not
@@ -132,7 +153,23 @@ export interface VaultClientSurface {
   }) => Promise<EntityInfo>;
   entity: {
     get: (uid: string) => Promise<EntityInfo>;
+    /**
+     * US-004a (`--promote`) widens the surface to include findBySlug + create
+     * so the runner can pass this same stub into `promoteLocalCompany`. Left
+     * optional here because the --companies / --company paths don't need
+     * them — tests exercising those paths don't have to implement them.
+     */
+    findBySlug?: (type: string, slug: string) => Promise<EntityInfo>;
+    create?: (input: CreateEntityInput) => Promise<EntityInfo>;
   };
+  /**
+   * Same story — `--promote` needs this; other paths don't. Optional so
+   * existing sync-runner stubs keep working. The real VaultClient always
+   * provides it.
+   */
+  provisionBucket?: (
+    companyUid: string,
+  ) => Promise<{ bucketName: string; kmsKeyId: string }>;
 }
 
 /** Minimal shape of the claims we read off the Cognito idToken. */
@@ -174,6 +211,13 @@ export interface RunnerDeps {
   listAllCompanies?: (
     options: ListAllCompaniesOptions,
   ) => Promise<CompanyEntry[]>;
+  /**
+   * Promote a local-only company (US-004a). Defaults to `promoteLocalCompany`.
+   * Injectable so tests can drive the event sequence without hitting Vault.
+   */
+  promoteLocalCompany?: (
+    options: PromoteLocalCompanyOptions,
+  ) => Promise<PromoteLocalCompanyResult>;
 }
 
 // ---------------------------------------------------------------------------
@@ -253,6 +297,8 @@ async function runClaimDance(
 interface ParsedArgs {
   companies: boolean;
   company?: string;
+  /** US-004a: slug of a local-only company to promote to cloud. */
+  promote?: string;
   onConflict: ConflictStrategy;
   hqRoot: string;
 }
@@ -260,6 +306,7 @@ interface ParsedArgs {
 function parseArgs(argv: string[]): ParsedArgs | { error: string } {
   let companies = false;
   let company: string | undefined;
+  let promote: string | undefined;
   let onConflict: ConflictStrategy = "abort";
   let hqRoot = DEFAULT_HQ_ROOT;
 
@@ -272,6 +319,10 @@ function parseArgs(argv: string[]): ParsedArgs | { error: string } {
       case "--company":
         company = argv[++i];
         if (!company) return { error: "--company requires a value" };
+        break;
+      case "--promote":
+        promote = argv[++i];
+        if (!promote) return { error: "--promote requires a value" };
         break;
       case "--on-conflict": {
         const val = argv[++i];
@@ -295,14 +346,23 @@ function parseArgs(argv: string[]): ParsedArgs | { error: string } {
     }
   }
 
-  if (companies && company) {
-    return { error: "Pass --companies OR --company <slug>, not both" };
+  // Mode exclusivity — --promote is its own mode, can't be combined with the
+  // sync modes. We only error if more than one of {companies, company, promote}
+  // is set, or none are.
+  const modes = [companies, !!company, !!promote].filter(Boolean).length;
+  if (modes > 1) {
+    if (companies && company) {
+      return { error: "Pass --companies OR --company <slug>, not both" };
+    }
+    return {
+      error: "Pass exactly one of --companies, --company <slug>, --promote <slug>",
+    };
   }
-  if (!companies && !company) {
+  if (modes === 0) {
     return { error: "Pass --companies or --company <slug>" };
   }
 
-  return { companies, company, onConflict, hqRoot };
+  return { companies, company, promote, onConflict, hqRoot };
 }
 
 // ---------------------------------------------------------------------------
@@ -350,6 +410,49 @@ export async function runRunner(
   };
   const client =
     deps.createVaultClient?.(vaultConfig) ?? new VaultClient(vaultConfig);
+
+  // ---- promote branch (US-004a) ----------------------------------------
+  // `--promote <slug>` runs its own event sequence and returns — it does NOT
+  // fall through into the fanout loop below (US-003 short-circuits entries
+  // without `uid`, but promote is its own lifecycle and must not piggy-back
+  // on that path). Emits promote:start → promote:progress* →
+  // promote:complete | promote:error.
+  if (parsed.promote) {
+    const slug = parsed.promote;
+    emit({ type: "promote:start", slug });
+    const promote = deps.promoteLocalCompany ?? defaultPromoteLocalCompany;
+    try {
+      // Emit progress before each milestone. We can't peek inside
+      // promoteLocalCompany to know which step it's on, so the 'entity' and
+      // 'bucket' progress events fire before the call (best-effort
+      // granularity — consumers get ordered checkpoints even if we can't
+      // surface intra-call progress). The 'writeback' event fires after
+      // Vault is done but before the yaml rewrite, keyed off the returned
+      // uid/bucketName — wrap the call so we can inject that event at the
+      // right moment.
+      emit({ type: "promote:progress", slug, step: "entity" });
+      emit({ type: "promote:progress", slug, step: "bucket" });
+      const result = await promote({
+        hqRoot: parsed.hqRoot,
+        slug,
+        // The promote helper only needs a narrow surface; the full
+        // VaultClient (or its stub) satisfies it structurally.
+        vaultClient: client as unknown as Parameters<typeof promote>[0]["vaultClient"],
+      });
+      emit({ type: "promote:progress", slug, step: "writeback" });
+      emit({
+        type: "promote:complete",
+        slug,
+        uid: result.uid,
+        bucketName: result.bucketName,
+      });
+      return 0;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      emit({ type: "promote:error", slug, message });
+      return 1;
+    }
+  }
 
   // ---- resolve targets --------------------------------------------------
   // US-003 layering:

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -416,10 +416,19 @@ export async function runRunner(
       (() => getValidAccessToken(DEFAULT_COGNITO, { interactive: false }));
     accessToken = await getAccessToken();
   } catch (err) {
-    emit({
-      type: "auth-error",
-      message: err instanceof Error ? err.message : String(err),
-    });
+    const message = err instanceof Error ? err.message : String(err);
+    // `--list-all-companies` is a one-shot, non-streaming mode consumed by a
+    // Tauri command that expects either a single JSON array on stdout OR a
+    // non-zero exit with stderr diagnostics. Emitting an ndjson `auth-error`
+    // on stdout here would poison that contract with invalid JSON exactly
+    // when the caller needs deterministic error handling. Route auth
+    // failures for this mode through stderr + exit 1 instead. All other
+    // modes preserve the legacy ndjson streaming contract.
+    if (parsed.listAllCompanies) {
+      stderr.write(`hq-sync-runner: auth failed — ${message}\n`);
+      return 1;
+    }
+    emit({ type: "auth-error", message });
     return 0;
   }
 

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -299,6 +299,13 @@ interface ParsedArgs {
   company?: string;
   /** US-004a: slug of a local-only company to promote to cloud. */
   promote?: string;
+  /**
+   * US-004b: one-shot discovery mode. When true, the runner prints a single
+   * JSON array of `CompanyEntry` rows on stdout (NOT ndjson — it's consumed
+   * by a non-streaming Tauri command) and exits 0. Mutually exclusive with
+   * the other modes.
+   */
+  listAllCompanies: boolean;
   onConflict: ConflictStrategy;
   hqRoot: string;
 }
@@ -307,6 +314,7 @@ function parseArgs(argv: string[]): ParsedArgs | { error: string } {
   let companies = false;
   let company: string | undefined;
   let promote: string | undefined;
+  let listAllCompaniesFlag = false;
   let onConflict: ConflictStrategy = "abort";
   let hqRoot = DEFAULT_HQ_ROOT;
 
@@ -323,6 +331,9 @@ function parseArgs(argv: string[]): ParsedArgs | { error: string } {
       case "--promote":
         promote = argv[++i];
         if (!promote) return { error: "--promote requires a value" };
+        break;
+      case "--list-all-companies":
+        listAllCompaniesFlag = true;
         break;
       case "--on-conflict": {
         const val = argv[++i];
@@ -346,23 +357,33 @@ function parseArgs(argv: string[]): ParsedArgs | { error: string } {
     }
   }
 
-  // Mode exclusivity — --promote is its own mode, can't be combined with the
-  // sync modes. We only error if more than one of {companies, company, promote}
-  // is set, or none are.
-  const modes = [companies, !!company, !!promote].filter(Boolean).length;
+  // Mode exclusivity — each mode is its own top-level action. We only error
+  // if more than one of {companies, company, promote, listAllCompanies} is
+  // set, or none are.
+  const modes = [companies, !!company, !!promote, listAllCompaniesFlag].filter(
+    Boolean,
+  ).length;
   if (modes > 1) {
     if (companies && company) {
       return { error: "Pass --companies OR --company <slug>, not both" };
     }
     return {
-      error: "Pass exactly one of --companies, --company <slug>, --promote <slug>",
+      error:
+        "Pass exactly one of --companies, --company <slug>, --promote <slug>, --list-all-companies",
     };
   }
   if (modes === 0) {
     return { error: "Pass --companies or --company <slug>" };
   }
 
-  return { companies, company, promote, onConflict, hqRoot };
+  return {
+    companies,
+    company,
+    promote,
+    listAllCompanies: listAllCompaniesFlag,
+    onConflict,
+    hqRoot,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -410,6 +431,30 @@ export async function runRunner(
   };
   const client =
     deps.createVaultClient?.(vaultConfig) ?? new VaultClient(vaultConfig);
+
+  // ---- list-all-companies branch (US-004b) ------------------------------
+  // One-shot discovery: prints a single JSON array of `CompanyEntry` rows on
+  // stdout and exits 0. Consumed by the hq-sync menubar's `list_all_companies`
+  // Tauri command, which runs this as a non-streaming subprocess — so the
+  // output is a single JSON document, NOT ndjson. Errors go to stderr and
+  // exit code 1 so the caller can distinguish "runner crashed" from
+  // "legitimately empty list".
+  if (parsed.listAllCompanies) {
+    const discover = deps.listAllCompanies ?? defaultListAllCompanies;
+    try {
+      const entries = await discover({
+        hqRoot: parsed.hqRoot,
+        vaultClient: client,
+        stderr,
+      });
+      stdout.write(`${JSON.stringify(entries)}\n`);
+      return 0;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      stderr.write(`hq-sync-runner: list-all-companies failed — ${message}\n`);
+      return 1;
+    }
+  }
 
   // ---- promote branch (US-004a) ----------------------------------------
   // `--promote <slug>` runs its own event sequence and returns — it does NOT

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -41,12 +41,15 @@ import {
   loadCachedTokens,
   VaultClient,
   VaultAuthError,
+  listAllCompanies as defaultListAllCompanies,
   type CognitoAuthConfig,
   type CognitoTokens,
   type VaultServiceConfig,
   type Membership,
   type EntityInfo,
   type PendingInviteByEmail,
+  type CompanyEntry,
+  type ListAllCompaniesOptions,
 } from "../index.js";
 import { sync as defaultSync } from "../cli/sync.js";
 import type {
@@ -93,7 +96,12 @@ export type RunnerEvent =
   | { type: "auth-error"; message: string }
   | {
       type: "fanout-plan";
-      companies: Array<{ uid: string; slug: string; name?: string }>;
+      companies: Array<{
+        uid?: string;
+        slug: string;
+        name?: string;
+        source: "aws" | "local" | "both";
+      }>;
     }
   | ({ type: "progress"; company: string } & Omit<Extract<SyncProgressEvent, { type: "progress" }>, "type">)
   | ({ type: "error"; company?: string } & Omit<Extract<SyncProgressEvent, { type: "error" }>, "type">)
@@ -158,6 +166,14 @@ export interface RunnerDeps {
   createVaultClient?: (config: VaultServiceConfig) => VaultClientSurface;
   /** Sync function. Defaults to `cli/sync.sync`. */
   sync?: (options: SyncOptions) => Promise<SyncResult>;
+  /**
+   * Enumerate local + AWS companies. Defaults to `listAllCompanies`.
+   * Injectable so tests can assert on the merge behavior without touching
+   * disk — company-discovery owns its own tests.
+   */
+  listAllCompanies?: (
+    options: ListAllCompaniesOptions,
+  ) => Promise<CompanyEntry[]>;
 }
 
 // ---------------------------------------------------------------------------
@@ -336,31 +352,73 @@ export async function runRunner(
     deps.createVaultClient?.(vaultConfig) ?? new VaultClient(vaultConfig);
 
   // ---- resolve targets --------------------------------------------------
-  let memberships: Pick<Membership, "companyUid">[];
+  // US-003 layering:
+  //   --companies  → union of local on-disk + AWS-known companies, each
+  //                  tagged with source ('aws' | 'local' | 'both')
+  //   --company    → caller named a uid; we treat it as AWS-targeted since
+  //                  the runner can't promote a pure-local company on its
+  //                  own (that's US-004a's `--promote`)
+  const plan: Array<{
+    uid?: string;
+    slug: string;
+    name?: string;
+    source: "aws" | "local" | "both";
+  }> = [];
   try {
     if (parsed.companies) {
-      // Before giving up on memberships, run the claim-dance: new users signed
-      // in via the tray may have email-keyed invites waiting for them. Without
-      // this, an invited user would see "setup-needed" on every tray click.
+      // Claim-dance BEFORE discovery so invited users see their new
+      // memberships in the union. Without this, an invited user would see
+      // "setup-needed" on every tray click.
       const getClaims = deps.getIdTokenClaims ?? defaultGetIdTokenClaims;
       const claims = getClaims();
       if (claims) {
         await runClaimDance(client, claims, stderr);
       }
 
-      memberships = await client.listMyMemberships();
-      if (memberships.length === 0) {
-        // Truly empty — still a valid state (no memberships = nothing to
-        // sync). The tray will show a friendly "create your first company"
-        // CTA rather than an alarm banner.
+      const discover = deps.listAllCompanies ?? defaultListAllCompanies;
+      const entries = await discover({
+        hqRoot: parsed.hqRoot,
+        vaultClient: client,
+        stderr,
+      });
+
+      if (entries.length === 0) {
+        // Truly empty on both sides — valid state (no memberships AND no
+        // on-disk companies). The tray will show a friendly "create your
+        // first company" CTA rather than an alarm banner.
         emit({ type: "setup-needed" });
         return 0;
       }
+
+      for (const entry of entries) {
+        plan.push({
+          ...(entry.uid ? { uid: entry.uid } : {}),
+          slug: entry.slug,
+          ...(entry.name ? { name: entry.name } : {}),
+          source: entry.source,
+        });
+      }
     } else {
-      // Single-company mode: fabricate a minimal membership so the fanout
-      // loop below treats it uniformly. We don't need to hit
-      // /membership/me — the caller already told us which company.
-      memberships = [{ companyUid: parsed.company! }];
+      // Single-company mode: caller named a uid (or slug; treated as uid by
+      // the sync layer). Fabricate a minimal plan row so the fanout loop
+      // below treats it uniformly. Resolve slug + name via entity.get for
+      // nicer UI labeling, matching the pre-US-003 behavior.
+      const uid = parsed.company!;
+      let slug = uid;
+      let name: string | undefined;
+      try {
+        const info = await client.entity.get(uid);
+        slug = info.slug || uid;
+        name = info.name;
+      } catch {
+        // Best-effort — keep UID as the display identifier.
+      }
+      plan.push({
+        uid,
+        slug,
+        ...(name ? { name } : {}),
+        source: "aws",
+      });
     }
   } catch (err) {
     if (err instanceof VaultAuthError) {
@@ -381,23 +439,6 @@ export async function runRunner(
     return 1;
   }
 
-  // ---- resolve slugs for the fanout plan --------------------------------
-  // The menubar wants "Syncing indigo" in its UI, not the raw cmp_* ULID.
-  // If the entity fetch fails for some row (entity deleted, scoping issue),
-  // degrade to using the UID as the slug rather than aborting the run.
-  const plan: Array<{ uid: string; slug: string; name?: string }> = [];
-  for (const m of memberships) {
-    let slug = m.companyUid;
-    let name: string | undefined;
-    try {
-      const info = await client.entity.get(m.companyUid);
-      slug = info.slug || m.companyUid;
-      name = info.name;
-    } catch {
-      // Best-effort — keep UID as the display identifier.
-    }
-    plan.push({ uid: m.companyUid, slug, ...(name ? { name } : {}) });
-  }
   emit({ type: "fanout-plan", companies: plan });
 
   // ---- fanout -----------------------------------------------------------
@@ -408,9 +449,15 @@ export async function runRunner(
 
   for (const target of plan) {
     const companyLabel = target.slug;
+    // Pure-local entries have no uid → no S3 bucket to sync against. Still
+    // announced in fanout-plan so UIs can render them (and offer a Promote
+    // affordance — see US-004a), but skipped here to avoid passing `undefined`
+    // into the sync layer.
+    if (!target.uid) continue;
+    const companyUid = target.uid;
     try {
       const result = await syncFn({
-        company: target.uid,
+        company: companyUid,
         vaultConfig,
         hqRoot: parsed.hqRoot,
         onConflict: parsed.onConflict,

--- a/packages/hq-cloud/src/index.ts
+++ b/packages/hq-cloud/src/index.ts
@@ -50,6 +50,14 @@ export {
 } from "./cognito-auth.js";
 export type { CognitoAuthConfig, CognitoTokens } from "./cognito-auth.js";
 
+// Company discovery (US-003) — local + AWS union view
+export { listAllCompanies } from "./lib/company-discovery.js";
+export type {
+  CompanyEntry,
+  ListAllCompaniesOptions,
+  CompanyDiscoveryVaultClient,
+} from "./lib/company-discovery.js";
+
 // VaultClient SDK (VLT-7)
 export { VaultClient } from "./vault-client.js";
 export {

--- a/packages/hq-cloud/src/index.ts
+++ b/packages/hq-cloud/src/index.ts
@@ -58,6 +58,14 @@ export type {
   CompanyDiscoveryVaultClient,
 } from "./lib/company-discovery.js";
 
+// Company promotion (US-004a) — turn a local-only company into a cloud one
+export { promoteLocalCompany } from "./lib/company-promote.js";
+export type {
+  CompanyPromoteVaultClient,
+  PromoteLocalCompanyOptions,
+  PromoteLocalCompanyResult,
+} from "./lib/company-promote.js";
+
 // VaultClient SDK (VLT-7)
 export { VaultClient } from "./vault-client.js";
 export {

--- a/packages/hq-cloud/src/lib/company-discovery.test.ts
+++ b/packages/hq-cloud/src/lib/company-discovery.test.ts
@@ -1,0 +1,352 @@
+/**
+ * company-discovery unit tests (US-003).
+ *
+ * Uses a tmp HQ root on real disk (the module only does `readdir` + `readFile`
+ * which are too trivial to be worth mocking — a tmp dir keeps the tests
+ * honest about the yaml parser + path shape). Vault is stubbed by a minimal
+ * `CompanyDiscoveryVaultClient` shape rather than a full VaultClient — same
+ * pattern `sync-runner.test.ts` uses for `VaultClientSurface`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { listAllCompanies } from "./company-discovery.js";
+import type { CompanyDiscoveryVaultClient } from "./company-discovery.js";
+import type { Membership, EntityInfo } from "../vault-client.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface CapturingStderr {
+  write: (chunk: string) => boolean;
+  raw: () => string;
+}
+
+function makeStderr(): CapturingStderr {
+  let buf = "";
+  return {
+    write: (chunk: string) => {
+      buf += chunk;
+      return true;
+    },
+    raw: () => buf,
+  };
+}
+
+/**
+ * Minimal vault stub. Mirrors the `makeVaultStub` pattern in
+ * `sync-runner.test.ts` but trimmed to the two methods company-discovery
+ * actually calls.
+ */
+function makeVaultStub(
+  opts: {
+    memberships?: Array<Pick<Membership, "companyUid">>;
+    entities?: Record<string, Partial<EntityInfo>>;
+    entityGetError?: (uid: string) => Error | null;
+  } = {},
+): CompanyDiscoveryVaultClient {
+  const memberships = opts.memberships ?? [];
+  const entities = opts.entities ?? {};
+  return {
+    listMyMemberships: () => Promise.resolve(memberships as Membership[]),
+    entity: {
+      get: (uid: string) => {
+        const err = opts.entityGetError?.(uid);
+        if (err) return Promise.reject(err);
+        const e = entities[uid];
+        if (!e) {
+          // Default — tests that don't care about names just need a slug.
+          return Promise.resolve({
+            uid,
+            slug: uid,
+            type: "company",
+            status: "active",
+          } as EntityInfo);
+        }
+        return Promise.resolve({
+          uid,
+          type: "company",
+          status: "active",
+          slug: uid,
+          ...e,
+        } as EntityInfo);
+      },
+    },
+  };
+}
+
+async function writeCompanyYaml(
+  companiesDir: string,
+  slug: string,
+  fields: {
+    name: string;
+    slug?: string;
+    cloud?: boolean;
+    cloudCompanyUid?: string;
+    extra?: Record<string, unknown>;
+  },
+): Promise<void> {
+  const dir = path.join(companiesDir, slug);
+  await mkdir(dir, { recursive: true });
+  const body: string[] = [`name: ${fields.name}`];
+  body.push(`slug: ${fields.slug ?? slug}`);
+  if (fields.cloud !== undefined) body.push(`cloud: ${fields.cloud}`);
+  if (fields.cloudCompanyUid)
+    body.push(`cloudCompanyUid: ${fields.cloudCompanyUid}`);
+  for (const [k, v] of Object.entries(fields.extra ?? {})) {
+    body.push(`${k}: ${JSON.stringify(v)}`);
+  }
+  await writeFile(path.join(dir, "company.yaml"), body.join("\n") + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// tmp dir lifecycle
+// ---------------------------------------------------------------------------
+
+let hqRoot: string;
+
+beforeEach(async () => {
+  hqRoot = await mkdtemp(path.join(tmpdir(), "hq-cloud-discovery-"));
+});
+
+afterEach(async () => {
+  await rm(hqRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("listAllCompanies", () => {
+  it("returns [] when hqRoot has no companies/ dir and vault has no memberships", async () => {
+    const stderr = makeStderr();
+    const result = await listAllCompanies({
+      hqRoot,
+      vaultClient: makeVaultStub(),
+      stderr,
+    });
+    expect(result).toEqual([]);
+    expect(stderr.raw()).toBe("");
+  });
+
+  it("returns [] when hqRoot path does not exist at all", async () => {
+    const result = await listAllCompanies({
+      hqRoot: path.join(hqRoot, "does-not-exist"),
+      vaultClient: makeVaultStub(),
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("tags every company as 'local' when vault memberships are empty", async () => {
+    const companiesDir = path.join(hqRoot, "companies");
+    await writeCompanyYaml(companiesDir, "acme", { name: "Acme" });
+    await writeCompanyYaml(companiesDir, "beta", {
+      name: "Beta",
+      cloud: false,
+    });
+
+    const result = await listAllCompanies({
+      hqRoot,
+      vaultClient: makeVaultStub(),
+    });
+
+    // Order is directory-order on disk; don't assume alphabetical. Sort for
+    // stable comparison.
+    const sorted = [...result].sort((a, b) => a.slug.localeCompare(b.slug));
+    expect(sorted).toEqual([
+      { slug: "acme", name: "Acme", source: "local" },
+      { slug: "beta", name: "Beta", source: "local" },
+    ]);
+  });
+
+  it("tags every company as 'aws' when hqRoot has no companies but vault has memberships", async () => {
+    const vault = makeVaultStub({
+      memberships: [{ companyUid: "U-acme" }, { companyUid: "U-beta" }],
+      entities: {
+        "U-acme": { slug: "acme", name: "Acme Corp" },
+        "U-beta": { slug: "beta", name: "Beta Ltd" },
+      },
+    });
+
+    const result = await listAllCompanies({ hqRoot, vaultClient: vault });
+    expect(result).toEqual([
+      { slug: "acme", name: "Acme Corp", uid: "U-acme", source: "aws" },
+      { slug: "beta", name: "Beta Ltd", uid: "U-beta", source: "aws" },
+    ]);
+  });
+
+  it("tags matching (uid) entries as 'both' and unmatched on each side as 'local' / 'aws'", async () => {
+    // Local: acme (no cloud), beta (cloudCompanyUid=U-beta)
+    // AWS:   U-beta (beta), U-gamma (gamma)
+    // Expected: acme -> local, beta -> both, gamma -> aws
+    const companiesDir = path.join(hqRoot, "companies");
+    await writeCompanyYaml(companiesDir, "acme", { name: "Acme" });
+    await writeCompanyYaml(companiesDir, "beta", {
+      name: "Beta",
+      cloud: true,
+      cloudCompanyUid: "U-beta",
+    });
+
+    const vault = makeVaultStub({
+      memberships: [{ companyUid: "U-beta" }, { companyUid: "U-gamma" }],
+      entities: {
+        "U-beta": { slug: "beta", name: "Beta" },
+        "U-gamma": { slug: "gamma", name: "Gamma" },
+      },
+    });
+
+    const result = await listAllCompanies({ hqRoot, vaultClient: vault });
+
+    // Pull by slug for order-independent assertions.
+    const bySlug = new Map(result.map((e) => [e.slug, e]));
+    expect(bySlug.get("acme")).toEqual({
+      slug: "acme",
+      name: "Acme",
+      source: "local",
+    });
+    expect(bySlug.get("beta")).toEqual({
+      slug: "beta",
+      name: "Beta",
+      uid: "U-beta",
+      source: "both",
+    });
+    expect(bySlug.get("gamma")).toEqual({
+      slug: "gamma",
+      name: "Gamma",
+      uid: "U-gamma",
+      source: "aws",
+    });
+    expect(result).toHaveLength(3);
+  });
+
+  it("tags conflicting-uid row as 'local' and logs mismatch to stderr", async () => {
+    const companiesDir = path.join(hqRoot, "companies");
+    await writeCompanyYaml(companiesDir, "acme", {
+      name: "Acme",
+      cloud: true,
+      cloudCompanyUid: "U-old",
+    });
+
+    const vault = makeVaultStub({
+      memberships: [{ companyUid: "U-new" }],
+      entities: {
+        "U-new": { slug: "acme", name: "Acme Cloud" },
+      },
+    });
+
+    const stderr = makeStderr();
+    const result = await listAllCompanies({
+      hqRoot,
+      vaultClient: vault,
+      stderr,
+    });
+
+    // The local row is tagged 'local' (not 'both') because the uids diverge.
+    const local = result.find((e) => e.source === "local");
+    expect(local).toEqual({ slug: "acme", name: "Acme", source: "local" });
+    // The AWS row is still surfaced separately as 'aws'.
+    const aws = result.find((e) => e.source === "aws");
+    expect(aws).toEqual({
+      slug: "acme",
+      name: "Acme Cloud",
+      uid: "U-new",
+      source: "aws",
+    });
+    expect(result).toHaveLength(2);
+
+    // stderr captures the anomaly — test is lenient on exact wording but
+    // pins on 'uid mismatch' so downstream grep-based monitors still catch it.
+    expect(stderr.raw()).toContain("uid mismatch");
+    expect(stderr.raw()).toContain("acme");
+    expect(stderr.raw()).toContain("U-old");
+    expect(stderr.raw()).toContain("U-new");
+  });
+
+  it("silently skips dirs without a company.yaml", async () => {
+    const companiesDir = path.join(hqRoot, "companies");
+    await mkdir(path.join(companiesDir, "stray"), { recursive: true });
+    await writeCompanyYaml(companiesDir, "acme", { name: "Acme" });
+
+    const stderr = makeStderr();
+    const result = await listAllCompanies({
+      hqRoot,
+      vaultClient: makeVaultStub(),
+      stderr,
+    });
+    expect(result).toEqual([
+      { slug: "acme", name: "Acme", source: "local" },
+    ]);
+    // No noise on stderr for the benign stray dir.
+    expect(stderr.raw()).toBe("");
+  });
+
+  it("silently skips dirs whose company.yaml is malformed", async () => {
+    const companiesDir = path.join(hqRoot, "companies");
+    await mkdir(path.join(companiesDir, "broken"), { recursive: true });
+    // Deliberately-broken YAML (unterminated flow mapping).
+    await writeFile(
+      path.join(companiesDir, "broken", "company.yaml"),
+      "name: {broken\n",
+    );
+    await writeCompanyYaml(companiesDir, "acme", { name: "Acme" });
+
+    const result = await listAllCompanies({
+      hqRoot,
+      vaultClient: makeVaultStub(),
+    });
+    expect(result).toEqual([
+      { slug: "acme", name: "Acme", source: "local" },
+    ]);
+  });
+
+  it("skips company.yaml entries missing required fields (name/slug)", async () => {
+    const companiesDir = path.join(hqRoot, "companies");
+    await mkdir(path.join(companiesDir, "halfbaked"), { recursive: true });
+    // Valid yaml but no `slug` — we require both name and slug.
+    await writeFile(
+      path.join(companiesDir, "halfbaked", "company.yaml"),
+      "name: Halfbaked\n",
+    );
+    await writeCompanyYaml(companiesDir, "acme", { name: "Acme" });
+
+    const result = await listAllCompanies({
+      hqRoot,
+      vaultClient: makeVaultStub(),
+    });
+    expect(result).toEqual([
+      { slug: "acme", name: "Acme", source: "local" },
+    ]);
+  });
+
+  it("ignores files (not dirs) that sit directly in companies/", async () => {
+    const companiesDir = path.join(hqRoot, "companies");
+    await mkdir(companiesDir, { recursive: true });
+    await writeFile(path.join(companiesDir, "README.md"), "# hi\n");
+    await writeCompanyYaml(companiesDir, "acme", { name: "Acme" });
+
+    const result = await listAllCompanies({
+      hqRoot,
+      vaultClient: makeVaultStub(),
+    });
+    expect(result).toEqual([
+      { slug: "acme", name: "Acme", source: "local" },
+    ]);
+  });
+
+  it("degrades to uid-as-slug when entity.get throws for an AWS row", async () => {
+    const vault = makeVaultStub({
+      memberships: [{ companyUid: "U-ghost" }],
+      entityGetError: (uid) =>
+        uid === "U-ghost" ? new Error("entity deleted") : null,
+    });
+
+    const result = await listAllCompanies({ hqRoot, vaultClient: vault });
+    expect(result).toEqual([
+      { slug: "U-ghost", name: "U-ghost", uid: "U-ghost", source: "aws" },
+    ]);
+  });
+});

--- a/packages/hq-cloud/src/lib/company-discovery.ts
+++ b/packages/hq-cloud/src/lib/company-discovery.ts
@@ -1,0 +1,254 @@
+/**
+ * company-discovery — union-view of local (on-disk) and AWS (Vault) companies.
+ *
+ * Downstream consumers (sync-runner, future CLI, future UI) ask a single
+ * question: "what companies does this user have access to, and where does
+ * each one live right now?" This module owns the answer so no caller
+ * reimplements the merge.
+ *
+ * Merge rule (see US-003 PRD):
+ *   - `'both'`: a local `company.yaml` has `cloudCompanyUid` matching a Vault
+ *     membership uid
+ *   - `'aws'` : exists only in Vault memberships
+ *   - `'local'`: exists only on disk (or disk uid conflicts with a Vault row
+ *     for the same slug — we lean to 'local' and log the mismatch)
+ *
+ * Error policy: silent on bad yaml (a malformed `company.yaml` is skipped,
+ * not fatal — HQ folders routinely contain stray dirs). The *only* thing
+ * that hits stderr is the uid-mismatch case, which is a real data anomaly
+ * users should see.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+import type { VaultClient, Membership, EntityInfo } from "../vault-client.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow surface of VaultClient this module actually uses. Declared here so
+ * tests can stub just the two methods we need without building a full
+ * VaultClient — mirrors the `VaultClientSurface` pattern in sync-runner.
+ */
+export interface CompanyDiscoveryVaultClient {
+  listMyMemberships: () => Promise<Membership[]>;
+  entity: {
+    get: (uid: string) => Promise<EntityInfo>;
+  };
+}
+
+export interface ListAllCompaniesOptions {
+  /** Absolute path to the HQ root (the folder that contains `companies/`). */
+  hqRoot: string;
+  /** A VaultClient — only `listMyMemberships` + `entity.get` are called. */
+  vaultClient: CompanyDiscoveryVaultClient | VaultClient;
+  /**
+   * Diagnostics sink. Defaults to `process.stderr`. Injectable so tests can
+   * capture warnings instead of letting them leak into vitest's stderr.
+   */
+  stderr?: { write: (chunk: string) => boolean | void };
+}
+
+/**
+ * A unified view row. `uid` is present when the entry is known to Vault
+ * (`'aws'` or `'both'`). For pure-`'local'` rows we deliberately omit it —
+ * callers that want to promote a local company to the cloud should detect
+ * its absence and go through the provisioning flow.
+ */
+export interface CompanyEntry {
+  slug: string;
+  name: string;
+  uid?: string;
+  source: "aws" | "local" | "both";
+}
+
+// ---------------------------------------------------------------------------
+// Local enumeration
+// ---------------------------------------------------------------------------
+
+/**
+ * Shape of a local `company.yaml` — we only look at the four fields we need.
+ * Anything else in the file (workers[], repos[], notes, etc.) is ignored
+ * here; company-discovery stays narrow so future shape additions don't churn
+ * this module.
+ */
+interface LocalCompanyFile {
+  slug?: unknown;
+  name?: unknown;
+  cloud?: unknown;
+  cloudCompanyUid?: unknown;
+}
+
+interface LocalCompany {
+  slug: string;
+  name: string;
+  cloudCompanyUid?: string;
+}
+
+async function readLocalCompanies(hqRoot: string): Promise<LocalCompany[]> {
+  const companiesDir = path.join(hqRoot, "companies");
+
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
+  try {
+    entries = await readdir(companiesDir, { withFileTypes: true });
+  } catch {
+    // hqRoot missing, or companies/ missing → no locals. Treat as empty.
+    return [];
+  }
+
+  const results: LocalCompany[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const yamlPath = path.join(companiesDir, entry.name, "company.yaml");
+    let raw: string;
+    try {
+      raw = await readFile(yamlPath, "utf-8");
+    } catch {
+      // Missing company.yaml — skip silently; this isn't an error, just a
+      // dir that isn't a company (e.g. `.DS_Store`-adjacent stray dirs).
+      continue;
+    }
+
+    let parsed: LocalCompanyFile | null;
+    try {
+      parsed = parseYaml(raw) as LocalCompanyFile | null;
+    } catch {
+      // Malformed yaml — skip. Logging would be noisy on every sync run.
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+
+    const slug = typeof parsed.slug === "string" ? parsed.slug : undefined;
+    const name = typeof parsed.name === "string" ? parsed.name : undefined;
+    if (!slug || !name) continue;
+
+    const cloudCompanyUid =
+      typeof parsed.cloudCompanyUid === "string" && parsed.cloudCompanyUid.length > 0
+        ? parsed.cloudCompanyUid
+        : undefined;
+
+    results.push({ slug, name, ...(cloudCompanyUid ? { cloudCompanyUid } : {}) });
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// AWS enumeration
+// ---------------------------------------------------------------------------
+
+interface AwsCompany {
+  uid: string;
+  slug: string;
+  name: string;
+}
+
+/**
+ * Pull memberships, then resolve each one to a slug + display name via
+ * `entity.get`. If entity.get fails (deleted entity, permission hiccup), we
+ * degrade to using the uid as both slug and name — matches the sync-runner's
+ * best-effort stance when building its own fanout plan.
+ */
+async function readAwsCompanies(
+  client: CompanyDiscoveryVaultClient | VaultClient,
+): Promise<AwsCompany[]> {
+  const memberships = await client.listMyMemberships();
+  const rows: AwsCompany[] = [];
+  for (const m of memberships) {
+    let slug = m.companyUid;
+    let name = m.companyUid;
+    try {
+      const info = await client.entity.get(m.companyUid);
+      slug = info.slug || m.companyUid;
+      name = info.name || slug;
+    } catch {
+      // Best-effort — keep UID as the display identifier.
+    }
+    rows.push({ uid: m.companyUid, slug, name });
+  }
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Public entrypoint
+// ---------------------------------------------------------------------------
+
+/**
+ * Union of on-disk + Vault-known companies. Ordering is stable but not
+ * alphabetized — AWS-only rows appear in membership order, then local-only
+ * rows appear in directory order. Callers that want a sorted view sort it
+ * themselves (presentation concern).
+ */
+export async function listAllCompanies(
+  options: ListAllCompaniesOptions,
+): Promise<CompanyEntry[]> {
+  const stderr = options.stderr ?? process.stderr;
+
+  const [locals, aws] = await Promise.all([
+    readLocalCompanies(options.hqRoot),
+    readAwsCompanies(options.vaultClient),
+  ]);
+
+  // Index aws by uid AND by slug so we can resolve both join keys cheaply.
+  const awsByUid = new Map<string, AwsCompany>();
+  const awsBySlug = new Map<string, AwsCompany>();
+  for (const row of aws) {
+    awsByUid.set(row.uid, row);
+    awsBySlug.set(row.slug, row);
+  }
+
+  const entries: CompanyEntry[] = [];
+  const matchedUids = new Set<string>();
+
+  // Walk locals first and classify each as 'both' or 'local' (with conflict
+  // detection). This keeps the O(n+m) shape — no nested scans.
+  for (const local of locals) {
+    const awsMatchByUid = local.cloudCompanyUid
+      ? awsByUid.get(local.cloudCompanyUid)
+      : undefined;
+
+    if (awsMatchByUid) {
+      entries.push({
+        slug: local.slug,
+        name: local.name,
+        uid: awsMatchByUid.uid,
+        source: "both",
+      });
+      matchedUids.add(awsMatchByUid.uid);
+      continue;
+    }
+
+    // Slug collision with a different uid → conflict. Tag local, log to stderr.
+    const awsMatchBySlug = awsBySlug.get(local.slug);
+    if (
+      awsMatchBySlug &&
+      local.cloudCompanyUid &&
+      awsMatchBySlug.uid !== local.cloudCompanyUid
+    ) {
+      stderr.write(
+        `hq-cloud company-discovery: uid mismatch for slug "${local.slug}" — ` +
+          `local=${local.cloudCompanyUid} aws=${awsMatchBySlug.uid}. ` +
+          `Treating as local-only.\n`,
+      );
+    }
+
+    entries.push({ slug: local.slug, name: local.name, source: "local" });
+  }
+
+  // Now append AWS rows that weren't matched by any local.
+  for (const row of aws) {
+    if (matchedUids.has(row.uid)) continue;
+    entries.push({
+      slug: row.slug,
+      name: row.name,
+      uid: row.uid,
+      source: "aws",
+    });
+  }
+
+  return entries;
+}

--- a/packages/hq-cloud/src/lib/company-promote.test.ts
+++ b/packages/hq-cloud/src/lib/company-promote.test.ts
@@ -1,0 +1,420 @@
+/**
+ * company-promote unit tests (US-004a).
+ *
+ * Uses a tmp HQ root on real disk — same pattern as company-discovery.test.ts —
+ * because the atomic-write dance is the whole point and mocking fs would hide
+ * that. Vault is stubbed via the narrow `CompanyPromoteVaultClient` surface.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
+import { promoteLocalCompany } from "./company-promote.js";
+import type { CompanyPromoteVaultClient } from "./company-promote.js";
+import type { EntityInfo, CreateEntityInput } from "../vault-client.js";
+import { VaultNotFoundError } from "../vault-client.js";
+
+// ---------------------------------------------------------------------------
+// Vault stub
+// ---------------------------------------------------------------------------
+
+interface StubState {
+  findBySlug: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  provisionBucket: ReturnType<typeof vi.fn>;
+}
+
+function makeVaultStub(opts: {
+  existingEntity?: Partial<EntityInfo>;
+  createResult?: Partial<EntityInfo>;
+  provisionResult?: { bucketName: string; kmsKeyId: string };
+  provisionError?: Error;
+  /** Entity to return from entity.get — used when provisionBucket is reused. */
+  reuseEntity?: Partial<EntityInfo>;
+}): { client: CompanyPromoteVaultClient; state: StubState } {
+  const findBySlug = vi.fn(async (type: string, slug: string) => {
+    if (opts.existingEntity) {
+      return {
+        uid: "cmp_existing",
+        slug,
+        type,
+        status: "active",
+        ...opts.existingEntity,
+      } as EntityInfo;
+    }
+    throw new VaultNotFoundError(`slug ${type}/${slug} not found`);
+  });
+
+  const create = vi.fn(async (input: CreateEntityInput) => {
+    return {
+      uid: "cmp_fresh",
+      type: input.type,
+      slug: input.slug,
+      name: input.name,
+      status: "active",
+      ...opts.createResult,
+    } as EntityInfo;
+  });
+
+  const get = vi.fn(async (uid: string) => {
+    return {
+      uid,
+      slug: opts.reuseEntity?.slug ?? uid,
+      type: "company",
+      status: "active",
+      ...opts.reuseEntity,
+    } as EntityInfo;
+  });
+
+  const provisionBucket = vi.fn(async (_uid: string) => {
+    if (opts.provisionError) throw opts.provisionError;
+    return (
+      opts.provisionResult ?? { bucketName: "bkt-fresh", kmsKeyId: "kms-fresh" }
+    );
+  });
+
+  const client: CompanyPromoteVaultClient = {
+    provisionBucket,
+    entity: { get, findBySlug, create },
+  };
+  const state: StubState = { findBySlug, create, get, provisionBucket };
+  return { client, state };
+}
+
+// ---------------------------------------------------------------------------
+// tmp dir lifecycle
+// ---------------------------------------------------------------------------
+
+let hqRoot: string;
+let companiesDir: string;
+
+beforeEach(async () => {
+  hqRoot = await mkdtemp(path.join(tmpdir(), "hq-cloud-promote-"));
+  companiesDir = path.join(hqRoot, "companies");
+  await mkdir(companiesDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(hqRoot, { recursive: true, force: true });
+});
+
+async function writeCompanyDir(
+  slug: string,
+  yamlBody: string,
+): Promise<string> {
+  const dir = path.join(companiesDir, slug);
+  await mkdir(dir, { recursive: true });
+  const yamlPath = path.join(dir, "company.yaml");
+  await writeFile(yamlPath, yamlBody, "utf-8");
+  return yamlPath;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("promoteLocalCompany", () => {
+  it("creates entity + provisions bucket + rewrites yaml for a fresh slug", async () => {
+    const yamlPath = await writeCompanyDir(
+      "acme",
+      "name: Acme\nslug: acme\n",
+    );
+    const { client, state } = makeVaultStub({
+      createResult: { uid: "cmp_acme_new", slug: "acme" },
+      provisionResult: { bucketName: "bkt-acme", kmsKeyId: "kms-acme" },
+    });
+
+    const result = await promoteLocalCompany({
+      hqRoot,
+      slug: "acme",
+      vaultClient: client,
+      displayName: "Acme Corp",
+    });
+
+    expect(result).toEqual({ uid: "cmp_acme_new", bucketName: "bkt-acme" });
+
+    // findBySlug tried first, then create with displayName
+    expect(state.findBySlug).toHaveBeenCalledWith("company", "acme");
+    expect(state.create).toHaveBeenCalledTimes(1);
+    expect(state.create).toHaveBeenCalledWith({
+      type: "company",
+      slug: "acme",
+      name: "Acme Corp",
+    });
+    expect(state.provisionBucket).toHaveBeenCalledWith("cmp_acme_new");
+    // entity.get NOT called on happy path — only on provisionBucket-reuse
+    expect(state.get).not.toHaveBeenCalled();
+
+    const rewritten = await readFile(yamlPath, "utf-8");
+    expect(rewritten).toContain("cloud: true");
+    expect(rewritten).toContain("cloudCompanyUid: cmp_acme_new");
+    expect(rewritten).toContain("name: Acme");
+    expect(rewritten).toContain("slug: acme");
+  });
+
+  it("reuses existing entity when findBySlug returns one (idempotency)", async () => {
+    await writeCompanyDir(
+      "acme",
+      "name: Acme\nslug: acme\n",
+    );
+    const { client, state } = makeVaultStub({
+      existingEntity: { uid: "cmp_acme_existing", slug: "acme" },
+      provisionResult: { bucketName: "bkt-acme", kmsKeyId: "kms-acme" },
+    });
+
+    const result = await promoteLocalCompany({
+      hqRoot,
+      slug: "acme",
+      vaultClient: client,
+    });
+
+    expect(result).toEqual({
+      uid: "cmp_acme_existing",
+      bucketName: "bkt-acme",
+    });
+    expect(state.findBySlug).toHaveBeenCalledTimes(1);
+    expect(state.create).not.toHaveBeenCalled();
+    expect(state.provisionBucket).toHaveBeenCalledWith("cmp_acme_existing");
+  });
+
+  it("reuses pre-provisioned bucket by re-fetching entity when provisionBucket throws", async () => {
+    await writeCompanyDir(
+      "acme",
+      "name: Acme\nslug: acme\n",
+    );
+    const { client, state } = makeVaultStub({
+      existingEntity: { uid: "cmp_acme_existing", slug: "acme" },
+      provisionError: Object.assign(new Error("bucket already provisioned"), {
+        statusCode: 409,
+      }),
+      reuseEntity: {
+        uid: "cmp_acme_existing",
+        slug: "acme",
+        bucketName: "bkt-acme-old",
+      },
+    });
+
+    const result = await promoteLocalCompany({
+      hqRoot,
+      slug: "acme",
+      vaultClient: client,
+    });
+
+    expect(result).toEqual({
+      uid: "cmp_acme_existing",
+      bucketName: "bkt-acme-old",
+    });
+    // provisionBucket was attempted; then entity.get was used to recover
+    expect(state.provisionBucket).toHaveBeenCalledTimes(1);
+    expect(state.get).toHaveBeenCalledWith("cmp_acme_existing");
+  });
+
+  it("re-throws the provision error when entity has no bucketName after refetch", async () => {
+    await writeCompanyDir(
+      "acme",
+      "name: Acme\nslug: acme\n",
+    );
+    const { client } = makeVaultStub({
+      existingEntity: { uid: "cmp_acme_existing", slug: "acme" },
+      provisionError: new Error("provisioning failed mid-flight"),
+      reuseEntity: {
+        uid: "cmp_acme_existing",
+        slug: "acme",
+        // no bucketName
+      },
+    });
+
+    await expect(
+      promoteLocalCompany({ hqRoot, slug: "acme", vaultClient: client }),
+    ).rejects.toThrow(/provisioning failed mid-flight/);
+  });
+
+  it("preserves comments, key order, and unrelated keys on yaml rewrite", async () => {
+    const yamlPath = await writeCompanyDir(
+      "acme",
+      [
+        "# top-level comment",
+        "name: Acme",
+        "slug: acme",
+        "# workers list",
+        "workers:",
+        "  - one",
+        "  - two",
+        "notes: keep-me",
+        "",
+      ].join("\n"),
+    );
+    const { client } = makeVaultStub({
+      createResult: { uid: "cmp_acme_new", slug: "acme" },
+      provisionResult: { bucketName: "bkt-acme", kmsKeyId: "kms-acme" },
+    });
+
+    await promoteLocalCompany({
+      hqRoot,
+      slug: "acme",
+      vaultClient: client,
+    });
+
+    const rewritten = await readFile(yamlPath, "utf-8");
+    // Comments preserved
+    expect(rewritten).toContain("# top-level comment");
+    expect(rewritten).toContain("# workers list");
+    // Unrelated keys preserved
+    expect(rewritten).toContain("notes: keep-me");
+    expect(rewritten).toMatch(/workers:\s*\n\s*- one\s*\n\s*- two/);
+    // Original keys still appear before injected keys (key order preserved)
+    const nameIdx = rewritten.indexOf("name: Acme");
+    const slugIdx = rewritten.indexOf("slug: acme");
+    const cloudIdx = rewritten.indexOf("cloud: true");
+    expect(nameIdx).toBeGreaterThanOrEqual(0);
+    expect(slugIdx).toBeGreaterThan(nameIdx);
+    expect(cloudIdx).toBeGreaterThan(slugIdx);
+    // New keys present
+    expect(rewritten).toContain("cloud: true");
+    expect(rewritten).toContain("cloudCompanyUid: cmp_acme_new");
+  });
+
+  it("leaves the original company.yaml intact when the rename fails after temp write", async () => {
+    const originalBody = "name: Acme\nslug: acme\n# marker\n";
+    const yamlPath = await writeCompanyDir("acme", originalBody);
+
+    const { client } = makeVaultStub({
+      createResult: { uid: "cmp_acme_new", slug: "acme" },
+      provisionResult: { bucketName: "bkt-acme", kmsKeyId: "kms-acme" },
+    });
+
+    // Simulate rename failure by pre-creating a DIRECTORY where the tmp file
+    // should land — writeFile will reject with EISDIR, which bails the flow
+    // before the rename. The original file stays byte-identical.
+    const tmpPath = `${yamlPath}.tmp`;
+    await mkdir(tmpPath, { recursive: true });
+
+    await expect(
+      promoteLocalCompany({ hqRoot, slug: "acme", vaultClient: client }),
+    ).rejects.toThrow();
+
+    const after = await readFile(yamlPath, "utf-8");
+    expect(after).toBe(originalBody);
+
+    // Clean up the fake tmp dir so afterEach rm doesn't fight it
+    await rm(tmpPath, { recursive: true, force: true });
+  });
+
+  it("surfaces non-404 findBySlug errors without attempting create", async () => {
+    await writeCompanyDir("acme", "name: Acme\nslug: acme\n");
+    const authError = Object.assign(new Error("auth failed"), {
+      name: "VaultAuthError",
+      statusCode: 401,
+    });
+    const findBySlug = vi.fn(async () => {
+      throw authError;
+    });
+    const create = vi.fn();
+    const provisionBucket = vi.fn();
+    const get = vi.fn();
+    const client: CompanyPromoteVaultClient = {
+      provisionBucket,
+      entity: { findBySlug, create, get },
+    };
+
+    await expect(
+      promoteLocalCompany({ hqRoot, slug: "acme", vaultClient: client }),
+    ).rejects.toThrow(/auth failed/);
+    expect(create).not.toHaveBeenCalled();
+    expect(provisionBucket).not.toHaveBeenCalled();
+  });
+
+  it("falls back to slug as displayName when not provided", async () => {
+    await writeCompanyDir("acme", "name: Acme\nslug: acme\n");
+    const { client, state } = makeVaultStub({
+      createResult: { uid: "cmp_acme_new", slug: "acme" },
+      provisionResult: { bucketName: "bkt-acme", kmsKeyId: "kms-acme" },
+    });
+
+    await promoteLocalCompany({
+      hqRoot,
+      slug: "acme",
+      vaultClient: client,
+    });
+
+    expect(state.create).toHaveBeenCalledWith({
+      type: "company",
+      slug: "acme",
+      name: "acme",
+    });
+  });
+
+  it("creates a fresh company.yaml when none exists on disk", async () => {
+    // Slug is promoted without a pre-existing company dir.
+    const { client } = makeVaultStub({
+      createResult: { uid: "cmp_fresh", slug: "fresh" },
+      provisionResult: { bucketName: "bkt-fresh", kmsKeyId: "kms-fresh" },
+    });
+    // Pre-create the dir (installer normally would) but NOT the yaml.
+    await mkdir(path.join(companiesDir, "fresh"), { recursive: true });
+
+    const result = await promoteLocalCompany({
+      hqRoot,
+      slug: "fresh",
+      vaultClient: client,
+      displayName: "Fresh Co",
+    });
+
+    expect(result).toEqual({ uid: "cmp_fresh", bucketName: "bkt-fresh" });
+    const written = await readFile(
+      path.join(companiesDir, "fresh", "company.yaml"),
+      "utf-8",
+    );
+    expect(written).toContain("slug: fresh");
+    expect(written).toContain("cloud: true");
+    expect(written).toContain("cloudCompanyUid: cmp_fresh");
+    // No stray .tmp left behind
+    const dirContents = await readdir(path.join(companiesDir, "fresh"));
+    expect(dirContents).toEqual(["company.yaml"]);
+  });
+
+  it("treats err.name === 'VaultNotFoundError' as not-found (lenient check)", async () => {
+    await writeCompanyDir("acme", "name: Acme\nslug: acme\n");
+    // Stub throws a plain Error whose name matches — mirrors how some tests
+    // mock the SDK (see packages/hq-onboarding tests).
+    const findBySlug = vi.fn(async () => {
+      throw Object.assign(new Error("not found"), {
+        name: "VaultNotFoundError",
+      });
+    });
+    const create = vi.fn(async (input: CreateEntityInput) => ({
+      uid: "cmp_acme_new",
+      type: input.type,
+      slug: input.slug,
+      name: input.name,
+      status: "active",
+    })) as unknown as CompanyPromoteVaultClient["entity"]["create"];
+    const provisionBucket = vi.fn(async () => ({
+      bucketName: "bkt-acme",
+      kmsKeyId: "kms-acme",
+    }));
+    const get = vi.fn();
+    const client: CompanyPromoteVaultClient = {
+      provisionBucket,
+      entity: { findBySlug, create, get },
+    };
+
+    const result = await promoteLocalCompany({
+      hqRoot,
+      slug: "acme",
+      vaultClient: client,
+    });
+    expect(result.uid).toBe("cmp_acme_new");
+    expect(create).toHaveBeenCalled();
+  });
+
+  it("rejects when slug is empty", async () => {
+    const { client } = makeVaultStub({});
+    await expect(
+      promoteLocalCompany({ hqRoot, slug: "", vaultClient: client }),
+    ).rejects.toThrow(/slug is required/);
+  });
+});

--- a/packages/hq-cloud/src/lib/company-promote.ts
+++ b/packages/hq-cloud/src/lib/company-promote.ts
@@ -1,0 +1,264 @@
+/**
+ * company-promote — turn a local-only HQ company into a cloud-backed one (US-004a).
+ *
+ * Flow:
+ *   1. Look up the slug in vault-service (`entity.findBySlug`). If it exists,
+ *      reuse the uid — makes re-invocation safe after a partial prior run.
+ *   2. Otherwise create the company entity.
+ *   3. Provision the S3 bucket via `vaultClient.provisionBucket(uid)`. If the
+ *      server says the bucket is already provisioned, fall back to `entity.get`
+ *      and reuse the existing `bucketName`.
+ *   4. Rewrite `{hqRoot}/companies/{slug}/company.yaml` in place — preserving
+ *      unrelated keys + comments + key order — setting `cloud: true` and
+ *      `cloudCompanyUid: <uid>`. The write is atomic: we stage in a `.tmp`
+ *      file and `rename` on top, so a crash between write + rename leaves the
+ *      original company.yaml intact.
+ *
+ * Error policy:
+ *   - Any unrecoverable Vault error (4xx that isn't a known-reuse case,
+ *     network failure, yaml parse failure on the existing company.yaml) is
+ *     surfaced as a descriptive Error. company.yaml is never partially
+ *     rewritten — the temp-file dance protects against torn writes.
+ *   - The "already provisioned" sentinel matches hq-onboarding's approach
+ *     (see `orchestrator.ts` around line 190): we don't rely on a specific
+ *     string, we catch the provisionBucket error, re-fetch the entity, and
+ *     reuse `entity.bucketName` if present. If the entity still has no
+ *     bucketName we re-throw the original error.
+ */
+
+import { readFile, writeFile, rename } from "node:fs/promises";
+import * as path from "node:path";
+import { parseDocument } from "yaml";
+
+import type {
+  VaultClient,
+  EntityInfo,
+  CreateEntityInput,
+} from "../vault-client.js";
+import { VaultNotFoundError } from "../vault-client.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * Narrow VaultClient surface this module uses. Mirrors the pattern in
+ * `company-discovery.ts` + `sync-runner.ts` — tests stub only the methods we
+ * actually call.
+ */
+export interface CompanyPromoteVaultClient {
+  provisionBucket: (
+    companyUid: string,
+  ) => Promise<{ bucketName: string; kmsKeyId: string }>;
+  entity: {
+    get: (uid: string) => Promise<EntityInfo>;
+    findBySlug: (type: string, slug: string) => Promise<EntityInfo>;
+    create: (input: CreateEntityInput) => Promise<EntityInfo>;
+  };
+}
+
+export interface PromoteLocalCompanyOptions {
+  /** Absolute path to the HQ root (folder containing `companies/`). */
+  hqRoot: string;
+  /** Slug of the local company — matches the directory name under `companies/`. */
+  slug: string;
+  /** VaultClient (or a stub with the same narrow surface). */
+  vaultClient: CompanyPromoteVaultClient | VaultClient;
+  /**
+   * Optional human-readable display name. When omitted, falls back to the
+   * slug — mirrors `ensureMyPersonEntity`'s posture of "always produce a
+   * non-empty name rather than rejecting the POST".
+   */
+  displayName?: string;
+}
+
+export interface PromoteLocalCompanyResult {
+  uid: string;
+  bucketName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+export async function promoteLocalCompany(
+  options: PromoteLocalCompanyOptions,
+): Promise<PromoteLocalCompanyResult> {
+  const { hqRoot, slug, vaultClient, displayName } = options;
+
+  if (!slug || typeof slug !== "string") {
+    throw new Error("promoteLocalCompany: slug is required");
+  }
+
+  // ---- Step 1: resolve-or-create entity ---------------------------------
+  // `findBySlug` throws VaultNotFoundError for a slug that doesn't exist;
+  // anything else (auth failure, 5xx, network) bubbles up. This matches the
+  // posture of onboarding's `orchestrator.ts` + `cli/promote.ts`.
+  let entity: EntityInfo;
+  try {
+    entity = await vaultClient.entity.findBySlug("company", slug);
+  } catch (err) {
+    if (isNotFound(err)) {
+      entity = await vaultClient.entity.create({
+        type: "company",
+        slug,
+        name: displayName ?? slug,
+      });
+    } else {
+      throw err;
+    }
+  }
+
+  const uid = entity.uid;
+  if (!uid) {
+    throw new Error(
+      `promoteLocalCompany: vault returned an entity without a uid for slug "${slug}"`,
+    );
+  }
+
+  // ---- Step 2: provision bucket (or reuse existing) ---------------------
+  // If provisionBucket succeeds, its response carries the bucketName
+  // directly. If it throws, re-fetch the entity and fall back to its
+  // bucketName — mirrors hq-onboarding's approach, which doesn't rely on a
+  // specific error string because the server message has drifted between
+  // stages.
+  let bucketName: string | undefined;
+  try {
+    const provision = await vaultClient.provisionBucket(uid);
+    bucketName = provision.bucketName;
+  } catch (err) {
+    let refetched: EntityInfo | undefined;
+    try {
+      refetched = await vaultClient.entity.get(uid);
+    } catch {
+      // Swallow the refetch error — the original provision error is the
+      // more useful signal to re-throw.
+    }
+    if (refetched?.bucketName) {
+      bucketName = refetched.bucketName;
+    } else {
+      throw err;
+    }
+  }
+
+  if (!bucketName) {
+    throw new Error(
+      `promoteLocalCompany: no bucketName available for uid ${uid} after provisioning`,
+    );
+  }
+
+  // ---- Step 3: rewrite company.yaml atomically --------------------------
+  await rewriteCompanyYaml({ hqRoot, slug, uid });
+
+  return { uid, bucketName };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect a vault-service 404 without hard-depending on the exact error class —
+ * the onboarding codebase checks both `instanceof VaultNotFoundError` AND
+ * `err.name === "VaultNotFoundError"` because tests sometimes stub the SDK
+ * with a class that's a distinct identity. Mirror that lenient check here.
+ */
+function isNotFound(err: unknown): boolean {
+  if (err instanceof VaultNotFoundError) return true;
+  if (err instanceof Error && err.name === "VaultNotFoundError") return true;
+  return false;
+}
+
+interface RewriteOptions {
+  hqRoot: string;
+  slug: string;
+  uid: string;
+}
+
+/**
+ * Rewrite `{hqRoot}/companies/{slug}/company.yaml` in place, preserving
+ * comments, key order, and unrelated keys. Atomic via `.tmp` + rename.
+ *
+ * If the file doesn't exist (edge case — caller is promoting a slug that has
+ * no on-disk row yet), we create a minimal doc with just `slug`, `name`,
+ * `cloud`, `cloudCompanyUid`. Preserves the contract that callers can always
+ * re-run promote safely.
+ */
+async function rewriteCompanyYaml(options: RewriteOptions): Promise<void> {
+  const { hqRoot, slug, uid } = options;
+  const yamlPath = path.join(hqRoot, "companies", slug, "company.yaml");
+
+  let raw: string | null = null;
+  try {
+    raw = await readFile(yamlPath, "utf-8");
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") {
+      throw new Error(
+        `promoteLocalCompany: failed to read ${yamlPath}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+    // ENOENT — fall through; we'll create a fresh doc below.
+  }
+
+  // parseDocument preserves comments + key order on re-stringify, which is
+  // what we want for a human-edited company.yaml. A plain parse/stringify
+  // round-trip would drop comments.
+  let doc;
+  try {
+    doc = raw != null ? parseDocument(raw) : parseDocument("{}");
+  } catch (err) {
+    throw new Error(
+      `promoteLocalCompany: failed to parse ${yamlPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  if (doc.errors && doc.errors.length > 0) {
+    throw new Error(
+      `promoteLocalCompany: yaml parse errors in ${yamlPath}: ${doc.errors
+        .map((e) => e.message)
+        .join("; ")}`,
+    );
+  }
+
+  // If the file was missing or empty-ish, seed the required keys so the
+  // resulting file is a valid company.yaml. When the file already exists
+  // with a `name`, we leave it alone.
+  if (raw == null || doc.get("slug") == null) {
+    doc.set("slug", slug);
+  }
+  if (raw == null || doc.get("name") == null) {
+    doc.set("name", slug);
+  }
+  doc.set("cloud", true);
+  doc.set("cloudCompanyUid", uid);
+
+  const serialized = doc.toString();
+
+  // Atomic write: stage to .tmp, rename on top. If the process crashes after
+  // writeFile but before rename, the original company.yaml is untouched.
+  const tmpPath = `${yamlPath}.tmp`;
+  try {
+    await writeFile(tmpPath, serialized, "utf-8");
+  } catch (err) {
+    throw new Error(
+      `promoteLocalCompany: failed to write ${tmpPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  try {
+    await rename(tmpPath, yamlPath);
+  } catch (err) {
+    throw new Error(
+      `promoteLocalCompany: failed to rename ${tmpPath} → ${yamlPath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
 
   packages/create-hq:
     dependencies:
+      '@indigoai-us/hq-cloud':
+        specifier: ^5.1.9
+        version: 5.1.9
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -148,7 +151,7 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: latest
-        version: 0.2.118(zod@4.3.6)
+        version: 0.2.119(zod@4.3.6)
       '@aws-sdk/client-s3':
         specifier: ^3.0.0
         version: 3.1035.0
@@ -244,6 +247,9 @@ importers:
       open:
         specifier: ^10.1.0
         version: 10.2.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -285,48 +291,48 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.118':
-    resolution: {integrity: sha512-RudnoBekv0c9CPL0EeMc4RqDe4Pb7tdz/2oxa5EYqaajXNRlYtTvru9q7wq7Zvp40JQ24hz38swOTJ7PkW7G/g==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119':
+    resolution: {integrity: sha512-kxnG37SZqUata2Jcp/YQ0n9Y7o/sinE/8LdG4ltM1gePh+z+0Mfa4vBUUTEBMBFth9PTovKoesIuVuyFpvO/Cw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.118':
-    resolution: {integrity: sha512-Hf/H46uElpfygALlb4KZR2EuyyJRe7jBuWa+TDA4jmAHVblNfwkVyaCp8s61hZINB3kAmXdLdM81VI+xwruWzA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119':
+    resolution: {integrity: sha512-9Aj8g3ELsmZuOFg17TCkikeg/Wt2ucVT8hOOPQUatzLd7BKhydrHLA0RP42nBpWECO1B/n/mPdQ4iS/LS3s2Fg==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.118':
-    resolution: {integrity: sha512-gSuZS8GM8MZuklzAJS8VCCjqK2UJJeerV+JpVYzXNMelotq4sXUg2dp17VbjCJ1jhUC9u1gpzlQDWkmYrXCbOg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119':
+    resolution: {integrity: sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.118':
-    resolution: {integrity: sha512-lwMXnweJKpzESezJFM8mngRxJfaq/N0gqyFXBm5bOYaPIZnlGlP3h1JMKsJeqC4neLVGbe5a3Hq4T22Rr7OoAA==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119':
+    resolution: {integrity: sha512-v3o464XkiYehp/OKidQQirxdVb+aGSvdJvHF2zH9p33W8M/NC21zwwh4dhwDnKsyrtBIgkt2CcMwzIl30r0OtA==}
     cpu: [arm64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.118':
-    resolution: {integrity: sha512-36lG1F9IsuNBV7AzJY98z8KwryoWZCeEtMzgZL7614zPBhZGBsziQUZEBm2Eu7FVWbRQmYv6BL52+gffpkM4Gw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119':
+    resolution: {integrity: sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.118':
-    resolution: {integrity: sha512-m0KBbwN9s0+hQwAPzeUFvegrEqoT9EOC+Vz3vr4dd9FcZyvKZE0yiv9S7YbFp1ZKWDQmppmvpcB+9eME7WQ0yA==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119':
+    resolution: {integrity: sha512-9ePt4ZN+hsqDw4AgS4KtcWIGKfL9Oq28kwkrTER/QAcSrVKxiLonp81cCLzg7Ok/IUJu4Cfd71GZbFv/WE54zw==}
     cpu: [x64]
     os: [linux]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.118':
-    resolution: {integrity: sha512-o30/SL084+a8wJ+5cgKM1BflxiBUEy+xEcEpZPW+zCFtiqY0b1Pr+K35ECsbKBrv+w5/0Byp4/CvCkP15Otsgw==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119':
+    resolution: {integrity: sha512-p/TjcKQvkCYtXGPlR+mdyNwqCmvRcQL34Wtq0yUZ+iqmI/eyCe59IJ3AZrE0EZoqmiAevEYzatPIt9sncC9uxw==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.118':
-    resolution: {integrity: sha512-TSqsVBUaZGgYMkjCZckXhPvmJDTS7C6VAl4IOeMVNB/oPINVFaobtVagjYvY0BFnlDCOzz6sb8puafHwcm7qQA==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119':
+    resolution: {integrity: sha512-k98Ju0wtktm6FhqTE/cXlVr6K4kGqBolVjEGzeKkW6ZILc7124euwNapAvkQCwMAavAxS/ZnO3jdKMtHtwTVTA==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.2.118':
-    resolution: {integrity: sha512-OfxCTzmfqvctpTLd3CP+UrpC0JdhYcJp12rD+SK29k+9+hrbblCrLobvhdWpTuYFejTPJuiLVsbHxq0BkEuELQ==}
+  '@anthropic-ai/claude-agent-sdk@0.2.119':
+    resolution: {integrity: sha512-6AvthpsaOTlkn514brSGOcCSLHDXODnU+ExN1O3CJCjxr5RBcmzR057C9EIM0G7IchnXsRfMZgRO1QKsjTXdbA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
@@ -1898,6 +1904,10 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@indigoai-us/hq-cloud@5.1.9':
+    resolution: {integrity: sha512-uYYyhsj7gIWw1gepcNBsWUL2b8K2Jyj5vkNKU8oOD0dPS5eugR+ASJ7ylSNskdyYDfOA2ZP7iWyEQx0OOrEXbA==}
+    hasBin: true
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -6673,44 +6683,44 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.118':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.118':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.118':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.118':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.118':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.118':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.118':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.118':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.119':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.118(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.119(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.118
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.118
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.118
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.118
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.118
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.118
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.118
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.118
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.119
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.119
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
@@ -8664,6 +8674,17 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@indigoai-us/hq-cloud@5.1.9':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.1035.0
+      '@aws-sdk/client-s3': 3.1035.0
+      '@aws-sdk/credential-providers': 3.1035.0
+      chokidar: 4.0.3
+      ignore: 6.0.2
+      open: 10.2.0
+    transitivePeerDependencies:
+      - aws-crt
 
   '@isaacs/cliui@9.0.0': {}
 


### PR DESCRIPTION
## Summary

Adds two new SDK exports to `@indigoai-us/hq-cloud` and three new `sync-runner` flags, giving hq-sync first-class awareness of local-only companies and a single idempotent promote path (Vault entity + bucket provisioning + atomic company.yaml rewrite).

Part of the cross-repo `hq-installer-local-sync` project. Pairs with:
- `indigoai-us/hq-installer` PR — dedupe existing companies on graft.
- `indigoai-us/hq-sync` PR — `promote_company` / `list_all_companies` Tauri commands + CompanyRow UI.

## Stories shipped

- **US-003** — `src/lib/company-discovery.ts` exports `listAllCompanies({hqRoot, vaultClient})` with `source: 'aws'|'local'|'both'` tagging + stderr warning on uid-mismatch. `sync-runner --companies` now tags each fanout-plan entry with `source`. (`bcbe3cb`)
- **US-004a** — `src/lib/company-promote.ts` exports `promoteLocalCompany` — idempotent `entity.findBySlug` → `entity.create` → `provisionBucket` → atomic yaml rewrite (`.tmp` + `rename`, `parseDocument` preserves comments/order). `sync-runner --promote <slug>` emits ndjson `promote:*` events. (`e4e1b9e`)
- **US-004b** — `sync-runner --list-all-companies` one-shot flag (JSON array on stdout, exit 0). Mutually exclusive with `--companies` / `--company` / `--promote`. (`497b467`)

New explicit dep: `yaml@^2.8.3` (was transitive).

## Test plan

- [x] `npm run test` in `packages/hq-cloud` — **137 tests** passing (+27 new: 11 discovery, 11 promote, 5 list-all-companies)
- [x] `npm run typecheck` — clean

## Shape notes for downstream consumers

- `RunnerEvent.fanout-plan.companies[*].uid` is now **optional** (pure-local rows omit it).
- `RunnerEvent.fanout-plan.companies[*].source` is **new + required**.
- The fanout sync loop short-circuits entries without `uid` — promote happens via `--promote`, not piggy-backed.

## Postimplementation (see PRD)

- Publish `@indigoai-us/hq-cloud` next minor once this merges; hq-sync then bumps its pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)