### PR TITLE
chore(cognito): cut over hq-cli + hq-cloud to hq-dev pool (Phase B)

### DIFF
--- a/packages/hq-cli/package.json
+++ b/packages/hq-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cli",
-  "version": "5.5.3",
+  "version": "5.5.4",
   "description": "HQ by Indigo management CLI — modules and cloud sync",
   "main": "dist/index.js",
   "bin": {

--- a/packages/hq-cli/src/utils/cognito-session.ts
+++ b/packages/hq-cli/src/utils/cognito-session.ts
@@ -6,7 +6,7 @@
  *   - `hq auth refresh` and the standalone `hq-auth-refresh` bin invoked by
  *     the deploy skill (.claude/skills/deploy/SKILL.md step 4)
  *
- * Defaults point at the shared hq-vault-dev Cognito pool. They mirror
+ * Defaults point at the shared vault-indigo-hq-dev Cognito pool. They mirror
  * tools/vlt-e2e/e2e-create-company-smoke.ts so the CLI and the in-tree demo script
  * stay drift-free. Override any of them via env:
  *
@@ -31,8 +31,8 @@ import {
 
 export const DEFAULT_COGNITO: CognitoAuthConfig = {
   region: process.env.AWS_REGION ?? "us-east-1",
-  userPoolDomain: process.env.HQ_COGNITO_DOMAIN ?? "hq-vault-dev",
-  clientId: process.env.HQ_COGNITO_CLIENT_ID ?? "4mmujmjq3srakdueg656b9m0mp",
+  userPoolDomain: process.env.HQ_COGNITO_DOMAIN ?? "vault-indigo-hq-dev",
+  clientId: process.env.HQ_COGNITO_CLIENT_ID ?? "7r7an9keh0u6hlsvepl74tvqb0",
   port: process.env.HQ_COGNITO_CALLBACK_PORT
     ? Number(process.env.HQ_COGNITO_CALLBACK_PORT)
     : 8765,
@@ -40,7 +40,7 @@ export const DEFAULT_COGNITO: CognitoAuthConfig = {
 
 export const DEFAULT_VAULT_API_URL =
   process.env.HQ_VAULT_API_URL ??
-  "https://tqdwdqxv75.execute-api.us-east-1.amazonaws.com";
+  "https://ky8cgbl4yh.execute-api.us-east-1.amazonaws.com";
 
 export const DEFAULT_HQ_ROOT = path.join(os.homedir(), "hq");
 

--- a/packages/hq-cloud/package.json
+++ b/packages/hq-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cloud",
-  "version": "5.1.11",
+  "version": "5.1.12",
   "description": "HQ by Indigo cloud sync engine — bidirectional S3 sync for mobile access",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -81,8 +81,8 @@ export type Direction = "pull" | "push" | "both";
 
 const DEFAULT_COGNITO: CognitoAuthConfig = {
   region: process.env.AWS_REGION ?? "us-east-1",
-  userPoolDomain: process.env.HQ_COGNITO_DOMAIN ?? "hq-vault-dev",
-  clientId: process.env.HQ_COGNITO_CLIENT_ID ?? "4mmujmjq3srakdueg656b9m0mp",
+  userPoolDomain: process.env.HQ_COGNITO_DOMAIN ?? "vault-indigo-hq-dev",
+  clientId: process.env.HQ_COGNITO_CLIENT_ID ?? "7r7an9keh0u6hlsvepl74tvqb0",
   port: process.env.HQ_COGNITO_CALLBACK_PORT
     ? Number(process.env.HQ_COGNITO_CALLBACK_PORT)
     : 8765,
@@ -90,7 +90,7 @@ const DEFAULT_COGNITO: CognitoAuthConfig = {
 
 const DEFAULT_VAULT_API_URL =
   process.env.HQ_VAULT_API_URL ??
-  "https://tqdwdqxv75.execute-api.us-east-1.amazonaws.com";
+  "https://ky8cgbl4yh.execute-api.us-east-1.amazonaws.com";
 
 const DEFAULT_HQ_ROOT = path.join(os.homedir(), "hq");
 

--- a/packages/hq-cloud/src/cognito-auth.test.ts
+++ b/packages/hq-cloud/src/cognito-auth.test.ts
@@ -146,7 +146,7 @@ describe("expiresAt shape round-trip", () => {
     const result = await refreshTokens(
       {
         region: "us-east-1",
-        userPoolDomain: "hq-vault-dev",
+        userPoolDomain: "vault-indigo-hq-dev",
         clientId: "test-client",
       },
       "prior-refresh-token",

--- a/packages/hq-cloud/src/cognito-auth.ts
+++ b/packages/hq-cloud/src/cognito-auth.ts
@@ -30,9 +30,9 @@ import open from "open";
 export interface CognitoAuthConfig {
   /** AWS region the User Pool lives in (e.g. "us-east-1"). */
   region: string;
-  /** Cognito User Pool Domain prefix (e.g. "vault-indigo-stefanjohnson"). */
+  /** Cognito User Pool Domain prefix (e.g. "vault-indigo-hq-dev"). */
   userPoolDomain: string;
-  /** App Client ID (e.g. "4mmujmjq3srakdueg656b9m0mp"). */
+  /** App Client ID (e.g. "7r7an9keh0u6hlsvepl74tvqb0"). */
   clientId: string;
   /** Loopback callback port. Defaults to 3000. */
   port?: number;


### PR DESCRIPTION
## Summary

Closes the loop on the Phase B Cognito cutover (hq-pro [ADR-0003](https://github.com/indigoai-us/hq-pro/blob/main/architectural-decisions.md)). The published packages \`@indigoai-us/hq-cli\` (5.5.3) and \`@indigoai-us/hq-cloud\` (5.1.11) were still pointing at the old vault-users-stefanjohnson stack, even though all the consumer apps (hq-installer, hq-onboarding, hq-sync, hq-console, hq-deploy) had cutover branches in flight.

Surfaced when testing hq-sync's menubar Tauri app: a fresh post-cutover Cognito token (issued by \`us-east-1_tj0uvVtDv\`) was sent to the old vault API at \`tqdwdqxv75\` because the spawned \`hq-sync-runner\` from npm 5.1.9 had the old URL hardcoded → 401.

## Changes

Flips three dimensions in the fallback blocks of both packages:

| Dimension | Before | After |
|---|---|---|
| userPoolDomain | \`hq-vault-dev\` | \`vault-indigo-hq-dev\` |
| clientId | \`4mmujmjq3srakdueg656b9m0mp\` | \`7r7an9keh0u6hlsvepl74tvqb0\` |
| vaultApiUrl | \`tqdwdqxv75...\` | \`ky8cgbl4yh.execute-api...\` |

Plus a JSDoc holdover in \`cognito-auth.ts\` that referenced an even older naming (\`vault-indigo-stefanjohnson\` from before the prior rename), and a synthetic test fixture flipped for consistency.

## Files

- \`packages/hq-cloud/src/bin/sync-runner.ts\` — 3 fallbacks
- \`packages/hq-cloud/src/cognito-auth.ts\` — 2 JSDoc examples
- \`packages/hq-cloud/src/cognito-auth.test.ts\` — 1 synthetic test fixture
- \`packages/hq-cli/src/utils/cognito-session.ts\` — 3 fallbacks + docstring

## Versions

- \`@indigoai-us/hq-cloud\`: 5.1.11 → **5.1.12**
- \`@indigoai-us/hq-cli\`: 5.5.3 → **5.5.4**

hq-cli depends on \`"@indigoai-us/hq-cloud": "^5.1.0"\`, so the new hq-cloud auto-flows at install time — no internal dep pin to bump.

## Publish path

CI publishes via OIDC trusted publishing on merge to \`main\` (per \`7c9422ef\` "move all publishes to OIDC trusted publishing"). Once published:

1. \`bun install -g @indigoai-us/hq-cli@latest\` updates the locally-installed CLI to 5.5.4
2. hq-sync's \`HQ_CLOUD_VERSION\` pin in \`src-tauri/src/commands/sync.rs\` needs to bump from \`5.1.9\` → \`5.1.12\` (separate PR in indigoai-us/hq-sync) so the menubar's spawned runner picks up the new binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)