### PR TITLE
hq-cli + hq-cloud: flip source defaults to hq-prod Cognito stack

### DIFF
--- a/packages/hq-cli/src/utils/cognito-session.ts
+++ b/packages/hq-cli/src/utils/cognito-session.ts
@@ -6,9 +6,11 @@
  *   - `hq auth refresh` and the standalone `hq-auth-refresh` bin invoked by
  *     the deploy skill (.claude/skills/deploy/SKILL.md step 4)
  *
- * Defaults point at the shared vault-indigo-hq-dev Cognito pool. They mirror
- * tools/vlt-e2e/e2e-create-company-smoke.ts so the CLI and the in-tree demo script
- * stay drift-free. Override any of them via env:
+ * Defaults point at the shared vault-indigo-hq-prod Cognito pool (canonical
+ * post-2026-04-25 cutover; hq-dev remains the staging fallback via env
+ * overrides). They mirror tools/vlt-e2e/e2e-create-company-smoke.ts so the
+ * CLI and the in-tree demo script stay drift-free. Override any of them via
+ * env:
  *
  *   AWS_REGION                 — e.g. us-east-1
  *   HQ_COGNITO_DOMAIN          — Cognito User Pool domain prefix
@@ -31,8 +33,8 @@ import {
 
 export const DEFAULT_COGNITO: CognitoAuthConfig = {
   region: process.env.AWS_REGION ?? "us-east-1",
-  userPoolDomain: process.env.HQ_COGNITO_DOMAIN ?? "vault-indigo-hq-dev",
-  clientId: process.env.HQ_COGNITO_CLIENT_ID ?? "7r7an9keh0u6hlsvepl74tvqb0",
+  userPoolDomain: process.env.HQ_COGNITO_DOMAIN ?? "vault-indigo-hq-prod",
+  clientId: process.env.HQ_COGNITO_CLIENT_ID ?? "7acei2c8v870enheptb1j5foln",
   port: process.env.HQ_COGNITO_CALLBACK_PORT
     ? Number(process.env.HQ_COGNITO_CALLBACK_PORT)
     : 8765,
@@ -40,7 +42,7 @@ export const DEFAULT_COGNITO: CognitoAuthConfig = {
 
 export const DEFAULT_VAULT_API_URL =
   process.env.HQ_VAULT_API_URL ??
-  "https://ky8cgbl4yh.execute-api.us-east-1.amazonaws.com";
+  "https://4nfy67z28h.execute-api.us-east-1.amazonaws.com";
 
 export const DEFAULT_HQ_ROOT = path.join(os.homedir(), "hq");
 

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -81,8 +81,8 @@ export type Direction = "pull" | "push" | "both";
 
 const DEFAULT_COGNITO: CognitoAuthConfig = {
   region: process.env.AWS_REGION ?? "us-east-1",
-  userPoolDomain: process.env.HQ_COGNITO_DOMAIN ?? "vault-indigo-hq-dev",
-  clientId: process.env.HQ_COGNITO_CLIENT_ID ?? "7r7an9keh0u6hlsvepl74tvqb0",
+  userPoolDomain: process.env.HQ_COGNITO_DOMAIN ?? "vault-indigo-hq-prod",
+  clientId: process.env.HQ_COGNITO_CLIENT_ID ?? "7acei2c8v870enheptb1j5foln",
   port: process.env.HQ_COGNITO_CALLBACK_PORT
     ? Number(process.env.HQ_COGNITO_CALLBACK_PORT)
     : 8765,
@@ -90,7 +90,7 @@ const DEFAULT_COGNITO: CognitoAuthConfig = {
 
 const DEFAULT_VAULT_API_URL =
   process.env.HQ_VAULT_API_URL ??
-  "https://ky8cgbl4yh.execute-api.us-east-1.amazonaws.com";
+  "https://4nfy67z28h.execute-api.us-east-1.amazonaws.com";
 
 const DEFAULT_HQ_ROOT = path.join(os.homedir(), "hq");
 


### PR DESCRIPTION
## Summary

Source-code fallback defaults flipped from the hq-dev Cognito stack to the new hq-prod stack.

| Field | hq-dev (was) | hq-prod (now) |
|---|---|---|
| User Pool ID | `us-east-1_tj0uvVtDv` | `us-east-1_AXf6Kb5nE` |
| Client ID | `7r7an9keh0u6hlsvepl74tvqb0` | `7acei2c8v870enheptb1j5foln` |
| Domain | `vault-indigo-hq-dev` | `vault-indigo-hq-prod` |
| Vault API | `https://ky8cgbl4yh.execute-api.us-east-1.amazonaws.com` | `https://4nfy67z28h.execute-api.us-east-1.amazonaws.com` |

Env-var overrides still win — staging deploys can keep targeting hq-dev by setting the existing `*_COGNITO_*` / `*_VAULT_API_URL` env vars.

## Test plan

- [ ] Production deploy (Vercel/Lambda/GH Actions) picks up the new fallback values
- [ ] Sign-in flow against hq-prod Cognito works end-to-end
- [ ] Vault API calls land on the hq-prod API Gateway endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)