### PR TITLE
feat(hq-cloud): `.hqinclude` allowlist mode (5.3.0)

### DIFF
--- a/packages/hq-cloud/package.json
+++ b/packages/hq-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cloud",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "HQ by Indigo cloud sync engine — bidirectional S3 sync for mobile access",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hq-cloud/src/ignore.test.ts
+++ b/packages/hq-cloud/src/ignore.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for createIgnoreFilter.
+ *
+ * Covers both modes: legacy permissive (no .hqinclude) and allowlist mode
+ * (.hqinclude present). The allowlist tests guard against accidentally
+ * leaking sensitive subtrees like data/ or workers/ to S3 — a regression
+ * here would silently push private content on the next sync.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { createIgnoreFilter } from "./ignore.js";
+
+describe("createIgnoreFilter", () => {
+  let hqRoot: string;
+
+  beforeEach(() => {
+    hqRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hq-ignore-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(hqRoot, { recursive: true, force: true });
+  });
+
+  it("permissive mode: regular files sync, defaults are ignored", () => {
+    const shouldSync = createIgnoreFilter(hqRoot);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/notes.md"))).toBe(true);
+    expect(shouldSync(path.join(hqRoot, "node_modules/foo/x.js"))).toBe(false);
+    expect(shouldSync(path.join(hqRoot, ".env"))).toBe(false);
+  });
+
+  it("permissive mode: .hqignore patterns are honored", () => {
+    fs.writeFileSync(path.join(hqRoot, ".hqignore"), "companies/*/data/\n");
+    const shouldSync = createIgnoreFilter(hqRoot);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/data/x.csv"))).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/notes.md"))).toBe(true);
+  });
+
+  it("allowlist mode: presence of .hqinclude switches to opt-in", () => {
+    fs.writeFileSync(
+      path.join(hqRoot, ".hqinclude"),
+      "companies/*/knowledge/\ncompanies/*/projects/\n",
+    );
+    const shouldSync = createIgnoreFilter(hqRoot);
+    // Allowlisted paths sync.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/knowledge/foo.md"))).toBe(true);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/projects/p1/prd.json"))).toBe(true);
+    // Anything else stays local — this is the privacy guarantee.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/data/leads.csv"))).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/workers/cmo/skill.md"))).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/settings/aws.json"))).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "personal/journal/2026-04-26.md"))).toBe(false);
+  });
+
+  it("allowlist mode: exclusion layers still subtract on top", () => {
+    // Even when a subtree is allowlisted, default ignores like node_modules/
+    // and .env must still apply. Otherwise an allowlisted subdir would sync
+    // gigabytes of dependency junk or leak secret env files.
+    fs.writeFileSync(path.join(hqRoot, ".hqinclude"), "companies/*/projects/\n");
+    const shouldSync = createIgnoreFilter(hqRoot);
+    expect(
+      shouldSync(path.join(hqRoot, "companies/indigo/projects/p1/prd.json")),
+    ).toBe(true);
+    expect(
+      shouldSync(path.join(hqRoot, "companies/indigo/projects/p1/node_modules/react/index.js")),
+    ).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/projects/p1/.env"))).toBe(false);
+  });
+});

--- a/packages/hq-cloud/src/ignore.ts
+++ b/packages/hq-cloud/src/ignore.ts
@@ -1,17 +1,23 @@
 /**
  * Ignore-file parser for cloud sync.
  *
- * Three layers, evaluated in order (later patterns override earlier ones):
- *   1. Built-in defaults — things that should *never* sync (VCS, node_modules,
- *      build artifacts, caches, env files). Cover the common stacks so that a
- *      first-time sync over a random project folder doesn't try to push
- *      `target/`, `node_modules/`, or `.next/` to S3.
- *   2. Repo `.gitignore` at hqRoot — reuses the user's existing exclusions so
- *      we don't re-list every build directory ourselves. Root-level only; we
- *      do not recurse like real git.
- *   3. `.hqignore` (preferred) or `.hqsyncignore` (legacy name) at hqRoot —
- *      sync-specific overrides. Use `!pattern` to re-include something an
- *      earlier layer excluded.
+ * Two modes:
+ *   - **Permissive (default)**: everything syncs except what ignore layers
+ *     subtract. Three layers stack (later overrides earlier):
+ *       1. Built-in defaults — VCS, node_modules, build artifacts, caches,
+ *          env files. Covers the common stacks so a first-time sync over a
+ *          random project folder doesn't push `target/` or `.next/` to S3.
+ *       2. Repo `.gitignore` at hqRoot — reuses existing exclusions so we
+ *          don't re-list every build directory. Root-level only.
+ *       3. `.hqignore` (preferred) or `.hqsyncignore` (legacy) — sync-specific
+ *          overrides. Use `!pattern` to re-include something earlier layers
+ *          excluded.
+ *
+ *   - **Allowlist**: triggered when `.hqinclude` exists at hqRoot. Nothing
+ *     syncs unless its path matches at least one pattern in `.hqinclude`. The
+ *     three exclusion layers still subtract on top — so even allowlisted
+ *     subtrees won't push `node_modules/` or `.env`. Privacy-by-default for
+ *     HQ trees that contain mixed personal + shareable data.
  */
 
 import * as fs from "fs";
@@ -102,10 +108,21 @@ export function createIgnoreFilter(hqRoot: string): (filePath: string) => boolea
     readIgnoreFile(path.join(hqRoot, ".hqsyncignore"));
   if (hqignore) ig.add(hqignore);
 
+  // Allowlist mode: when `.hqinclude` exists, sync is opt-in. The matcher
+  // here treats include patterns as ignore patterns and inverts the verdict —
+  // a path is "allowed" iff its relative path matches at least one entry.
+  // Exclusion layers above still subtract, so build artifacts inside an
+  // allowlisted subtree (e.g. node_modules/ inside companies/x/repos/y/) are
+  // still skipped.
+  const hqinclude = readIgnoreFile(path.join(hqRoot, ".hqinclude"));
+  const includeMatcher = hqinclude ? ignore().add(hqinclude) : null;
+
   return (filePath: string): boolean => {
     const relative = path.relative(hqRoot, filePath);
     if (!relative || relative.startsWith("..")) return true; // outside HQ root
-    return !ig.ignores(relative);
+    if (ig.ignores(relative)) return false;
+    if (includeMatcher && !includeMatcher.ignores(relative)) return false;
+    return true;
   };
 }
 


### PR DESCRIPTION
## Summary
Adds an opt-in **allowlist mode** to `@indigoai-us/hq-cloud`'s sync filter. When `.hqinclude` exists at the HQ root, only paths matching at least one pattern in it sync to the company vault bucket — flipping the engine from "everything except blocklist" to "nothing except allowlist". The three exclusion layers (built-in defaults, `.gitignore`, `.hqignore`) still subtract on top, so an allowlisted subtree won't push `node_modules/` or `.env`.

Privacy-by-default for HQ trees that mix shareable company state (knowledge/, projects/, policies/) with private content (data/, workers/, settings/, personal scratch dirs).

## Why
Today the local HQ tree was syncing `companies/*/data/` (190 keys) and `companies/*/workers/` (9 keys) into the indigo vault bucket — class of content (datasets, prompt libraries) that should never round-trip through S3. A blocklist patch (adding `data/` + `workers/` to defaults) closes the immediate hole, but the right shape is to invert the policy: explicit shareable subtrees, everything else stays local.

## Files
- `packages/hq-cloud/src/ignore.ts` — adds `.hqinclude` parsing; new return-shape gate `if (includeMatcher && !includeMatcher.ignores(relative)) return false`. Updated docstring covers permissive vs allowlist modes.
- `packages/hq-cloud/src/ignore.test.ts` (new) — 4 cases: permissive defaults, `.hqignore` patterns, allowlist opt-in, exclusion layers stack on top of allowlist.
- `packages/hq-cloud/package.json` — `5.2.1 → 5.3.0` (additive feature, semver minor).

## Companion changes (already shipped/landing separately)
- **HQ root** — operator HQ tree got `.hqinclude` committed (this is what activates the new mode for me@coreyepstein.com's machine). Allowlists `companies/*/{knowledge,projects,policies,board.json,company.yaml,.hq/,manifest.yaml}`, `.claude/`, `projects/`, `workspace/{threads,orchestrator}/`, root `INDEX.md`/`README.md`/`manifest.yaml`. Plus `data/` + `workers/` added to `.hqignore` as belt-and-suspenders for any future blocklist-mode operator.
- **indigoai-us/hq-sync#35** (merged) — Rust mirror in `src-tauri/src/util/ignore.rs` (V2 daemon) added `data/` + `workers/` to `DEFAULT_IGNORES`. Blocklist-only — does not parse `.hqinclude` yet (V2 follow-up).

## Publish
Workflow `publish.yml` triggers on `push: tags: ["v*"]`. After this PR merges, push `vX.Y.Z` (next hq-cli version, or whatever convention you prefer) and the trusted-publisher OIDC flow ships `@indigoai-us/hq-cloud@5.3.0`. Skip-if-published gate handles unchanged sibling packages.

## Test plan
- [x] `npm run test --workspace packages/hq-cloud` — 145 passed (9 files), including the 4 new allowlist tests
- [ ] Smoke on operator machine: `hq sync push companies/indigo/...` after merge — confirm `data/`, `workers/`, `settings/` paths excluded; `knowledge/`, `projects/`, `policies/` paths uploaded
- [ ] Verify S3 listing on `cmp_01KPRAETKTNEZY298X8ZBRRFNX` after first post-publish sync — no `data/` or `workers/` keys