### PR TITLE
fix(hq-cloud): emit error/auth-error on stderr, not stdout

### DIFF
--- a/packages/hq-cloud/src/bin/sync-runner.test.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.test.ts
@@ -206,18 +206,20 @@ describe("argv parsing", () => {
 // ---------------------------------------------------------------------------
 
 describe("auth", () => {
-  it("emits auth-error and returns 0 when token fetch fails", async () => {
+  it("emits auth-error on stderr and returns 0 when token fetch fails", async () => {
     const deps = makeDeps({
       getAccessToken: vi.fn().mockRejectedValue(new Error("no cached tokens")),
     });
     const code = await runRunner(["--companies"], deps);
     expect(code).toBe(0);
-    expect(deps.stdout.events()).toEqual([
+    // auth-error is an error-class event → stderr, not stdout
+    expect(deps.stderr.events()).toEqual([
       { type: "auth-error", message: "no cached tokens" },
     ]);
+    expect(deps.stdout.events()).toEqual([]);
   });
 
-  it("emits auth-error when VaultAuthError thrown during discovery", async () => {
+  it("emits auth-error on stderr when VaultAuthError thrown during discovery", async () => {
     const deps = makeDeps({
       createVaultClient: () => ({
         ...makeVaultStub(),
@@ -227,12 +229,13 @@ describe("auth", () => {
     });
     const code = await runRunner(["--companies"], deps);
     expect(code).toBe(0);
-    expect(deps.stdout.events()).toEqual([
+    expect(deps.stderr.events()).toEqual([
       { type: "auth-error", message: "token expired" },
     ]);
+    expect(deps.stdout.events()).toEqual([]);
   });
 
-  it("emits error event and returns 1 on non-auth discovery failure", async () => {
+  it("emits error event on stderr and returns 1 on non-auth discovery failure", async () => {
     const deps = makeDeps({
       createVaultClient: () => ({
         ...makeVaultStub(),
@@ -241,13 +244,15 @@ describe("auth", () => {
     });
     const code = await runRunner(["--companies"], deps);
     expect(code).toBe(1);
-    const events = deps.stdout.events();
+    // error events go to stderr, not stdout
+    const events = deps.stderr.events();
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       type: "error",
       message: "network down",
       path: "(discovery)",
     });
+    expect(deps.stdout.events()).toEqual([]);
   });
 });
 
@@ -588,7 +593,8 @@ describe("per-company fanout", () => {
 
     const code = await runRunner(["--companies"], deps);
     expect(code).toBe(0);
-    const errs = deps.stdout
+    // Per-file errors are routed to stderr (error-class events).
+    const errs = deps.stderr
       .events()
       .filter((e): e is Extract<RunnerEvent, { type: "error" }> =>
         e.type === "error",
@@ -691,23 +697,27 @@ describe("per-company fanout", () => {
     const code = await runRunner(["--companies"], deps);
     expect(code).toBe(0); // whole fanout still returns 0
 
-    const events = deps.stdout.events();
     // Error event for acme (company-level) with path sentinel "(company)"
-    const companyErr = events.find(
-      (e): e is Extract<RunnerEvent, { type: "error" }> =>
-        e.type === "error" && e.company === "acme",
-    );
+    // — error-class events route to stderr.
+    const companyErr = deps.stderr
+      .events()
+      .find(
+        (e): e is Extract<RunnerEvent, { type: "error" }> =>
+          e.type === "error" && e.company === "acme",
+      );
     expect(companyErr).toMatchObject({
       type: "error",
       company: "acme",
       path: "(company)",
       message: "acme blew up",
     });
-    // But beta still completed
-    const betaComplete = events.find(
-      (e): e is Extract<RunnerEvent, { type: "complete" }> =>
-        e.type === "complete" && e.company === "beta",
-    );
+    // But beta still completed — non-error events stay on stdout.
+    const betaComplete = deps.stdout
+      .events()
+      .find(
+        (e): e is Extract<RunnerEvent, { type: "complete" }> =>
+          e.type === "complete" && e.company === "beta",
+      );
     expect(betaComplete).toBeDefined();
     expect(betaComplete?.filesDownloaded).toBe(1);
   });

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -4,10 +4,10 @@
  * (ADR-0001).
  *
  * The AppBar Sync menubar (Tauri + Rust) spawns this binary as a subprocess
- * and reads ndjson events from stdout. The protocol is intentionally narrow
- * and versioned-by-shape, not by tooling — no chalk, no colors, no human
- * prose. If you want to invoke sync as a human, use `hq sync` in
- * `@indigoai-us/hq-cli`.
+ * and reads ndjson events from BOTH stdout and stderr (see "Channels"
+ * below). The protocol is intentionally narrow and versioned-by-shape, not
+ * by tooling — no chalk, no colors, no human prose. If you want to invoke
+ * sync as a human, use `hq sync` in `@indigoai-us/hq-cli`.
  *
  * Flags:
  *   --companies               Fan out across every membership the caller has
@@ -18,14 +18,23 @@
  *                             only output mode. Accepted for symmetry with the
  *                             AppBar's argv in case someone passes it.
  *
- * Event protocol (one JSON object per line on stdout):
- *   setup-needed   — caller signed in but has no person entity yet
- *   auth-error     — no valid token available (interactive login disabled)
- *   fanout-plan    — list of companies we're about to sync
- *   progress       — per-file download
- *   error          — per-file or per-company error
- *   complete       — per-company summary
- *   all-complete   — aggregate summary after fanout
+ * Channels (one JSON object per line):
+ *   stdout — protocol stream:
+ *     setup-needed   caller signed in but has no person entity yet
+ *     fanout-plan    list of companies we're about to sync
+ *     progress       per-file download
+ *     complete       per-company summary
+ *     all-complete   aggregate summary after fanout
+ *   stderr — diagnostic stream:
+ *     error          per-file or per-company error
+ *     auth-error     no valid token available (interactive login disabled)
+ *
+ * Why the split: error-class events go to stderr so the menubar's Sentry
+ * breadcrumb pipeline picks them up automatically (see hq-sync
+ * src-tauri/src/commands/sync.rs `ProcessEvent::Stderr` handler). The
+ * single Sentry capture at runner-exit then ships one #hq-alerts issue
+ * with the full per-file → company → exit error trail attached, instead
+ * of requiring per-event capture calls in the menubar.
  *
  * Exit code:
  *   0 — event stream describes the outcome (including setup-needed)
@@ -100,10 +109,14 @@ const DEFAULT_HQ_ROOT = path.join(os.homedir(), "hq");
 // ---------------------------------------------------------------------------
 
 /**
- * Every event emitted on stdout. The `company` field is present on every
- * event except `setup-needed` / `auth-error` / `fanout-plan` / `all-complete`
- * (which describe the whole run) — consumers should treat its absence as
- * "meta-event, not tied to a specific company".
+ * Every event the runner emits. Channel routing (stdout vs stderr) is
+ * decided inside `runRunner`'s `emit` helper based on the event's `type`
+ * — see the doc-block on the file header for the split.
+ *
+ * The `company` field is present on every event except `setup-needed` /
+ * `auth-error` / `fanout-plan` / `all-complete` (which describe the whole
+ * run) — consumers should treat its absence as "meta-event, not tied to a
+ * specific company".
  */
 export type RunnerEvent =
   | { type: "setup-needed" }
@@ -347,8 +360,35 @@ export async function runRunner(
   const stdout = deps.stdout ?? process.stdout;
   const stderr = deps.stderr ?? process.stderr;
 
+  // ---- emit ---------------------------------------------------------------
+  // Error-class events go to stderr; everything else to stdout.
+  //
+  // Why split: the AppBar Sync menubar (Tauri + Rust) feeds runner stderr
+  // into Sentry as breadcrumbs and captures one Sentry event when the
+  // runner exits non-zero. Routing `error` / `auth-error` events through
+  // stderr makes them part of that breadcrumb trail automatically — the
+  // menubar doesn't need a per-event capture call, and operators get the
+  // full context (per-file errors → company error → exit) in a single
+  // Sentry issue alerted to #hq-alerts.
+  //
+  // Non-error events (progress, complete, fanout-plan, all-complete,
+  // setup-needed) stay on stdout. They're the protocol stream the menubar
+  // parses for UI updates; mixing them with error events on the same
+  // channel was the original design (single ndjson stream, simpler to
+  // tee), but error context belongs in the diagnostic channel.
+  //
+  // Backward compat: older menubar releases (pre-PR-#34) parse only
+  // stdout for ndjson; with this change they will NOT receive error
+  // events. The menubar's `HQ_CLOUD_VERSION` pin gates which runner
+  // they spawn, so old menubars stay on the previous runner version
+  // even after this one is published.
+  const ERROR_TYPES: ReadonlySet<RunnerEvent["type"]> = new Set([
+    "error",
+    "auth-error",
+  ]);
   const emit = (event: RunnerEvent): void => {
-    stdout.write(`${JSON.stringify(event)}\n`);
+    const stream = ERROR_TYPES.has(event.type) ? stderr : stdout;
+    stream.write(`${JSON.stringify(event)}\n`);
   };
 
   // ---- argv -------------------------------------------------------------


### PR DESCRIPTION
## Summary

Splits `hq-sync-runner`'s ndjson protocol across two channels:

| Channel | Events |
|---|---|
| **stdout** (protocol stream) | `progress`, `complete`, `all-complete`, `fanout-plan`, `setup-needed` |
| **stderr** (diagnostic stream) | `error`, `auth-error` |

Implementation: a 5-line `emit` shim in `runRunner` picks the channel based on `event.type`. All call sites unchanged.

## Why

hq-sync's Tauri host now feeds runner stderr into Sentry as breadcrumbs and captures one Sentry event when the runner exits non-zero (see [indigoai-us/hq-sync#34](https://github.com/indigoai-us/hq-sync/pull/34)). Routing error-class events through stderr makes them part of that breadcrumb trail automatically — no per-event capture call required in the menubar, and operators get the full per-file → company → exit error trail in a single `#hq-alerts` issue.

## Backward compat

Older menubar releases (pre-#34) parse only stdout for ndjson; with this change they will **not** receive `error` / `auth-error` events. The menubar's `HQ_CLOUD_VERSION` pin gates which runner version they spawn, so old menubars stay on the previous runner version even after this one is published.

**Follow-up coordination:** after this PR ships and a new `@indigoai-us/hq-cloud` is published, bump `HQ_CLOUD_VERSION` in hq-sync's `src-tauri/src/commands/sync.rs` to pull the new runner.

## Test plan

- [x] `pnpm test` → 141/141 pass (38 in sync-runner.test.ts)
- [x] `pnpm typecheck` clean
- [ ] Reviewer: confirm the channel-split doc-block at the top of `sync-runner.ts` matches the actual routing in `emit`
- [ ] After publish: smoke-test by running `hq-sync-runner --companies` locally and `tee`-ing both streams, observe ndjson appears on the expected channels