### PR TITLE
fix(hq-cloud): require both sides to drift before flagging a sync conflict

### DIFF
--- a/packages/hq-cloud/src/cli/share.test.ts
+++ b/packages/hq-cloud/src/cli/share.test.ts
@@ -9,9 +9,11 @@ import * as os from "os";
 import { clearContextCache } from "../context.js";
 import type { VaultServiceConfig } from "../types.js";
 
-// Mock s3 module at the top level
+// Mock s3 module at the top level. uploadFile resolves to a synthetic ETag
+// so share() can record it on the journal entry — the real PutObject
+// response shape is `{ ETag: '"<hex>"' }`.
 vi.mock("../s3.js", () => ({
-  uploadFile: vi.fn().mockResolvedValue(undefined),
+  uploadFile: vi.fn().mockResolvedValue({ etag: '"upload-etag"' }),
   downloadFile: vi.fn().mockResolvedValue(undefined),
   listRemoteFiles: vi.fn().mockResolvedValue([]),
   deleteRemoteFile: vi.fn().mockResolvedValue(undefined),
@@ -77,6 +79,10 @@ describe("share", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    // clearAllMocks wipes the default ETag impl set in vi.mock(), so
+    // re-prime it for the next test.
+    vi.mocked(uploadFile).mockResolvedValue({ etag: '"upload-etag"' });
+    vi.mocked(headRemoteFile).mockResolvedValue(null);
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.rmSync(stateDir, { recursive: true, force: true });
     delete process.env.HQ_STATE_DIR;
@@ -276,18 +282,18 @@ describe("share", () => {
     expect(uploadFile).toHaveBeenCalledWith(expect.anything(), testFile, "changed.md");
   });
 
-  it("populates conflictPaths and emits a conflict event when remote drifted from journal", async () => {
+  it("populates conflictPaths and emits a conflict event when both local and remote drifted from journal", async () => {
     const companyRoot = path.join(tmpDir, "companies", "acme");
     fs.mkdirSync(companyRoot, { recursive: true });
     const testFile = path.join(companyRoot, "drifted.md");
     fs.writeFileSync(testFile, "local edit");
 
-    // Journal has a stale hash → local diverged. headRemoteFile returning
-    // non-null tells share() the remote also exists; combined with the
-    // hash mismatch this trips the conflict branch.
+    // Stale hash → local diverged. Remote ETag in head response differs
+    // from the one stored in the journal → remote also moved. Both sides
+    // changed since last sync = real conflict.
     vi.mocked(headRemoteFile).mockResolvedValueOnce({
       lastModified: new Date(),
-      etag: '"remote-changed"',
+      etag: '"remote-new-etag"',
       size: 99,
     });
 
@@ -303,6 +309,7 @@ describe("share", () => {
             size: 10,
             syncedAt: new Date().toISOString(),
             direction: "up",
+            remoteEtag: "remote-old-etag",
           },
         },
       }),
@@ -330,6 +337,124 @@ describe("share", () => {
       direction: "push",
       resolution: "keep",
     });
+  });
+
+  it("uploads (no conflict) when only the local side changed since last sync", async () => {
+    // Regression for hq-cloud#<conflict-detection>: a local edit to a file
+    // that exists on S3 used to trigger a push conflict because the
+    // detector compared `journalEntry.hash !== localHash` without checking
+    // the remote. Combined with `--on-conflict keep`, this silently dropped
+    // every edit to any pre-existing file.
+    const companyRoot = path.join(tmpDir, "companies", "acme");
+    fs.mkdirSync(companyRoot, { recursive: true });
+    const testFile = path.join(companyRoot, "edited.md");
+    fs.writeFileSync(testFile, "edited locally");
+
+    const syncedAt = new Date(Date.now() - 60_000).toISOString();
+    vi.mocked(headRemoteFile).mockResolvedValueOnce({
+      lastModified: new Date(Date.parse(syncedAt) - 30_000),
+      etag: '"unchanged-remote"',
+      size: 5,
+    });
+
+    const journalPath = path.join(stateDir, "sync-journal.acme.json");
+    fs.writeFileSync(
+      journalPath,
+      JSON.stringify({
+        version: "1",
+        lastSync: syncedAt,
+        files: {
+          "edited.md": {
+            hash: "stale-hash-for-old-content",
+            size: 5,
+            syncedAt,
+            direction: "down",
+            remoteEtag: "unchanged-remote",
+          },
+        },
+      }),
+    );
+
+    const events: unknown[] = [];
+    const result = await share({
+      paths: [testFile],
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onConflict: "keep",
+      onEvent: (e) => events.push(e),
+    });
+
+    expect(result.conflictPaths).toEqual([]);
+    expect(result.filesUploaded).toBe(1);
+    expect(events.some((e): e is { type: string } =>
+      typeof e === "object" && e !== null && (e as { type?: string }).type === "conflict",
+    )).toBe(false);
+  });
+
+  it("falls back to lastModified vs syncedAt when journal entry has no remoteEtag (legacy)", async () => {
+    // Legacy entries from before the remoteEtag field existed should be
+    // treated as "remote unchanged" iff lastModified <= syncedAt.
+    const companyRoot = path.join(tmpDir, "companies", "acme");
+    fs.mkdirSync(companyRoot, { recursive: true });
+    const testFile = path.join(companyRoot, "legacy.md");
+    fs.writeFileSync(testFile, "edited locally");
+
+    const syncedAt = new Date().toISOString();
+    vi.mocked(headRemoteFile).mockResolvedValueOnce({
+      lastModified: new Date(Date.parse(syncedAt) - 5_000),
+      etag: '"some-etag"',
+      size: 5,
+    });
+
+    const journalPath = path.join(stateDir, "sync-journal.acme.json");
+    fs.writeFileSync(
+      journalPath,
+      JSON.stringify({
+        version: "1",
+        lastSync: syncedAt,
+        files: {
+          "legacy.md": {
+            hash: "stale-hash",
+            size: 5,
+            syncedAt,
+            direction: "down",
+            // no remoteEtag — pre-fix journal
+          },
+        },
+      }),
+    );
+
+    const result = await share({
+      paths: [testFile],
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onConflict: "keep",
+    });
+
+    expect(result.conflictPaths).toEqual([]);
+    expect(result.filesUploaded).toBe(1);
+  });
+
+  it("records the upload's ETag on the journal entry", async () => {
+    const companyRoot = path.join(tmpDir, "companies", "acme");
+    fs.mkdirSync(companyRoot, { recursive: true });
+    const testFile = path.join(companyRoot, "fresh.md");
+    fs.writeFileSync(testFile, "new file");
+
+    vi.mocked(uploadFile).mockResolvedValueOnce({ etag: '"new-upload-etag"' });
+
+    await share({
+      paths: [testFile],
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+    });
+
+    const journalPath = path.join(stateDir, "sync-journal.acme.json");
+    const journal = JSON.parse(fs.readFileSync(journalPath, "utf-8"));
+    expect(journal.files["fresh.md"].remoteEtag).toBe("new-upload-etag");
   });
 
   it("skipUnchanged=false (default) uploads even when hash matches", async () => {

--- a/packages/hq-cloud/src/cli/share.ts
+++ b/packages/hq-cloud/src/cli/share.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import type { VaultServiceConfig } from "../types.js";
 import { resolveEntityContext, isExpiringSoon, refreshEntityContext } from "../context.js";
 import { uploadFile, headRemoteFile } from "../s3.js";
-import { readJournal, writeJournal, hashFile, updateEntry } from "../journal.js";
+import { readJournal, writeJournal, hashFile, updateEntry, normalizeEtag } from "../journal.js";
 import { createIgnoreFilter, isWithinSizeLimit } from "../ignore.js";
 import { resolveConflict } from "./conflict.js";
 import type { ConflictStrategy } from "./conflict.js";
@@ -123,16 +123,24 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
       ctx = await refreshEntityContext(companyRef, vaultConfig);
     }
 
-    // Check for remote conflict — refuse to overwrite newer remote version
+    // Check for remote conflict — refuse to overwrite newer remote version.
+    //
+    // A real conflict requires BOTH sides to have moved since the last sync.
+    // The previous predicate only checked `journalEntry.hash !== localHash`,
+    // which mislabelled every local edit as a conflict and (combined with
+    // `--on-conflict keep`) silently dropped the user's edit. We now compare
+    // the current remote ETag against the one captured at last sync; when
+    // missing (legacy entries), we fall back to the same `lastModified >
+    // syncedAt` heuristic the pull side uses.
     const remoteMeta = await headRemoteFile(ctx, relativePath);
     if (remoteMeta) {
       const journalEntry = journal.files[relativePath];
+      const localChanged = !!journalEntry && journalEntry.hash !== localHash;
+      const remoteChanged = !!journalEntry && hasRemoteChanged(remoteMeta, journalEntry);
 
-      // If remote has changed since our last sync, it's a conflict
-      if (journalEntry && journalEntry.hash !== localHash) {
+      if (localChanged && remoteChanged) {
         conflictPaths.push(relativePath);
 
-        // Local has changes — check if remote also changed
         const resolution = await resolveConflict(
           {
             path: relativePath,
@@ -171,10 +179,12 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
     try {
       const stat = fs.statSync(absolutePath);
 
-      await uploadFile(ctx, absolutePath, relativePath);
+      const { etag } = await uploadFile(ctx, absolutePath, relativePath);
 
-      // Update journal with optional message
-      updateEntry(journal, relativePath, localHash, stat.size, "up");
+      // Update journal with optional message; capture the post-upload ETag
+      // so the next sync can distinguish "remote moved since we last wrote"
+      // from "user edited locally" without conflating the two.
+      updateEntry(journal, relativePath, localHash, stat.size, "up", etag);
       if (message) {
         journal.files[relativePath] = {
           ...journal.files[relativePath],
@@ -317,4 +327,22 @@ function walkDir(
 function isWithin(parent: string, child: string): boolean {
   const rel = path.relative(parent, child);
   return rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel));
+}
+
+/**
+ * Returns true when the remote object appears to have moved since the
+ * journal entry's last-recorded sync. Prefers ETag equality; falls back to
+ * `lastModified > syncedAt` for legacy entries written before remoteEtag
+ * was tracked. Conservative on tie (`<=` skews "remote unchanged") so an
+ * S3-side mtime that exactly equals our syncedAt is not treated as drift.
+ */
+function hasRemoteChanged(
+  remote: { lastModified: Date; etag: string },
+  entry: { syncedAt: string; remoteEtag?: string },
+): boolean {
+  if (entry.remoteEtag) {
+    return normalizeEtag(remote.etag) !== entry.remoteEtag;
+  }
+  const syncedAt = new Date(entry.syncedAt).getTime();
+  return remote.lastModified.getTime() > syncedAt;
 }

--- a/packages/hq-cloud/src/cli/sync.test.ts
+++ b/packages/hq-cloud/src/cli/sync.test.ts
@@ -330,4 +330,58 @@ describe("sync", () => {
     // File should be overwritten with mock content
     expect(fs.readFileSync(path.join(companyDocs, "handoff.md"), "utf-8")).toBe("mock file content");
   });
+
+  it("does NOT flag a pull conflict when only local changed since last sync", async () => {
+    // Regression: previously, any local edit to a file that also existed on
+    // S3 produced a pull conflict because the predicate only checked
+    // `journalEntry.hash !== localHash`. With `--on-conflict keep` this
+    // silently dropped local edits during the round-trip. With remoteEtag
+    // matching the journal, the remote is known unchanged and the pull
+    // phase should leave the local edit alone for the push phase to upload.
+    const companyDocs = path.join(tmpDir, "companies", "acme", "docs");
+    fs.mkdirSync(companyDocs, { recursive: true });
+    fs.writeFileSync(path.join(companyDocs, "handoff.md"), "local edit");
+
+    fs.writeFileSync(
+      journalPath,
+      JSON.stringify({
+        version: "1",
+        lastSync: new Date().toISOString(),
+        files: {
+          "docs/handoff.md": {
+            hash: "stale-hash-from-pre-edit",
+            size: 20,
+            syncedAt: new Date(Date.now() - 3600000).toISOString(),
+            direction: "down",
+            // Matches the listRemoteFiles mock's etag for handoff.md.
+            remoteEtag: "abc123",
+          },
+        },
+      }),
+    );
+
+    const result = await sync({
+      company: "acme",
+      onConflict: "keep",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+    });
+
+    expect(result.conflicts).toBe(0);
+    expect(result.conflictPaths).toEqual([]);
+    // Local edit must be preserved (not clobbered by download)
+    expect(fs.readFileSync(path.join(companyDocs, "handoff.md"), "utf-8")).toBe("local edit");
+  });
+
+  it("records remoteEtag from listRemoteFiles on the journal entry after download", async () => {
+    await sync({
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+    });
+
+    const journal = JSON.parse(fs.readFileSync(journalPath, "utf-8"));
+    expect(journal.files["docs/handoff.md"].remoteEtag).toBe("abc123");
+    expect(journal.files["knowledge/readme.md"].remoteEtag).toBe("def456");
+  });
 });

--- a/packages/hq-cloud/src/cli/sync.ts
+++ b/packages/hq-cloud/src/cli/sync.ts
@@ -10,7 +10,7 @@ import * as path from "path";
 import type { VaultServiceConfig } from "../types.js";
 import { resolveEntityContext, isExpiringSoon, refreshEntityContext } from "../context.js";
 import { downloadFile, listRemoteFiles } from "../s3.js";
-import { readJournal, writeJournal, hashFile, updateEntry, getEntry } from "../journal.js";
+import { readJournal, writeJournal, hashFile, updateEntry, getEntry, normalizeEtag } from "../journal.js";
 import { createIgnoreFilter } from "../ignore.js";
 import { resolveConflict } from "./conflict.js";
 import type { ConflictStrategy, ConflictResolution } from "./conflict.js";
@@ -147,9 +147,14 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
 
     if (fs.existsSync(localPath)) {
       const localHash = hashFile(localPath);
+      const localChanged = !!journalEntry && journalEntry.hash !== localHash;
+      const remoteChanged = !!journalEntry && hasRemoteChanged(remoteFile, journalEntry);
 
-      // If local file has changed since last sync, it's a conflict
-      if (journalEntry && journalEntry.hash !== localHash) {
+      // A real conflict requires BOTH sides to have moved since the last
+      // sync. If only local changed, push will handle it; pulling here would
+      // clobber the local edit. If only remote changed, fall through to
+      // download. If neither moved, skip.
+      if (localChanged && remoteChanged) {
         conflicts++;
         conflictPaths.push(remoteFile.key);
 
@@ -187,17 +192,18 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
           continue;
         }
         // "overwrite" falls through to download
-      } else if (journalEntry && journalEntry.hash === localHash) {
-        // Local unchanged since last sync — check if remote changed
-        // by comparing etag/timestamp
-        const lastSyncTime = new Date(journalEntry.syncedAt).getTime();
-        const remoteModTime = remoteFile.lastModified.getTime();
-        if (remoteModTime <= lastSyncTime) {
-          // Remote hasn't changed either — skip
-          filesSkipped++;
-          continue;
-        }
+      } else if (journalEntry && localChanged && !remoteChanged) {
+        // Local-only edit: leave it for the push phase to upload. Pulling
+        // would silently overwrite the user's work.
+        filesSkipped++;
+        continue;
+      } else if (journalEntry && !localChanged && !remoteChanged) {
+        // Neither side moved — nothing to do.
+        filesSkipped++;
+        continue;
       }
+      // Otherwise (no journal entry, or remote-only changed) fall through
+      // to download.
     }
 
     // Download
@@ -206,7 +212,9 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
 
       const hash = hashFile(localPath);
       const stat = fs.statSync(localPath);
-      updateEntry(journal, remoteFile.key, hash, stat.size, "down");
+      // Capture the listing's ETag so subsequent syncs can detect remote
+      // drift independently of mtime drift.
+      updateEntry(journal, remoteFile.key, hash, stat.size, "down", remoteFile.etag);
 
       // Attach message from journal entry if present
       const remoteJournalMessage = (journalEntry as { message?: string } | undefined)?.message;
@@ -260,6 +268,23 @@ function resolveActiveCompany(hqRoot: string): string | undefined {
     }
   }
   return undefined;
+}
+
+/**
+ * Returns true when the remote object appears to have moved since the
+ * journal entry's last-recorded sync. Prefers ETag equality; falls back to
+ * `lastModified > syncedAt` for legacy entries written before remoteEtag
+ * was tracked. Conservative on tie (`<=` skews "remote unchanged").
+ */
+function hasRemoteChanged(
+  remote: { lastModified: Date; etag: string },
+  entry: { syncedAt: string; remoteEtag?: string },
+): boolean {
+  if (entry.remoteEtag) {
+    return normalizeEtag(remote.etag) !== entry.remoteEtag;
+  }
+  const syncedAt = new Date(entry.syncedAt).getTime();
+  return remote.lastModified.getTime() > syncedAt;
 }
 
 /**

--- a/packages/hq-cloud/src/journal.ts
+++ b/packages/hq-cloud/src/journal.ts
@@ -80,14 +80,29 @@ export function updateEntry(
   hash: string,
   size: number,
   direction: "up" | "down",
+  remoteEtag?: string,
 ): void {
-  journal.files[relativePath] = {
+  const entry: JournalEntry = {
     hash,
     size,
     syncedAt: new Date().toISOString(),
     direction,
   };
+  if (remoteEtag !== undefined && remoteEtag !== "") {
+    entry.remoteEtag = normalizeEtag(remoteEtag);
+  }
+  journal.files[relativePath] = entry;
   journal.lastSync = new Date().toISOString();
+}
+
+/**
+ * S3 returns ETags wrapped in literal double-quotes (e.g. `"d41d8cd9..."`).
+ * Strip them so equality comparisons across HEAD / GET / PUT responses are
+ * stable regardless of which AWS SDK call surfaced the value.
+ */
+export function normalizeEtag(etag: string): string {
+  if (!etag) return "";
+  return etag.replace(/^"|"$/g, "");
 }
 
 export function getEntry(

--- a/packages/hq-cloud/src/s3.ts
+++ b/packages/hq-cloud/src/s3.ts
@@ -38,11 +38,11 @@ export async function uploadFile(
   ctx: EntityContext,
   localPath: string,
   key: string,
-): Promise<void> {
+): Promise<{ etag: string }> {
   const client = buildClient(ctx);
   const body = fs.readFileSync(localPath);
 
-  await client.send(
+  const response = await client.send(
     new PutObjectCommand({
       Bucket: ctx.bucketName,
       Key: key,
@@ -50,6 +50,8 @@ export async function uploadFile(
       ContentType: getMimeType(key),
     }),
   );
+
+  return { etag: response.ETag || "" };
 }
 
 export async function downloadFile(

--- a/packages/hq-cloud/src/types.ts
+++ b/packages/hq-cloud/src/types.ts
@@ -26,6 +26,14 @@ export interface JournalEntry {
   size: number;
   syncedAt: string;
   direction: "up" | "down";
+  /**
+   * S3 ETag of the remote object as of last successful sync, normalized (no
+   * surrounding quotes). Optional for backwards compatibility: entries
+   * written before this field existed won't have it, in which case
+   * conflict detection falls back to comparing remote `lastModified`
+   * against `syncedAt`.
+   */
+  remoteEtag?: string;
 }
 
 export interface SyncJournal {

--- a/packages/hq-cloud/src/watcher.ts
+++ b/packages/hq-cloud/src/watcher.ts
@@ -113,8 +113,8 @@ export class SyncWatcher {
           const existing = journal.files[relativePath];
           if (existing && existing.hash === hash) continue;
 
-          await uploadFile(this.ctx, change.absolutePath, relativePath);
-          updateEntry(journal, relativePath, hash, stat.size, "up");
+          const { etag } = await uploadFile(this.ctx, change.absolutePath, relativePath);
+          updateEntry(journal, relativePath, hash, stat.size, "up", etag);
         }
       } catch (err) {
         console.error(


### PR DESCRIPTION
## Summary

Editing any file that already exists on S3 used to produce a push+pull conflict pair, and with `--on-conflict keep` (the default for the menubar Sync Now) the user's edit was silently dropped.

**Repro:** edit `policies/account-mapping.md` after a successful sync, then run Sync Now. Log shows `filesUploaded:0, filesDownloaded:0, conflicts:2` — file wedged in both directions.

## Root cause

The conflict predicate in both [`cli/share.ts`](https://github.com/indigoai-us/hq/blob/main/packages/hq-cloud/src/cli/share.ts) (push) and [`cli/sync.ts`](https://github.com/indigoai-us/hq/blob/main/packages/hq-cloud/src/cli/sync.ts) (pull) only checked whether **local** changed since last sync:

```ts
if (journalEntry && journalEntry.hash !== localHash) {
  // declare conflict
}
```

The comment above the push branch said *"If remote has changed since our last sync, it's a conflict"* but the code never inspected the remote. `JournalEntry` had no remote-side anchor (no etag, no version), so the detector physically couldn't tell remote-changed from remote-unchanged. Any local edit got mislabelled as a conflict, and `--on-conflict keep` then dropped the edit.

Trace, from a real `~/.hq/logs/hq-sync.log`:

```
{"type":"conflict","company":"indigo","path":"policies/account-mapping.md","direction":"push","resolution":"keep"}
{"type":"conflict","company":"indigo","path":"policies/account-mapping.md","direction":"pull","resolution":"keep"}
{"type":"complete","filesDownloaded":0,"filesUploaded":0,"conflicts":2}
```

## Fix

- Add optional `remoteEtag` to `JournalEntry`. Captured on every successful upload (`PutObject` `ETag`) and download (`ListObjectsV2` `ETag`), normalized (surrounding quotes stripped) so equality is `===`.
- Conflict now requires **both** `localChanged` AND `remoteChanged`. Remote drift is detected via ETag equality; legacy entries without `remoteEtag` fall back to the existing `lastModified > syncedAt` heuristic that the pull side already used.
- Pull phase: when only local changed, skip the file and let the push phase upload it (previously: false-positive pull conflict that clobbered the local edit on `--on-conflict overwrite`, or wedged the file on `--on-conflict keep`).
- `uploadFile` now returns `{ etag }` so the post-upload ETag can be threaded into the journal. All in-tree callers (`cli/share.ts`, `watcher.ts`) updated.

Backwards compatible: old journals deserialize fine and just exercise the mtime fallback until the first successful sync backfills the `remoteEtag`.

## Files

| File | Change |
|---|---|
| `src/types.ts` | Add `remoteEtag?: string` to `JournalEntry`. |
| `src/journal.ts` | `updateEntry` accepts optional `remoteEtag`; export `normalizeEtag`. |
| `src/s3.ts` | `uploadFile` returns `Promise<{ etag: string }>`. |
| `src/cli/share.ts` | Three-way predicate; record post-upload etag; new `hasRemoteChanged` helper. |
| `src/cli/sync.ts` | Three-way predicate; record listing etag on download; matching helper. |
| `src/watcher.ts` | Thread upload etag into journal. |
| `src/cli/share.test.ts` | Update "remote drifted" test to actually drift; new tests for "only local changed → upload (no conflict)", legacy entries without `remoteEtag`, and ETag-recorded-on-upload. |
| `src/cli/sync.test.ts` | New tests for "only local changed → no pull conflict, local preserved" and ETag-recorded-on-download. |

## Test plan

- [x] `pnpm --filter @indigoai-us/hq-cloud typecheck` (clean)
- [x] `pnpm --filter @indigoai-us/hq-cloud test` — 158/158 passing (was 153 before; +5 new regression tests)
- [x] Full workspace `pnpm -r typecheck` — clean across hq-cloud, hq-cli, hq-onboarding, godclaw, create-hq, hq-agent, apps/web
- [ ] Manual: edit a synced file in HQ, run Sync Now, confirm `filesUploaded:1, conflicts:0` (vs. the broken `filesUploaded:0, conflicts:2`)
- [ ] Manual: legacy journal (no `remoteEtag`) — confirm fallback heuristic doesn't regress conflict detection on truly-divergent files

## Notes

- No version bump in this PR — the repo's convention is dedicated `release: hq-cloud@X.Y.Z` commits, so leaving that to maintainers.
- This was discovered in a real sync log on 2026-04-27. Immediate workaround for affected files: delete the file's entry from `~/.hq/sync-journal.{slug}.json` so the next sync re-establishes baseline. (The upgraded version makes that workaround unnecessary going forward.)