### PR TITLE
feat(hq-cloud): lineage tracking + conflict files via S3 VersionId

### DIFF
--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -114,6 +114,13 @@ export type RunnerEvent =
     }
   | ({ type: "progress"; company: string } & Omit<Extract<SyncProgressEvent, { type: "progress" }>, "type">)
   | ({ type: "error"; company?: string } & Omit<Extract<SyncProgressEvent, { type: "error" }>, "type">)
+  /**
+   * Lineage divergence detected — `share`/`sync` wrote a `.conflict-` file
+   * next to the original and recorded an entry in `<hq_root>/.hq-conflicts/index.json`.
+   * The menubar UI uses these to surface a "N conflicts pending" badge; the
+   * `/resolve-conflicts` HQ skill is the resolution path.
+   */
+  | ({ type: "conflict-detected"; company: string } & Omit<Extract<SyncProgressEvent, { type: "conflict-detected" }>, "type">)
   | ({
       type: "complete";
       company: string;
@@ -492,6 +499,15 @@ export async function runRunner(
           path: event.path,
           bytes: event.bytes,
           ...(event.message ? { message: event.message } : {}),
+        });
+      } else if (event.type === "conflict-detected") {
+        emit({
+          type: "conflict-detected",
+          company: companyLabel,
+          path: event.path,
+          conflictPath: event.conflictPath,
+          side: event.side,
+          remoteVersionId: event.remoteVersionId,
         });
       } else {
         emit({

--- a/packages/hq-cloud/src/cli/share.test.ts
+++ b/packages/hq-cloud/src/cli/share.test.ts
@@ -11,15 +11,21 @@ import type { VaultServiceConfig } from "../types.js";
 
 // Mock s3 module at the top level
 vi.mock("../s3.js", () => ({
-  uploadFile: vi.fn().mockResolvedValue(undefined),
-  downloadFile: vi.fn().mockResolvedValue(undefined),
+  uploadFile: vi.fn().mockResolvedValue({ versionId: "vMOCK" }),
+  downloadFile: vi.fn().mockResolvedValue({ versionId: "vMOCK" }),
+  downloadFileBytes: vi.fn().mockResolvedValue({
+    bytes: Buffer.from("mock cloud content"),
+    versionId: "vMOCK",
+  }),
   listRemoteFiles: vi.fn().mockResolvedValue([]),
+  listObjectVersions: vi.fn().mockResolvedValue([]),
   deleteRemoteFile: vi.fn().mockResolvedValue(undefined),
   headRemoteFile: vi.fn().mockResolvedValue(null),
+  isPreconditionFailed: vi.fn().mockReturnValue(false),
 }));
 
 import { share } from "./share.js";
-import { headRemoteFile, uploadFile } from "../s3.js";
+import { headRemoteFile, uploadFile, downloadFileBytes, isPreconditionFailed } from "../s3.js";
 
 const mockConfig: VaultServiceConfig = {
   apiUrl: "https://vault-api.test",
@@ -339,5 +345,95 @@ describe("share", () => {
     expect(events).toHaveLength(2);
     expect(events.every((e) => e.type === "progress")).toBe(true);
     expect(events.map((e) => e.path).sort()).toEqual(["a.md", "b.md"]);
+  });
+
+  it("lineage push 412 writes conflict file + index entry, leaves local untouched", async () => {
+    const companyRoot = path.join(tmpDir, "companies", "acme");
+    fs.mkdirSync(companyRoot, { recursive: true });
+    const localPath = path.join(companyRoot, "notes.md");
+    const localContent = "local edits the user just made";
+    fs.writeFileSync(localPath, localContent);
+
+    // Seed a lineage-active journal entry — different hash than current
+    // local content, with an s3VersionId pointer to the parent we *think*
+    // is in the cloud.
+    const journalPath = path.join(stateDir, "sync-journal.acme.json");
+    fs.writeFileSync(
+      journalPath,
+      JSON.stringify({
+        version: "1",
+        lastSync: new Date(Date.now() - 60_000).toISOString(),
+        files: {
+          "notes.md": {
+            hash: "old-hash-from-last-sync",
+            size: 10,
+            syncedAt: new Date(Date.now() - 60_000).toISOString(),
+            direction: "up",
+            s3VersionId: "vPARENT",
+          },
+        },
+      }),
+    );
+
+    // Make the upload look like a 412 from S3 — the cloud advanced past our
+    // parent. The conflict path should fire.
+    const preconditionErr = Object.assign(new Error("PreconditionFailed"), {
+      name: "PreconditionFailed",
+    });
+    vi.mocked(uploadFile).mockRejectedValueOnce(preconditionErr);
+    vi.mocked(isPreconditionFailed).mockReturnValueOnce(true);
+    vi.mocked(downloadFileBytes).mockResolvedValueOnce({
+      bytes: Buffer.from("CLOUD VERSION the other machine pushed"),
+      versionId: "vCLOUD",
+    });
+
+    const events: Array<{ type: string; path?: string; conflictPath?: string }> = [];
+    const result = await share({
+      paths: [localPath],
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onEvent: (e) => {
+        events.push(
+          e.type === "conflict-detected"
+            ? { type: e.type, path: e.path, conflictPath: e.conflictPath }
+            : { type: e.type, path: e.path },
+        );
+      },
+    });
+
+    expect(result.filesUploaded).toBe(0);
+    expect(result.filesSkipped).toBe(1);
+
+    // Local file is unchanged — user's edits never touched.
+    expect(fs.readFileSync(localPath, "utf-8")).toBe(localContent);
+
+    // Conflict event emitted with both paths.
+    const conflictEvent = events.find((e) => e.type === "conflict-detected");
+    expect(conflictEvent).toBeDefined();
+    expect(conflictEvent!.path).toBe("notes.md");
+
+    // Conflict file written next to the original (HQ-relative path).
+    const conflictAbs = path.join(tmpDir, conflictEvent!.conflictPath!);
+    expect(fs.existsSync(conflictAbs)).toBe(true);
+    expect(fs.readFileSync(conflictAbs, "utf-8")).toBe(
+      "CLOUD VERSION the other machine pushed",
+    );
+
+    // Index entry appended.
+    const indexPath = path.join(tmpDir, ".hq-conflicts", "index.json");
+    expect(fs.existsSync(indexPath)).toBe(true);
+    const idx = JSON.parse(fs.readFileSync(indexPath, "utf-8"));
+    expect(idx.conflicts).toHaveLength(1);
+    expect(idx.conflicts[0].side).toBe("push");
+    expect(idx.conflicts[0].lastKnownVersionId).toBe("vPARENT");
+    expect(idx.conflicts[0].remoteVersionId).toBe("vCLOUD");
+
+    // Journal NOT updated for this file — entry stays at the old hash so a
+    // subsequent sync re-evaluates against the same parent. (See spec: we
+    // never silently bump s3VersionId without resolution.)
+    const journalAfter = JSON.parse(fs.readFileSync(journalPath, "utf-8"));
+    expect(journalAfter.files["notes.md"].hash).toBe("old-hash-from-last-sync");
+    expect(journalAfter.files["notes.md"].s3VersionId).toBe("vPARENT");
   });
 });

--- a/packages/hq-cloud/src/cli/share.ts
+++ b/packages/hq-cloud/src/cli/share.ts
@@ -5,16 +5,29 @@
  * Refuses to overwrite a newer remote version without prompting.
  */
 
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import type { VaultServiceConfig } from "../types.js";
 import { resolveEntityContext, isExpiringSoon, refreshEntityContext } from "../context.js";
-import { uploadFile, headRemoteFile } from "../s3.js";
-import { readJournal, writeJournal, hashFile, updateEntry } from "../journal.js";
+import {
+  uploadFile,
+  headRemoteFile,
+  downloadFileBytes,
+  isPreconditionFailed,
+} from "../s3.js";
+import { readJournal, writeJournal, hashFile } from "../journal.js";
 import { createIgnoreFilter, isWithinSizeLimit } from "../ignore.js";
 import { resolveConflict } from "./conflict.js";
 import type { ConflictStrategy } from "./conflict.js";
 import type { SyncProgressEvent } from "./sync.js";
+import {
+  buildConflictPath,
+  buildConflictId,
+  readShortMachineId,
+  writeConflictFile,
+} from "../lib/conflict-file.js";
+import { appendConflictEntry } from "../lib/conflict-index.js";
 
 export interface ShareOptions {
   /** Path(s) to share (files or directories) */
@@ -116,14 +129,79 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
       ctx = await refreshEntityContext(companyRef, vaultConfig);
     }
 
-    // Check for remote conflict — refuse to overwrite newer remote version
+    const journalEntry = journal.files[relativePath];
+    const lineageActive =
+      journalEntry !== undefined &&
+      journalEntry.s3VersionId !== undefined &&
+      journalEntry.s3VersionId !== null;
+
+    // Lineage-active path: optimistic concurrency via If-Match. The bucket's
+    // VersionId chain is the parent pointer; if S3 rejects with 412, someone
+    // else's push landed between our last sync and now. We never overwrite —
+    // we record both versions and surface them to the user.
+    if (lineageActive) {
+      try {
+        const stat = fs.statSync(absolutePath);
+        const result = await uploadFile(ctx, absolutePath, relativePath, {
+          ifMatch: journalEntry!.s3VersionId!,
+        });
+
+        // Successful push — stamp the new VersionId as our parent pointer.
+        journal.files[relativePath] = {
+          hash: localHash,
+          size: stat.size,
+          syncedAt: new Date().toISOString(),
+          direction: "up",
+          s3VersionId: result.versionId,
+          ...(message ? { message } : {}),
+        } as typeof journal.files[string];
+        journal.lastSync = new Date().toISOString();
+
+        filesUploaded++;
+        bytesUploaded += stat.size;
+        emit({
+          type: "progress",
+          path: relativePath,
+          bytes: stat.size,
+          ...(message ? { message } : {}),
+        });
+      } catch (err) {
+        if (isPreconditionFailed(err)) {
+          // Cloud has advanced past our last-known parent. Don't overwrite —
+          // fetch the cloud version and write it as a `.conflict-` file
+          // alongside the original. The user resolves later via the
+          // /resolve-conflicts skill; the next sync re-tries with the
+          // resolved hash.
+          await recordPushConflict({
+            ctx,
+            hqRoot,
+            relativePath,
+            localHash,
+            companySlug: ctx.slug,
+            lastKnownVersionId: journalEntry!.s3VersionId!,
+            emit,
+          });
+          filesSkipped++;
+          continue;
+        }
+        emit({
+          type: "error",
+          path: relativePath,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+      continue;
+    }
+
+    // Degraded / first-push path: no parent pointer yet (pre-lineage journal,
+    // or the file was never synced). Falls back to the legacy "HEAD then
+    // prompt" flow for hash-based conflict detection — same behavior as
+    // before. The first successful push stamps s3VersionId, and every
+    // subsequent push goes through the lineage-active branch above.
     const remoteMeta = await headRemoteFile(ctx, relativePath);
     if (remoteMeta) {
-      const journalEntry = journal.files[relativePath];
-
       // If remote has changed since our last sync, it's a conflict
       if (journalEntry && journalEntry.hash !== localHash) {
-        // Local has changes — check if remote also changed
         const resolution = await resolveConflict(
           {
             path: relativePath,
@@ -145,20 +223,21 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
       }
     }
 
-    // Upload
     try {
       const stat = fs.statSync(absolutePath);
 
-      await uploadFile(ctx, absolutePath, relativePath);
+      const result = await uploadFile(ctx, absolutePath, relativePath);
 
-      // Update journal with optional message
-      updateEntry(journal, relativePath, localHash, stat.size, "up");
-      if (message) {
-        journal.files[relativePath] = {
-          ...journal.files[relativePath],
-          message,
-        } as typeof journal.files[string] & { message: string };
-      }
+      // Stamp s3VersionId on first sync — activates lineage from now on.
+      journal.files[relativePath] = {
+        hash: localHash,
+        size: stat.size,
+        syncedAt: new Date().toISOString(),
+        direction: "up",
+        s3VersionId: result.versionId,
+        ...(message ? { message } : {}),
+      } as typeof journal.files[string];
+      journal.lastSync = new Date().toISOString();
 
       filesUploaded++;
       bytesUploaded += stat.size;
@@ -183,6 +262,77 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
 }
 
 /**
+ * Push detected divergence (412 from If-Match). Fetch the cloud's current
+ * bytes, write them to a `.conflict-` file next to the original, append an
+ * entry to the conflict index, and emit the event so the runner can update
+ * its UI counter.
+ *
+ * Local file is left untouched. The user's edits are still safely on disk
+ * at the original path; the cloud's version is what landed in the conflict
+ * file.
+ */
+async function recordPushConflict(args: {
+  ctx: import("../types.js").EntityContext;
+  hqRoot: string;
+  relativePath: string;
+  localHash: string;
+  companySlug: string;
+  lastKnownVersionId: string;
+  emit: (event: SyncProgressEvent) => void;
+}): Promise<void> {
+  const { ctx, hqRoot, relativePath, localHash, companySlug, lastKnownVersionId, emit } = args;
+
+  // S3 keys are company-relative; the on-disk path is HQ-relative under
+  // companies/<slug>/. Conflict files always live next to the original.
+  const hqRelativeOriginal = path.join("companies", companySlug, relativePath);
+  const detectedAt = new Date().toISOString();
+  const machineId = readShortMachineId();
+
+  let cloudBytes: Buffer;
+  let cloudVersionId: string | null;
+  try {
+    const fetched = await downloadFileBytes(ctx, relativePath);
+    cloudBytes = fetched.bytes;
+    cloudVersionId = fetched.versionId;
+  } catch (err) {
+    // Couldn't fetch cloud bytes — emit error and bail. The journal entry
+    // is left untouched so next sync re-tries (and re-conflicts cleanly).
+    emit({
+      type: "error",
+      path: relativePath,
+      message: `conflict detected but cloud fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return;
+  }
+
+  const conflictRelative = buildConflictPath(hqRelativeOriginal, detectedAt, machineId);
+  writeConflictFile(hqRoot, conflictRelative, cloudBytes);
+
+  const remoteHash = crypto.createHash("sha256").update(cloudBytes).digest("hex");
+
+  appendConflictEntry(hqRoot, {
+    id: buildConflictId(hqRelativeOriginal, detectedAt),
+    originalPath: hqRelativeOriginal,
+    conflictPath: conflictRelative,
+    detectedAt,
+    side: "push",
+    machineId,
+    localHash,
+    remoteHash,
+    remoteVersionId: cloudVersionId ?? "",
+    lastKnownVersionId,
+  });
+
+  emit({
+    type: "conflict-detected",
+    path: relativePath,
+    conflictPath: conflictRelative,
+    side: "push",
+    remoteVersionId: cloudVersionId ?? "",
+  });
+}
+
+/**
  * Default human-readable share output. Preserves the exact format the CLI
  * emitted before `onEvent` was added — tty users see no change.
  */
@@ -193,6 +343,12 @@ function defaultConsoleLogger(event: SyncProgressEvent): void {
     } else {
       console.log(`  ✓ ${event.path}`);
     }
+  } else if (event.type === "conflict-detected") {
+    // Surface conflicts visibly in tty output too — same pattern as the
+    // runner's UI badge, but for direct CLI users.
+    console.error(
+      `  ! conflict: ${event.path} — cloud version saved as ${event.conflictPath}`,
+    );
   } else {
     console.error(`  ✗ ${event.path} — ${event.message}`);
   }

--- a/packages/hq-cloud/src/cli/sync.test.ts
+++ b/packages/hq-cloud/src/cli/sync.test.ts
@@ -21,20 +21,32 @@ vi.mock("../s3.js", async () => {
   ];
 
   return {
-    uploadFile: innerVi.fn().mockResolvedValue(undefined),
+    uploadFile: innerVi.fn().mockResolvedValue({ versionId: "vMOCK" }),
     downloadFile: innerVi.fn().mockImplementation(async (_ctx: unknown, _key: string, localPath: string) => {
       const dir = innerPath.dirname(localPath);
       if (!innerFs.existsSync(dir)) innerFs.mkdirSync(dir, { recursive: true });
       innerFs.writeFileSync(localPath, "mock file content");
+      return { versionId: "vMOCK" };
+    }),
+    downloadFileBytes: innerVi.fn().mockResolvedValue({
+      bytes: Buffer.from("mock cloud content"),
+      versionId: "vMOCK",
     }),
     listRemoteFiles: innerVi.fn().mockResolvedValue(remoteFiles),
+    listObjectVersions: innerVi.fn().mockResolvedValue([]),
     deleteRemoteFile: innerVi.fn().mockResolvedValue(undefined),
     headRemoteFile: innerVi.fn().mockResolvedValue(null),
+    isPreconditionFailed: innerVi.fn().mockReturnValue(false),
   };
 });
 
 import { sync } from "./sync.js";
 import * as s3Module from "../s3.js";
+import {
+  downloadFileBytes,
+  headRemoteFile,
+  listObjectVersions,
+} from "../s3.js";
 
 const mockConfig: VaultServiceConfig = {
   apiUrl: "https://vault-api.test",
@@ -285,5 +297,148 @@ describe("sync", () => {
     expect(result.filesDownloaded).toBeGreaterThanOrEqual(1);
     // File should be overwritten with mock content
     expect(fs.readFileSync(path.join(companyDocs, "handoff.md"), "utf-8")).toBe("mock file content");
+  });
+
+  it("lineage pull divergence writes conflict file, leaves local untouched", async () => {
+    const companyDocs = path.join(tmpDir, "companies", "acme", "docs");
+    fs.mkdirSync(companyDocs, { recursive: true });
+    const localPath = path.join(companyDocs, "handoff.md");
+    const localContent = "LOCAL — what was here before sync ran";
+    fs.writeFileSync(localPath, localContent);
+
+    const { hashFile } = await import("../journal.js");
+    const localHash = hashFile(localPath);
+
+    // Lineage-active journal entry — local hash matches journal hash (no
+    // local edits), parent pointer is "vPARENT".
+    fs.writeFileSync(
+      journalPath,
+      JSON.stringify({
+        version: "1",
+        lastSync: new Date(Date.now() - 60_000).toISOString(),
+        files: {
+          "docs/handoff.md": {
+            hash: localHash,
+            size: localContent.length,
+            syncedAt: new Date(Date.now() - 60_000).toISOString(),
+            direction: "down",
+            s3VersionId: "vPARENT",
+          },
+        },
+      }),
+    );
+
+    // Cloud has advanced past our parent, AND our parent is NOT in the
+    // recent version chain → divergence.
+    vi.mocked(headRemoteFile).mockResolvedValueOnce({
+      lastModified: new Date(Date.now()),
+      etag: '"cloud-etag"',
+      size: 99,
+      versionId: "vCLOUD",
+    });
+    vi.mocked(listObjectVersions).mockResolvedValueOnce([
+      "vCLOUD",
+      "vSOMEONE_ELSE",
+      // vPARENT is missing — diverged
+    ]);
+    vi.mocked(downloadFileBytes).mockResolvedValueOnce({
+      bytes: Buffer.from("CLOUD — different lineage from another machine"),
+      versionId: "vCLOUD",
+    });
+
+    const events: Array<{ type: string; path?: string; conflictPath?: string }> = [];
+    const result = await sync({
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onEvent: (e) => {
+        events.push(
+          e.type === "conflict-detected"
+            ? { type: e.type, path: e.path, conflictPath: e.conflictPath }
+            : { type: e.type, path: e.path },
+        );
+      },
+    });
+
+    // Only one of the two mock remote files conflicts — handoff.md.
+    // The other (knowledge/readme.md) has no journal entry → fast-path
+    // download.
+    expect(result.conflicts).toBe(1);
+
+    // Local handoff.md is preserved exactly — never overwritten.
+    expect(fs.readFileSync(localPath, "utf-8")).toBe(localContent);
+
+    // Cloud's bytes landed in a `.conflict-` file.
+    const conflictEvent = events.find((e) => e.type === "conflict-detected");
+    expect(conflictEvent).toBeDefined();
+    const conflictAbs = path.join(tmpDir, conflictEvent!.conflictPath!);
+    expect(fs.existsSync(conflictAbs)).toBe(true);
+    expect(fs.readFileSync(conflictAbs, "utf-8")).toBe(
+      "CLOUD — different lineage from another machine",
+    );
+
+    // Index entry recorded.
+    const indexPath = path.join(tmpDir, ".hq-conflicts", "index.json");
+    const idx = JSON.parse(fs.readFileSync(indexPath, "utf-8"));
+    expect(idx.conflicts).toHaveLength(1);
+    expect(idx.conflicts[0].side).toBe("pull");
+    expect(idx.conflicts[0].lastKnownVersionId).toBe("vPARENT");
+    expect(idx.conflicts[0].remoteVersionId).toBe("vCLOUD");
+  });
+
+  it("lineage pull fast-forward downloads cleanly when parent is in chain", async () => {
+    const companyDocs = path.join(tmpDir, "companies", "acme", "docs");
+    fs.mkdirSync(companyDocs, { recursive: true });
+    const localPath = path.join(companyDocs, "handoff.md");
+    const oldLocal = "OLD CONTENT — superseded by cloud";
+    fs.writeFileSync(localPath, oldLocal);
+
+    const { hashFile } = await import("../journal.js");
+    const localHash = hashFile(localPath);
+
+    fs.writeFileSync(
+      journalPath,
+      JSON.stringify({
+        version: "1",
+        lastSync: new Date(Date.now() - 60_000).toISOString(),
+        files: {
+          "docs/handoff.md": {
+            hash: localHash,
+            size: oldLocal.length,
+            syncedAt: new Date(Date.now() - 60_000).toISOString(),
+            direction: "down",
+            s3VersionId: "vPARENT",
+          },
+        },
+      }),
+    );
+
+    // Cloud advanced, but our parent IS in the version chain → fast-forward.
+    vi.mocked(headRemoteFile).mockResolvedValueOnce({
+      lastModified: new Date(Date.now()),
+      etag: '"cloud-etag"',
+      size: 99,
+      versionId: "vCLOUD",
+    });
+    vi.mocked(listObjectVersions).mockResolvedValueOnce([
+      "vCLOUD",
+      "vPARENT", // our parent is in the chain — fast-forward, not divergence
+    ]);
+
+    const result = await sync({
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+    });
+
+    // Local was overwritten with the cloud's content (mock writes "mock file content").
+    expect(fs.readFileSync(localPath, "utf-8")).toBe("mock file content");
+    expect(result.conflicts).toBe(0);
+    // No .hq-conflicts dir created on a clean fast-forward.
+    expect(fs.existsSync(path.join(tmpDir, ".hq-conflicts"))).toBe(false);
+
+    // Journal stamped with the new VersionId.
+    const journalAfter = JSON.parse(fs.readFileSync(journalPath, "utf-8"));
+    expect(journalAfter.files["docs/handoff.md"].s3VersionId).toBe("vMOCK");
   });
 });

--- a/packages/hq-cloud/src/cli/sync.ts
+++ b/packages/hq-cloud/src/cli/sync.ts
@@ -5,15 +5,29 @@
  * Never auto-overwrites local changes — prompts on conflict.
  */
 
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import type { VaultServiceConfig } from "../types.js";
 import { resolveEntityContext, isExpiringSoon, refreshEntityContext } from "../context.js";
-import { downloadFile, listRemoteFiles } from "../s3.js";
+import {
+  downloadFile,
+  downloadFileBytes,
+  headRemoteFile,
+  listRemoteFiles,
+  listObjectVersions,
+} from "../s3.js";
 import { readJournal, writeJournal, hashFile, updateEntry, getEntry } from "../journal.js";
 import { createIgnoreFilter } from "../ignore.js";
 import { resolveConflict } from "./conflict.js";
 import type { ConflictStrategy } from "./conflict.js";
+import {
+  buildConflictPath,
+  buildConflictId,
+  readShortMachineId,
+  writeConflictFile,
+} from "../lib/conflict-file.js";
+import { appendConflictEntry } from "../lib/conflict-index.js";
 
 /**
  * Per-file events emitted by `sync()` as it progresses.
@@ -28,7 +42,21 @@ import type { ConflictStrategy } from "./conflict.js";
  */
 export type SyncProgressEvent =
   | { type: "progress"; path: string; bytes: number; message?: string }
-  | { type: "error"; path: string; message: string };
+  | { type: "error"; path: string; message: string }
+  /**
+   * Lineage detected divergence — the cloud's VersionId chain doesn't
+   * include our last-known parent. Both versions are now on disk: the
+   * original path holds the local (push) or pre-existing (pull) bytes,
+   * and `conflictPath` holds the cloud bytes. The user resolves later
+   * via the `/resolve-conflicts` HQ skill.
+   */
+  | {
+      type: "conflict-detected";
+      path: string;
+      conflictPath: string;
+      side: "push" | "pull";
+      remoteVersionId: string;
+    };
 
 export interface SyncOptions {
   /** Company slug or UID (defaults to active company from config) */
@@ -129,86 +157,283 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
       ctx = await refreshEntityContext(companyRef, vaultConfig);
     }
 
-    // Check for local conflict
     const journalEntry = getEntry(journal, remoteFile.key);
+    const lineageActive =
+      journalEntry !== undefined &&
+      journalEntry.s3VersionId !== undefined &&
+      journalEntry.s3VersionId !== null;
 
-    if (fs.existsSync(localPath)) {
-      const localHash = hashFile(localPath);
-
-      // If local file has changed since last sync, it's a conflict
-      if (journalEntry && journalEntry.hash !== localHash) {
-        conflicts++;
-
-        const resolution = await resolveConflict(
-          {
-            path: remoteFile.key,
-            localHash,
-            remoteModified: remoteFile.lastModified,
-            localModified: fs.statSync(localPath).mtime,
-            direction: "pull",
-          },
-          onConflict,
-        );
-
-        if (resolution === "abort") {
-          writeJournal(journalSlug, journal);
-          return { filesDownloaded, bytesDownloaded, filesSkipped, conflicts, aborted: true };
-        }
-        if (resolution === "keep" || resolution === "skip") {
-          filesSkipped++;
-          continue;
-        }
-        // "overwrite" falls through to download
-      } else if (journalEntry && journalEntry.hash === localHash) {
-        // Local unchanged since last sync — check if remote changed
-        // by comparing etag/timestamp
-        const lastSyncTime = new Date(journalEntry.syncedAt).getTime();
-        const remoteModTime = remoteFile.lastModified.getTime();
-        if (remoteModTime <= lastSyncTime) {
-          // Remote hasn't changed either — skip
-          filesSkipped++;
-          continue;
-        }
+    // Fast path: brand-new file or no prior sync record. No conflict possible.
+    if (!fs.existsSync(localPath) || !journalEntry) {
+      const downloadOutcome = await tryDownload(remoteFile.key);
+      if (downloadOutcome === "abort") {
+        writeJournal(journalSlug, journal);
+        return { filesDownloaded, bytesDownloaded, filesSkipped, conflicts, aborted: true };
       }
+      continue;
     }
 
-    // Download
-    try {
-      await downloadFile(ctx, remoteFile.key, localPath);
+    const localHash = hashFile(localPath);
 
-      const hash = hashFile(localPath);
-      const stat = fs.statSync(localPath);
-      updateEntry(journal, remoteFile.key, hash, stat.size, "down");
+    if (lineageActive) {
+      // Lineage path: cloud's VersionId chain is the source of truth for
+      // divergence. We don't trust hashes alone (a 3-way edit cycle could
+      // produce matching hashes on different lineages).
+      const lastKnownVersionId = journalEntry.s3VersionId!;
 
-      // Attach message from journal entry if present
-      const remoteJournalMessage = (journalEntry as { message?: string } | undefined)?.message;
-      emit({
-        type: "progress",
-        path: remoteFile.key,
-        bytes: stat.size,
-        ...(remoteJournalMessage ? { message: remoteJournalMessage } : {}),
-      });
-
-      filesDownloaded++;
-      bytesDownloaded += stat.size;
-    } catch (err) {
-      // STS session policy may deny access to some paths — this is expected
-      // for guest members with allowedPrefixes
-      if (isAccessDenied(err)) {
+      // Cheap pre-filter: if remote's lastModified is older than our last
+      // sync AND local hash matches journal hash, nothing changed.
+      const lastSyncTime = new Date(journalEntry.syncedAt).getTime();
+      const remoteModTime = remoteFile.lastModified.getTime();
+      if (
+        journalEntry.hash === localHash &&
+        remoteModTime <= lastSyncTime
+      ) {
         filesSkipped++;
-      } else {
+        continue;
+      }
+
+      // Need cloud's current VersionId to compare. ListObjectsV2 doesn't
+      // include it, so HEAD here. Cost is one HEAD per file that *might*
+      // have changed — files we already pre-filtered as unchanged skip it.
+      let remoteHead: Awaited<ReturnType<typeof headRemoteFile>>;
+      try {
+        remoteHead = await headRemoteFile(ctx, remoteFile.key);
+      } catch (err) {
+        if (isAccessDenied(err)) {
+          filesSkipped++;
+          continue;
+        }
+        throw err;
+      }
+      if (!remoteHead) {
+        // Remote file gone between LIST and HEAD (rare). Skip — delete
+        // semantics are out of scope for this iteration.
+        filesSkipped++;
+        continue;
+      }
+
+      // Cloud hasn't actually moved — false alarm from the timestamp filter.
+      // Stamp the no-op so future syncs short-circuit even quicker.
+      if (remoteHead.versionId === lastKnownVersionId) {
+        if (journalEntry.hash !== localHash) {
+          // Local has uncommitted edits, cloud unchanged — pure pending-push,
+          // not a pull-side conflict. Leave for share() to handle.
+        }
+        filesSkipped++;
+        continue;
+      }
+
+      // Cloud advanced. Walk its version chain to determine fast-forward
+      // vs divergence.
+      let versionChain: string[];
+      try {
+        versionChain = await listObjectVersions(ctx, remoteFile.key, 100);
+      } catch (err) {
         emit({
           type: "error",
           path: remoteFile.key,
-          message: err instanceof Error ? err.message : String(err),
+          message: `version chain walk failed: ${err instanceof Error ? err.message : String(err)}`,
         });
+        continue;
       }
+
+      const isFastForward = versionChain.includes(lastKnownVersionId);
+
+      if (isFastForward && journalEntry.hash === localHash) {
+        // Pure fast-forward, no local edits → safe to overwrite local with cloud.
+        const downloadOutcome = await tryDownload(remoteFile.key);
+        if (downloadOutcome === "abort") {
+          writeJournal(journalSlug, journal);
+          return { filesDownloaded, bytesDownloaded, filesSkipped, conflicts, aborted: true };
+        }
+        continue;
+      }
+
+      // Either (a) cloud diverged from our parent, or (b) cloud fast-forwarded
+      // but local also has uncommitted edits. Both are conflicts — record
+      // both sides, never overwrite.
+      conflicts++;
+      await recordPullConflict({
+        ctx,
+        hqRoot,
+        remoteKey: remoteFile.key,
+        companySlug: ctx.slug,
+        personalMode: options.personalMode === true,
+        localHash,
+        remoteVersionId: remoteHead.versionId ?? "",
+        lastKnownVersionId,
+        emit,
+      });
+      filesSkipped++;
+      continue;
+    }
+
+    // Degraded path: pre-lineage journal entry (no s3VersionId). Falls back
+    // to the legacy timestamp + interactive-prompt flow. The first successful
+    // download stamps s3VersionId and activates lineage from then on.
+    if (journalEntry.hash !== localHash) {
+      conflicts++;
+      const resolution = await resolveConflict(
+        {
+          path: remoteFile.key,
+          localHash,
+          remoteModified: remoteFile.lastModified,
+          localModified: fs.statSync(localPath).mtime,
+          direction: "pull",
+        },
+        onConflict,
+      );
+
+      if (resolution === "abort") {
+        writeJournal(journalSlug, journal);
+        return { filesDownloaded, bytesDownloaded, filesSkipped, conflicts, aborted: true };
+      }
+      if (resolution === "keep" || resolution === "skip") {
+        filesSkipped++;
+        continue;
+      }
+      // "overwrite" falls through
+    } else {
+      // Local unchanged — only download if remote moved (legacy logic).
+      const lastSyncTime = new Date(journalEntry.syncedAt).getTime();
+      const remoteModTime = remoteFile.lastModified.getTime();
+      if (remoteModTime <= lastSyncTime) {
+        filesSkipped++;
+        continue;
+      }
+    }
+
+    const downloadOutcome = await tryDownload(remoteFile.key);
+    if (downloadOutcome === "abort") {
+      writeJournal(journalSlug, journal);
+      return { filesDownloaded, bytesDownloaded, filesSkipped, conflicts, aborted: true };
     }
   }
 
   writeJournal(journalSlug, journal);
 
   return { filesDownloaded, bytesDownloaded, filesSkipped, conflicts, aborted: false };
+
+  // Inner closure: download + journal stamp + emit. Closes over `ctx`,
+  // `journal`, `companyRoot`, `journalSlug`, the counters, and `emit`. Keeps
+  // the four call sites (new file, fast-forward, degraded overwrite, legacy
+  // refresh) DRY without leaking journal-write details into the main loop.
+  async function tryDownload(key: string): Promise<"ok" | "abort" | "error"> {
+    const localPath = path.join(companyRoot, key);
+    try {
+      const result = await downloadFile(ctx, key, localPath);
+      const hash = hashFile(localPath);
+      const stat = fs.statSync(localPath);
+      updateEntry(journal, key, hash, stat.size, "down", result.versionId);
+
+      const journalMessage = (journal.files[key] as { message?: string } | undefined)?.message;
+      emit({
+        type: "progress",
+        path: key,
+        bytes: stat.size,
+        ...(journalMessage ? { message: journalMessage } : {}),
+      });
+
+      filesDownloaded++;
+      bytesDownloaded += stat.size;
+      return "ok";
+    } catch (err) {
+      if (isAccessDenied(err)) {
+        filesSkipped++;
+        return "ok";
+      }
+      emit({
+        type: "error",
+        path: key,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return "error";
+    }
+  }
+}
+
+/**
+ * Pull detected divergence — the cloud's VersionId chain doesn't include
+ * our last-known parent (or cloud is fast-forward but local has uncommitted
+ * edits). Fetch cloud bytes, write to a `.conflict-` file next to the
+ * original, append to the conflict index, emit event.
+ *
+ * Local file is NOT modified. The user resolves later via the
+ * `/resolve-conflicts` skill.
+ */
+async function recordPullConflict(args: {
+  ctx: import("../types.js").EntityContext;
+  hqRoot: string;
+  remoteKey: string;
+  companySlug: string;
+  personalMode: boolean;
+  localHash: string;
+  remoteVersionId: string;
+  lastKnownVersionId: string;
+  emit: (event: SyncProgressEvent) => void;
+}): Promise<void> {
+  const {
+    ctx,
+    hqRoot,
+    remoteKey,
+    companySlug,
+    personalMode,
+    localHash,
+    remoteVersionId,
+    lastKnownVersionId,
+    emit,
+  } = args;
+
+  // Personal mode keys are HQ-relative; company keys live under
+  // companies/<slug>/. Conflict files always sit next to the original on
+  // disk — translate the S3 key to the HQ-relative path.
+  const hqRelativeOriginal = personalMode
+    ? remoteKey
+    : path.join("companies", companySlug, remoteKey);
+  const detectedAt = new Date().toISOString();
+  const machineId = readShortMachineId();
+
+  let cloudBytes: Buffer;
+  let cloudVersionId: string | null;
+  try {
+    const fetched = await downloadFileBytes(ctx, remoteKey);
+    cloudBytes = fetched.bytes;
+    cloudVersionId = fetched.versionId;
+  } catch (err) {
+    emit({
+      type: "error",
+      path: remoteKey,
+      message: `conflict detected but cloud fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    });
+    return;
+  }
+
+  const conflictRelative = buildConflictPath(hqRelativeOriginal, detectedAt, machineId);
+  writeConflictFile(hqRoot, conflictRelative, cloudBytes);
+
+  const remoteHash = crypto.createHash("sha256").update(cloudBytes).digest("hex");
+
+  appendConflictEntry(hqRoot, {
+    id: buildConflictId(hqRelativeOriginal, detectedAt),
+    originalPath: hqRelativeOriginal,
+    conflictPath: conflictRelative,
+    detectedAt,
+    side: "pull",
+    machineId,
+    localHash,
+    remoteHash,
+    remoteVersionId: cloudVersionId ?? remoteVersionId,
+    lastKnownVersionId,
+  });
+
+  emit({
+    type: "conflict-detected",
+    path: remoteKey,
+    conflictPath: conflictRelative,
+    side: "pull",
+    remoteVersionId: cloudVersionId ?? remoteVersionId,
+  });
 }
 
 /**
@@ -249,6 +474,10 @@ function defaultConsoleLogger(event: SyncProgressEvent): void {
     } else {
       console.log(`  ✓ ${event.path}`);
     }
+  } else if (event.type === "conflict-detected") {
+    console.error(
+      `  ! conflict: ${event.path} — cloud version saved as ${event.conflictPath}`,
+    );
   } else if (event.type === "error") {
     console.error(`  ✗ ${event.path} — ${event.message}`);
   }

--- a/packages/hq-cloud/src/ignore.ts
+++ b/packages/hq-cloud/src/ignore.ts
@@ -68,6 +68,18 @@ export const DEFAULT_IGNORES = [
   ".hq-sync-state.json",
   "modules.lock",
 
+  // Conflict files — local-only by design. Each machine resolves its own
+  // queue; uploading a `.conflict-` file to the cloud would just create
+  // more conflicts on the other side. Pattern matches:
+  //   knowledge/notes.md.conflict-2026-04-27T22-05-14Z-abc123.md
+  //   projects/foo/prd.json.conflict-2026-04-27T22-05-14Z-abc123.json
+  "*.conflict-*-*.*",
+  // Files with no extension still get the suffix (no trailing `.<ext>`):
+  //   secrets.conflict-2026-04-27T22-05-14Z-abc123
+  "*.conflict-*-*",
+  // The conflict index dir itself — pending-conflict metadata, not user content.
+  ".hq-conflicts/",
+
   // HQ repos directory (managed separately, not synced)
   "repos/",
 

--- a/packages/hq-cloud/src/index.ts
+++ b/packages/hq-cloud/src/index.ts
@@ -15,12 +15,30 @@ export {
 export {
   uploadFile,
   downloadFile,
+  downloadFileBytes,
   listRemoteFiles,
+  listObjectVersions,
   deleteRemoteFile,
   headRemoteFile,
+  isPreconditionFailed,
 } from "./s3.js";
 
-export type { RemoteFile } from "./s3.js";
+export type { RemoteFile, UploadOptions, UploadResult, DownloadResult } from "./s3.js";
+
+// Conflict-tracking primitives (lineage v5.3)
+export {
+  buildConflictPath,
+  buildConflictId,
+  readShortMachineId,
+  writeConflictFile,
+} from "./lib/conflict-file.js";
+export {
+  appendConflictEntry,
+  getConflictIndexPath,
+  readConflictIndex,
+  removeConflictEntry,
+  writeConflictIndex,
+} from "./lib/conflict-index.js";
 
 export {
   readJournal,
@@ -108,4 +126,6 @@ export type {
   PushResult,
   PullResult,
   DaemonState,
+  ConflictIndex,
+  ConflictIndexEntry,
 } from "./types.js";

--- a/packages/hq-cloud/src/journal.ts
+++ b/packages/hq-cloud/src/journal.ts
@@ -74,18 +74,32 @@ export function hashFile(filePath: string): string {
   return crypto.createHash("sha256").update(content).digest("hex");
 }
 
+/**
+ * Update or insert a journal entry.
+ *
+ * `s3VersionId` is optional — when not provided, the field is omitted from
+ * the entry (preserves the pre-lineage behavior for any caller that hasn't
+ * been migrated). New code paths explicitly pass the VersionId returned by
+ * S3 on upload/download so divergence detection has a parent pointer to
+ * compare against on the next sync.
+ *
+ * Pass `null` (vs. undefined) to record "the bucket has versioning disabled"
+ * — distinct from "we don't know" — see the JournalEntry doc on s3VersionId.
+ */
 export function updateEntry(
   journal: SyncJournal,
   relativePath: string,
   hash: string,
   size: number,
   direction: "up" | "down",
+  s3VersionId?: string | null,
 ): void {
   journal.files[relativePath] = {
     hash,
     size,
     syncedAt: new Date().toISOString(),
     direction,
+    ...(s3VersionId !== undefined ? { s3VersionId } : {}),
   };
   journal.lastSync = new Date().toISOString();
 }

--- a/packages/hq-cloud/src/lib/conflict-file.ts
+++ b/packages/hq-cloud/src/lib/conflict-file.ts
@@ -1,0 +1,101 @@
+/**
+ * Conflict file naming + writing.
+ *
+ * When share/sync detects divergence, the cloud's version of the file is
+ * written next to the original with a name encoding the timestamp and the
+ * machine that detected the conflict. Lets multiple machines independently
+ * surface their own conflicts without name collisions, and lets the user
+ * (or the `/resolve-conflicts` HQ skill) see local + cloud side-by-side
+ * in their file browser.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Path to `~/.hq/menubar.json`. Evaluated lazily at call time (not module
+ * load) so that tests overriding `HOME` after import — and any future code
+ * that changes the user's effective home dir at runtime — see the right
+ * file. Going through `os.homedir()` rather than `process.env.HOME` keeps
+ * the Windows USERPROFILE fallback intact.
+ */
+function menubarJsonPath(): string {
+  return path.join(os.homedir(), ".hq", "menubar.json");
+}
+
+/**
+ * Read the short machine ID (first 6 chars) from `~/.hq/menubar.json`.
+ * Falls back to "unknown" if the file is missing/unreadable — conflict
+ * files should still be written even when machine identity is unclear.
+ */
+export function readShortMachineId(): string {
+  try {
+    const raw = fs.readFileSync(menubarJsonPath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    const id = typeof parsed.machineId === "string" ? parsed.machineId : "";
+    return id.slice(0, 6) || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Build the conflict file path for an original. ISO uses `-` instead of
+ * `:` so the result is filesystem-safe on every OS, and the original
+ * extension is preserved at the end so editors syntax-highlight correctly.
+ *
+ *   knowledge/notes.md, 2026-04-27T22:05:14Z, abc123
+ *     → knowledge/notes.md.conflict-2026-04-27T22-05-14Z-abc123.md
+ *
+ *   projects/foo/prd.json, ..., abc123
+ *     → projects/foo/prd.json.conflict-...-abc123.json
+ *
+ * Files without an extension get the `.conflict-...` suffix appended verbatim.
+ */
+export function buildConflictPath(
+  originalRelative: string,
+  detectedAt: string,
+  shortMachineId: string,
+): string {
+  const safeTs = detectedAt.replace(/:/g, "-").replace(/\.\d+/, "");
+  const ext = path.extname(originalRelative); // ".md" or "" if none
+  // The full original path is preserved (extension and all) so users can
+  // visually pair `notes.md` with `notes.md.conflict-…md` in their file
+  // browser. The trailing `<ext>` after the timestamp keeps the file
+  // syntax-highlighted in editors that key off the final extension.
+  const suffix = `.conflict-${safeTs}-${shortMachineId}${ext}`;
+  return `${originalRelative}${suffix}`;
+}
+
+/**
+ * Write the cloud-side bytes to the conflict path. Creates parent dirs as
+ * needed (the conflict file always lives next to the original, so the
+ * parent already exists in the steady-state — but defense-in-depth).
+ */
+export function writeConflictFile(
+  hqRoot: string,
+  conflictRelative: string,
+  contents: Buffer,
+): void {
+  const abs = path.join(hqRoot, conflictRelative);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+/**
+ * Stable conflict ID — used to dedupe re-detections of the same conflict.
+ * Re-running sync after a conflict but before the user has resolved should
+ * NOT pile up duplicate entries. The id is derived from the original path
+ * and the detection timestamp; if the same original conflicts twice with
+ * the user resolving in between, that's a new id (different timestamp),
+ * which is correct.
+ */
+export function buildConflictId(
+  originalRelative: string,
+  detectedAt: string,
+): string {
+  const safeTs = detectedAt.replace(/:/g, "-").replace(/\.\d+/, "");
+  const safePath = originalRelative.replace(/[\/\\.]/g, "-");
+  return `${safePath}-${safeTs}`;
+}

--- a/packages/hq-cloud/src/lib/conflict-index.ts
+++ b/packages/hq-cloud/src/lib/conflict-index.ts
@@ -1,0 +1,127 @@
+/**
+ * Conflict index — durable record of pending divergences awaiting resolution.
+ *
+ * Lives at `<hq_root>/.hq-conflicts/index.json` (inside HQ content, NOT in
+ * `~/.hq/`). Two reasons it sits in HQ content rather than in the state dir:
+ *   1. The `/resolve-conflicts` HQ skill discovers it relative to the user's
+ *      HQ folder — that's the user's mental anchor for "where my files are."
+ *   2. The conflict-side files themselves live in HQ content, so the index
+ *      and the files it references stay co-located. If the user moves HQ,
+ *      the index moves with it.
+ *
+ * Excluded from cross-machine sync via `.hqignore` — each machine resolves
+ * its own queue. We never propagate conflict files (they'd just create more
+ * conflicts on the other side).
+ *
+ * Writes are atomic (tmp + rename). The resolution skill mutates this file
+ * mid-walk; a torn write would corrupt the only record of pending conflicts
+ * and could lose track of files we'd written to disk. Higher stakes than the
+ * journal, which the next sync can rebuild.
+ */
+
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import type { ConflictIndex, ConflictIndexEntry } from "../types.js";
+
+const CONFLICTS_DIR = ".hq-conflicts";
+const INDEX_FILENAME = "index.json";
+
+/**
+ * Absolute path to the conflict index for a given HQ root.
+ */
+export function getConflictIndexPath(hqRoot: string): string {
+  return path.join(hqRoot, CONFLICTS_DIR, INDEX_FILENAME);
+}
+
+/**
+ * Read the conflict index. Returns an empty index if the file doesn't exist
+ * yet (first-conflict-ever case).
+ *
+ * Throws on corrupt JSON — we deliberately don't auto-repair, since the only
+ * record of pending conflicts is too important to silently overwrite. The
+ * `/resolve-conflicts` skill surfaces this case to the user with a manual
+ * inspection prompt.
+ */
+export function readConflictIndex(hqRoot: string): ConflictIndex {
+  const indexPath = getConflictIndexPath(hqRoot);
+  if (!fs.existsSync(indexPath)) {
+    return { version: 1, conflicts: [] };
+  }
+  const raw = fs.readFileSync(indexPath, "utf-8");
+  const parsed = JSON.parse(raw) as ConflictIndex;
+  // Defensive: an empty file or wrong-shape JSON shouldn't crash callers.
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.conflicts)) {
+    return { version: 1, conflicts: [] };
+  }
+  return parsed;
+}
+
+/**
+ * Atomically write the conflict index. Writes to `<index>.tmp.<random>` then
+ * renames into place — `rename(2)` is atomic on POSIX, so a crash mid-write
+ * leaves either the old file or the new one, never a half-written one.
+ *
+ * Always sorts conflicts by `detectedAt` ascending before writing — keeps
+ * the file diff-friendly across runs and makes "oldest-first walk" the
+ * natural read order in the resolution skill.
+ */
+export function writeConflictIndex(
+  hqRoot: string,
+  index: ConflictIndex,
+): void {
+  const indexPath = getConflictIndexPath(hqRoot);
+  fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+
+  const sorted: ConflictIndex = {
+    version: index.version,
+    conflicts: [...index.conflicts].sort((a, b) =>
+      a.detectedAt.localeCompare(b.detectedAt),
+    ),
+  };
+
+  // Random suffix in tmp name avoids collision if two sync runs ever overlap
+  // (shouldn't happen — the runner serializes — but cheap insurance).
+  const tmpPath = `${indexPath}.tmp.${crypto.randomBytes(6).toString("hex")}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(sorted, null, 2));
+  fs.renameSync(tmpPath, indexPath);
+}
+
+/**
+ * Idempotent append. If an entry with the same `id` already exists (same
+ * original path, same detection timestamp), update it in place rather than
+ * duplicating. This matters because re-running sync after a conflict but
+ * before resolution will re-detect the same divergence — without dedup the
+ * index would grow unboundedly.
+ *
+ * The "update in place" path also covers the case where the cloud advanced
+ * again between detections: we want the latest `remoteVersionId` and
+ * `remoteHash` so the resolution skill shows the user the *current* cloud
+ * state, not stale data from the first detection.
+ */
+export function appendConflictEntry(
+  hqRoot: string,
+  entry: ConflictIndexEntry,
+): void {
+  const index = readConflictIndex(hqRoot);
+  const existingIdx = index.conflicts.findIndex((c) => c.id === entry.id);
+  if (existingIdx >= 0) {
+    index.conflicts[existingIdx] = entry;
+  } else {
+    index.conflicts.push(entry);
+  }
+  writeConflictIndex(hqRoot, index);
+}
+
+/**
+ * Remove an entry by id. Used by the `/resolve-conflicts` skill after the
+ * user picks a resolution and the conflict file is cleaned up. No-op if the
+ * id isn't present (e.g. user manually removed the file then re-ran the
+ * skill — we want that to be a clean exit, not an error).
+ */
+export function removeConflictEntry(hqRoot: string, id: string): void {
+  const index = readConflictIndex(hqRoot);
+  const filtered = index.conflicts.filter((c) => c.id !== id);
+  if (filtered.length === index.conflicts.length) return;
+  writeConflictIndex(hqRoot, { version: index.version, conflicts: filtered });
+}

--- a/packages/hq-cloud/src/lib/conflict.test.ts
+++ b/packages/hq-cloud/src/lib/conflict.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the pure conflict primitives — path building, machine-id
+ * fallback, atomic index writes, dedup. Kept in one file so the related
+ * helpers stay co-located.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  buildConflictPath,
+  buildConflictId,
+  readShortMachineId,
+} from "./conflict-file.js";
+import {
+  appendConflictEntry,
+  getConflictIndexPath,
+  readConflictIndex,
+  removeConflictEntry,
+  writeConflictIndex,
+} from "./conflict-index.js";
+import type { ConflictIndexEntry } from "../types.js";
+
+describe("buildConflictPath", () => {
+  it("inserts the conflict marker before the original extension", () => {
+    expect(
+      buildConflictPath("knowledge/notes.md", "2026-04-27T22:05:14Z", "abc123"),
+    ).toBe("knowledge/notes.md.conflict-2026-04-27T22-05-14Z-abc123.md");
+  });
+
+  it("preserves nested paths and json extensions", () => {
+    expect(
+      buildConflictPath("projects/foo/prd.json", "2026-04-27T22:05:14.123Z", "abc123"),
+    ).toBe("projects/foo/prd.json.conflict-2026-04-27T22-05-14Z-abc123.json");
+  });
+
+  it("appends the suffix verbatim for files without an extension", () => {
+    expect(
+      buildConflictPath("secrets", "2026-04-27T22:05:14Z", "abc123"),
+    ).toBe("secrets.conflict-2026-04-27T22-05-14Z-abc123");
+  });
+});
+
+describe("buildConflictId", () => {
+  it("escapes path separators and dots so the id is filesystem-safe", () => {
+    expect(
+      buildConflictId("knowledge/notes.md", "2026-04-27T22:05:14Z"),
+    ).toBe("knowledge-notes-md-2026-04-27T22-05-14Z");
+  });
+
+  it("yields the same id for the same (path, ts) pair — dedup primitive", () => {
+    const a = buildConflictId("foo/bar.md", "2026-04-27T22:05:14Z");
+    const b = buildConflictId("foo/bar.md", "2026-04-27T22:05:14Z");
+    expect(a).toBe(b);
+  });
+});
+
+describe("readShortMachineId", () => {
+  let originalHome: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "hq-machineid-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns the first 6 chars when menubar.json has a machineId", () => {
+    fs.mkdirSync(path.join(tmpHome, ".hq"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, ".hq", "menubar.json"),
+      JSON.stringify({ machineId: "deadbeefcafe1234567890" }),
+    );
+    expect(readShortMachineId()).toBe("deadbe");
+  });
+
+  it("falls back to 'unknown' when menubar.json is missing", () => {
+    expect(readShortMachineId()).toBe("unknown");
+  });
+
+  it("falls back to 'unknown' when menubar.json is malformed", () => {
+    fs.mkdirSync(path.join(tmpHome, ".hq"), { recursive: true });
+    fs.writeFileSync(path.join(tmpHome, ".hq", "menubar.json"), "{not-json");
+    expect(readShortMachineId()).toBe("unknown");
+  });
+});
+
+describe("conflict index", () => {
+  let tmpHq: string;
+
+  beforeEach(() => {
+    tmpHq = fs.mkdtempSync(path.join(os.tmpdir(), "hq-cidx-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHq, { recursive: true, force: true });
+  });
+
+  function entry(overrides: Partial<ConflictIndexEntry> = {}): ConflictIndexEntry {
+    return {
+      id: "knowledge-notes-md-2026-04-27T22-05-14Z",
+      originalPath: "knowledge/notes.md",
+      conflictPath: "knowledge/notes.md.conflict-2026-04-27T22-05-14Z-abc123.md",
+      detectedAt: "2026-04-27T22:05:14Z",
+      side: "pull",
+      machineId: "abc123",
+      localHash: "local",
+      remoteHash: "remote",
+      remoteVersionId: "v2",
+      lastKnownVersionId: "v1",
+      ...overrides,
+    };
+  }
+
+  it("returns an empty index when the file does not exist", () => {
+    const idx = readConflictIndex(tmpHq);
+    expect(idx).toEqual({ version: 1, conflicts: [] });
+  });
+
+  it("creates the .hq-conflicts dir on first write", () => {
+    appendConflictEntry(tmpHq, entry());
+    expect(fs.existsSync(getConflictIndexPath(tmpHq))).toBe(true);
+    expect(fs.existsSync(path.join(tmpHq, ".hq-conflicts"))).toBe(true);
+  });
+
+  it("appends new entries and dedupes on id (idempotent re-detection)", () => {
+    appendConflictEntry(tmpHq, entry({ id: "a", remoteVersionId: "v1" }));
+    appendConflictEntry(tmpHq, entry({ id: "b", remoteVersionId: "v1" }));
+    // Re-detect "a" — the second push should update in place, not duplicate.
+    appendConflictEntry(tmpHq, entry({ id: "a", remoteVersionId: "v9" }));
+
+    const idx = readConflictIndex(tmpHq);
+    expect(idx.conflicts).toHaveLength(2);
+    const a = idx.conflicts.find((c) => c.id === "a");
+    expect(a?.remoteVersionId).toBe("v9"); // updated, not appended
+  });
+
+  it("sorts conflicts by detectedAt ascending on every write", () => {
+    appendConflictEntry(tmpHq, entry({ id: "newer", detectedAt: "2026-04-27T23:00:00Z" }));
+    appendConflictEntry(tmpHq, entry({ id: "older", detectedAt: "2026-04-27T22:00:00Z" }));
+    const idx = readConflictIndex(tmpHq);
+    expect(idx.conflicts.map((c) => c.id)).toEqual(["older", "newer"]);
+  });
+
+  it("removeConflictEntry removes a single entry by id", () => {
+    appendConflictEntry(tmpHq, entry({ id: "keep" }));
+    appendConflictEntry(tmpHq, entry({ id: "drop" }));
+    removeConflictEntry(tmpHq, "drop");
+    const idx = readConflictIndex(tmpHq);
+    expect(idx.conflicts.map((c) => c.id)).toEqual(["keep"]);
+  });
+
+  it("removeConflictEntry is a no-op when the id is not present", () => {
+    appendConflictEntry(tmpHq, entry({ id: "a" }));
+    expect(() => removeConflictEntry(tmpHq, "missing")).not.toThrow();
+    expect(readConflictIndex(tmpHq).conflicts).toHaveLength(1);
+  });
+
+  it("writeConflictIndex leaves no .tmp files on disk after success", () => {
+    writeConflictIndex(tmpHq, { version: 1, conflicts: [entry()] });
+    const files = fs.readdirSync(path.join(tmpHq, ".hq-conflicts"));
+    // Only index.json should remain; tmp files renamed atomically into place.
+    expect(files).toEqual(["index.json"]);
+  });
+
+  it("returns an empty index for malformed-but-parseable JSON", () => {
+    const indexPath = getConflictIndexPath(tmpHq);
+    fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+    fs.writeFileSync(indexPath, JSON.stringify({ version: 1 })); // no `conflicts` array
+    const idx = readConflictIndex(tmpHq);
+    expect(idx.conflicts).toEqual([]);
+  });
+});

--- a/packages/hq-cloud/src/s3.ts
+++ b/packages/hq-cloud/src/s3.ts
@@ -13,6 +13,7 @@ import {
   PutObjectCommand,
   GetObjectCommand,
   ListObjectsV2Command,
+  ListObjectVersionsCommand,
   DeleteObjectCommand,
   HeadObjectCommand,
 } from "@aws-sdk/client-s3";
@@ -34,29 +35,69 @@ function buildClient(ctx: EntityContext): S3Client {
   });
 }
 
+/**
+ * Result of a successful upload.
+ *
+ * `versionId` is the opaque S3 VersionId of the new object. It's `null` when
+ * the bucket has versioning disabled (S3 returns the literal string "null" in
+ * that case; we surface it as JS `null` so callers can distinguish "we know
+ * there's no version" from "the field wasn't returned"). Callers stamp this
+ * into the journal as the parent pointer for the next push.
+ */
+export interface UploadResult {
+  versionId: string | null;
+}
+
+/**
+ * Optional knobs for `uploadFile`. `ifMatch` is the optimistic-concurrency
+ * primitive: when set, S3 atomically rejects the PUT (412 Precondition
+ * Failed) if the cloud's current VersionId differs from the supplied value.
+ * That's how we detect divergence on the push side without a separate HEAD
+ * race window.
+ */
+export interface UploadOptions {
+  ifMatch?: string;
+}
+
 export async function uploadFile(
   ctx: EntityContext,
   localPath: string,
   key: string,
-): Promise<void> {
+  options: UploadOptions = {},
+): Promise<UploadResult> {
   const client = buildClient(ctx);
   const body = fs.readFileSync(localPath);
 
-  await client.send(
+  const response = await client.send(
     new PutObjectCommand({
       Bucket: ctx.bucketName,
       Key: key,
       Body: body,
       ContentType: getMimeType(key),
+      // Only include IfMatch when caller provides one — undefined and the
+      // header is omitted, preserving the unconditional-PUT path for
+      // brand-new files (no journal entry → no parent pointer).
+      ...(options.ifMatch !== undefined ? { IfMatch: options.ifMatch } : {}),
     }),
   );
+
+  return { versionId: normalizeVersionId(response.VersionId) };
+}
+
+/**
+ * Result of a successful download. `versionId` is the cloud's VersionId of
+ * the bytes the caller just wrote to disk — pull stamps this into the
+ * journal as the new parent pointer.
+ */
+export interface DownloadResult {
+  versionId: string | null;
 }
 
 export async function downloadFile(
   ctx: EntityContext,
   key: string,
   localPath: string,
-): Promise<void> {
+): Promise<DownloadResult> {
   const client = buildClient(ctx);
 
   const response = await client.send(
@@ -81,6 +122,42 @@ export async function downloadFile(
     chunks.push(Buffer.from(chunk));
   }
   fs.writeFileSync(localPath, Buffer.concat(chunks));
+
+  return { versionId: normalizeVersionId(response.VersionId) };
+}
+
+/**
+ * Fetch a key's bytes without writing to disk. Used by the conflict path:
+ * when divergence is detected, we want the cloud's bytes in memory so we
+ * can write them to a `.conflict-` file next to the original. Going through
+ * the disk-writing `downloadFile` would require a tmp file dance.
+ */
+export async function downloadFileBytes(
+  ctx: EntityContext,
+  key: string,
+): Promise<{ bytes: Buffer; versionId: string | null }> {
+  const client = buildClient(ctx);
+
+  const response = await client.send(
+    new GetObjectCommand({
+      Bucket: ctx.bucketName,
+      Key: key,
+    }),
+  );
+
+  if (!response.Body) {
+    throw new Error(`Empty response for ${key}`);
+  }
+
+  const chunks: Buffer[] = [];
+  const stream = response.Body as AsyncIterable<Uint8Array>;
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return {
+    bytes: Buffer.concat(chunks),
+    versionId: normalizeVersionId(response.VersionId),
+  };
 }
 
 export interface RemoteFile {
@@ -140,11 +217,19 @@ export async function deleteRemoteFile(
 
 /**
  * Check if a remote key exists and return its metadata.
+ *
+ * Includes `versionId` so callers can compare against the journal's
+ * `s3VersionId` for divergence detection without a separate API call.
  */
 export async function headRemoteFile(
   ctx: EntityContext,
   key: string,
-): Promise<{ lastModified: Date; etag: string; size: number } | null> {
+): Promise<{
+  lastModified: Date;
+  etag: string;
+  size: number;
+  versionId: string | null;
+} | null> {
   const client = buildClient(ctx);
   try {
     const response = await client.send(
@@ -157,6 +242,7 @@ export async function headRemoteFile(
       lastModified: response.LastModified || new Date(),
       etag: response.ETag || "",
       size: response.ContentLength || 0,
+      versionId: normalizeVersionId(response.VersionId),
     };
   } catch (err: unknown) {
     if (err && typeof err === "object" && "name" in err && err.name === "NotFound") {
@@ -164,6 +250,84 @@ export async function headRemoteFile(
     }
     throw err;
   }
+}
+
+/**
+ * List recent VersionIds for a key, newest first.
+ *
+ * Capped at `maxVersions` (default 100). The cap matters for two reasons:
+ *   1. ListObjectVersions paginates, and the entire bucket's history could
+ *      be huge — we never need more than the recent chain.
+ *   2. If our last-known VersionId isn't in the most recent N, the file has
+ *      effectively diverged in ancient history and treating it as a conflict
+ *      is the safe choice (no realistic fast-forward beyond N versions ago).
+ *
+ * Returns just the IDs (string[]) — callers only need them for chain-membership
+ * checks, not the full version metadata.
+ */
+export async function listObjectVersions(
+  ctx: EntityContext,
+  key: string,
+  maxVersions = 100,
+): Promise<string[]> {
+  const client = buildClient(ctx);
+  const versions: string[] = [];
+  let keyMarker: string | undefined;
+  let versionIdMarker: string | undefined;
+
+  while (versions.length < maxVersions) {
+    const response = await client.send(
+      new ListObjectVersionsCommand({
+        Bucket: ctx.bucketName,
+        Prefix: key,
+        KeyMarker: keyMarker,
+        VersionIdMarker: versionIdMarker,
+        MaxKeys: Math.min(maxVersions - versions.length, 1000),
+      }),
+    );
+
+    for (const v of response.Versions || []) {
+      // Prefix is a starts-with filter, so a key like "notes.md" would
+      // also match "notes.md.backup". Filter to exact key matches only.
+      if (v.Key !== key) continue;
+      if (!v.VersionId) continue;
+      versions.push(v.VersionId);
+      if (versions.length >= maxVersions) break;
+    }
+
+    if (!response.IsTruncated) break;
+    keyMarker = response.NextKeyMarker;
+    versionIdMarker = response.NextVersionIdMarker;
+  }
+
+  return versions;
+}
+
+/**
+ * Did this error come from a failed `If-Match` precondition (HTTP 412)?
+ *
+ * AWS SDK v3 surfaces this as `name: "PreconditionFailed"` with
+ * `$metadata.httpStatusCode === 412`. Either signal is sufficient; we check
+ * both to be robust against SDK error-shape changes.
+ */
+export function isPreconditionFailed(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+  if (e.name === "PreconditionFailed") return true;
+  if (e.$metadata?.httpStatusCode === 412) return true;
+  return false;
+}
+
+/**
+ * S3 returns the literal string "null" for objects in buckets where
+ * versioning is disabled (or was disabled when the object was put). We
+ * surface that as JS `null` to keep the TS type honest — `s3VersionId === "null"`
+ * would otherwise be a footgun across the journal.
+ */
+function normalizeVersionId(raw: string | undefined): string | null {
+  if (!raw) return null;
+  if (raw === "null") return null;
+  return raw;
 }
 
 function getMimeType(filePath: string): string {

--- a/packages/hq-cloud/src/types.ts
+++ b/packages/hq-cloud/src/types.ts
@@ -26,12 +26,73 @@ export interface JournalEntry {
   size: number;
   syncedAt: string;
   direction: "up" | "down";
+  /**
+   * Opaque S3 VersionId of the cloud object at last successful sync.
+   * Used as a parent pointer for divergence detection: pushes include it as
+   * `If-Match` precondition; pulls compare it against the cloud's current
+   * VersionId to distinguish fast-forward from divergence.
+   *
+   * Optional for backwards compatibility with journals written before
+   * lineage tracking shipped. Missing = degraded mode (push without
+   * If-Match, pull always treated as fast-forward). The next successful
+   * sync stamps it.
+   *
+   * `null` (vs undefined) means the bucket has versioning disabled —
+   * we got `VersionId: "null"` from S3 but recorded it explicitly so
+   * we can distinguish "we know there's no version" from "field absent."
+   */
+  s3VersionId?: string | null;
 }
 
 export interface SyncJournal {
   version: "1";
   lastSync: string;
   files: Record<string, JournalEntry>;
+}
+
+/**
+ * Per-entry record in `~/HQ/.hq-conflicts/index.json`. Written by share/sync
+ * when divergence is detected (push with stale If-Match → 412, or pull where
+ * cloud's VersionId chain doesn't include our last-known VersionId).
+ *
+ * Read by the `/resolve-conflicts` HQ skill which walks the user through
+ * each entry, applies their decision (keep local | take cloud | discard),
+ * cleans up the conflict file, and removes the entry from the index.
+ */
+export interface ConflictIndexEntry {
+  /** Stable identifier — derived from path + detectedAt. Lets the index
+   *  writer dedupe re-detections of the same conflict. */
+  id: string;
+  /** Path relative to hq_root of the original file (the local-canonical
+   *  copy). Stays in place; the user resolves *into* it. */
+  originalPath: string;
+  /** Path relative to hq_root of the `.conflict-<ts>-<machine>.<ext>` file
+   *  containing the cloud version that diverged from local. Excluded from
+   *  sync via `.hqignore`. */
+  conflictPath: string;
+  /** ISO 8601 timestamp the conflict was detected. */
+  detectedAt: string;
+  /** Which side detected the conflict — push (local→cloud rejected by
+   *  If-Match) or pull (cloud→local download saw divergent chain). */
+  side: "push" | "pull";
+  /** Short machine ID (first 6 chars of `~/.hq/menubar.json` machineId)
+   *  to disambiguate when multiple machines conflict on the same key. */
+  machineId: string;
+  /** sha256 of the local file at detection time. */
+  localHash: string;
+  /** sha256 of the cloud file at detection time. */
+  remoteHash: string;
+  /** Cloud's current S3 VersionId at detection. */
+  remoteVersionId: string;
+  /** The VersionId we *thought* was the parent — i.e. what was in our
+   *  journal entry. The chain from `lastKnownVersionId` to
+   *  `remoteVersionId` is the divergent gap. */
+  lastKnownVersionId: string | null;
+}
+
+export interface ConflictIndex {
+  version: 1;
+  conflicts: ConflictIndexEntry[];
 }
 
 export interface SyncStatus {


### PR DESCRIPTION
## Summary

Detects sync divergence cleanly via S3 VersionId chains so two machines (or two users) editing the same file never silently overwrite each other.

- **Push side:** `PUT` with `If-Match: <last-known-VersionId>` → S3 atomically rejects (412) when cloud has advanced past our parent. On 412, fetch cloud bytes, write `<original>.conflict-<ts>-<machine>.<ext>` next to the original, append to `~/HQ/.hq-conflicts/index.json`, emit `conflict-detected` event. **Local stays untouched.**
- **Pull side:** HEAD remote, compare `versionId` to journal's `s3VersionId`. On mismatch, walk `ListObjectVersions` (capped at 100) — if our parent is in the chain it's a fast-forward (clean download); if not, divergence (write conflict file, leave local untouched).
- **Backwards-compatible:** pre-lineage journal entries (no `s3VersionId`) stay on the legacy timestamp+prompt flow until their first sync under the new code stamps a parent pointer.

New pure modules:
- `lib/conflict-file.ts` — path builder, machine-id reader, atomic writer
- `lib/conflict-index.ts` — read/append/dedup/remove with tmp+rename writes
- `lib/conflict.test.ts` — coverage for both modules

Schema additions:
- `JournalEntry.s3VersionId` (optional; `null` = bucket versioning disabled)

## Why now

This is a **prerequisite** for two follow-on PRs already prepared locally:
1. `feat/cloud-provision-cli` — adds `hq cloud provision company <slug>` (built on top of this branch)
2. `feat/resolve-conflicts` (in `hq-core-staging`) — kernel-level CLI consumer that walks the conflict index this code produces

Without this branch landed, both consumers have nothing to read.

## Test plan

- [ ] CI: `vitest run` passes (3 new test files: `share.test.ts`, `sync.test.ts`, `conflict.test.ts` — together +439 lines of tests)
- [ ] CI: existing `hq-cloud` tests still pass (no regressions in legacy timestamp+prompt path)
- [ ] Local manual: induce a real conflict by editing the same file on two machines; confirm `~/HQ/.hq-conflicts/index.json` populates and the `.conflict-<ts>-<machine>.<ext>` mirror file appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)