### PR TITLE
feat(hq-cli): `cloud provision company <slug>` — canonical cloud-promote subcommand

### DIFF
--- a/packages/hq-cli/src/commands/cloud-provision.test.ts
+++ b/packages/hq-cli/src/commands/cloud-provision.test.ts
@@ -1,0 +1,652 @@
+/**
+ * Unit tests for `hq cloud provision company <slug>` (cloud-provision.ts).
+ *
+ * Coverage targets:
+ *   - validateSlug — pure validation
+ *   - validateManifestAndDir — fs reads against tmp manifest + company dir
+ *   - patchManifest — atomic YAML mutation, preserves siblings, idempotent
+ *   - writeCompanyConfig — atomic JSON write, creates parent .hq/, idempotent
+ *   - createDefaultVaultClient — HTTP surface with mocked global fetch
+ *   - provisionCompany — full orchestrator with all dependencies injected
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+
+import {
+  ProvisionError,
+  type ProvisionResult,
+  type VaultClient,
+  type VaultEntity,
+  companyConfigPath,
+  companyDirPath,
+  createDefaultVaultClient,
+  manifestPath,
+  patchManifest,
+  provisionCompany,
+  validateManifestAndDir,
+  validateSlug,
+  writeCompanyConfig,
+} from "./cloud-provision.js";
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+let tmpRoot: string;
+
+function seedManifest(
+  root: string,
+  companies: Record<string, Record<string, unknown> | null> = {
+    indigo: { status: "active" },
+  },
+): void {
+  const mPath = manifestPath(root);
+  fs.mkdirSync(path.dirname(mPath), { recursive: true });
+  fs.writeFileSync(mPath, yaml.dump({ companies }));
+}
+
+function seedCompanyDir(root: string, slug: string): void {
+  fs.mkdirSync(companyDirPath(root, slug), { recursive: true });
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "hq-cloud-provision-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+// ── validateSlug ─────────────────────────────────────────────────────────────
+
+describe("validateSlug", () => {
+  it("accepts a valid slug", () => {
+    expect(() => validateSlug("indigo")).not.toThrow();
+    expect(() => validateSlug("acme-co")).not.toThrow();
+    expect(() => validateSlug("acme_co")).not.toThrow();
+    expect(() => validateSlug("acme.co")).not.toThrow();
+    expect(() => validateSlug("ACME123")).not.toThrow();
+  });
+
+  it("rejects an empty slug with code 2", () => {
+    expect(() => validateSlug("")).toThrowError(ProvisionError);
+    try {
+      validateSlug("");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProvisionError);
+      expect((e as ProvisionError).code).toBe(2);
+    }
+  });
+
+  it("rejects whitespace-only slug", () => {
+    expect(() => validateSlug("   ")).toThrowError(ProvisionError);
+  });
+
+  it("rejects slugs with invalid characters", () => {
+    expect(() => validateSlug("acme co")).toThrowError(/Invalid slug/);
+    expect(() => validateSlug("acme/co")).toThrowError(/Invalid slug/);
+    expect(() => validateSlug("acme!")).toThrowError(/Invalid slug/);
+    expect(() => validateSlug("acme$co")).toThrowError(/Invalid slug/);
+  });
+
+  it('rejects the reserved "personal" slug', () => {
+    expect(() => validateSlug("personal")).toThrowError(/reserved/);
+    try {
+      validateSlug("personal");
+    } catch (e) {
+      expect((e as ProvisionError).code).toBe(2);
+    }
+  });
+});
+
+// ── validateManifestAndDir ───────────────────────────────────────────────────
+
+describe("validateManifestAndDir", () => {
+  it("returns parsed manifest on the happy path", () => {
+    seedManifest(tmpRoot, { indigo: { status: "active" } });
+    seedCompanyDir(tmpRoot, "indigo");
+    const { manifest } = validateManifestAndDir(tmpRoot, "indigo");
+    expect(manifest.companies?.indigo).toEqual({ status: "active" });
+  });
+
+  it("throws code 2 if manifest.yaml is missing", () => {
+    seedCompanyDir(tmpRoot, "indigo");
+    try {
+      validateManifestAndDir(tmpRoot, "indigo");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProvisionError);
+      expect((e as ProvisionError).code).toBe(2);
+      expect((e as ProvisionError).message).toMatch(/manifest\.yaml not found/);
+    }
+  });
+
+  it("throws code 2 if manifest is malformed (no .companies)", () => {
+    const mPath = manifestPath(tmpRoot);
+    fs.mkdirSync(path.dirname(mPath), { recursive: true });
+    fs.writeFileSync(mPath, "not_companies: 'oops'\n");
+    seedCompanyDir(tmpRoot, "indigo");
+    expect(() => validateManifestAndDir(tmpRoot, "indigo")).toThrowError(
+      /malformed/,
+    );
+  });
+
+  it("throws code 2 if slug is missing from manifest", () => {
+    seedManifest(tmpRoot, { other: { status: "active" } });
+    seedCompanyDir(tmpRoot, "indigo");
+    try {
+      validateManifestAndDir(tmpRoot, "indigo");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as ProvisionError).code).toBe(2);
+      expect((e as ProvisionError).message).toMatch(/not found under \.companies/);
+    }
+  });
+
+  it("throws code 2 if company is status: archived", () => {
+    seedManifest(tmpRoot, { indigo: { status: "archived" } });
+    seedCompanyDir(tmpRoot, "indigo");
+    expect(() => validateManifestAndDir(tmpRoot, "indigo")).toThrowError(
+      /archived/,
+    );
+  });
+
+  it("throws code 2 if company directory is missing", () => {
+    seedManifest(tmpRoot, { indigo: { status: "active" } });
+    // Note: NOT calling seedCompanyDir
+    expect(() => validateManifestAndDir(tmpRoot, "indigo")).toThrowError(
+      /does not exist/,
+    );
+  });
+
+  it("accepts a manifest entry that is null (no fields)", () => {
+    seedManifest(tmpRoot, { indigo: null });
+    seedCompanyDir(tmpRoot, "indigo");
+    expect(() => validateManifestAndDir(tmpRoot, "indigo")).not.toThrow();
+  });
+});
+
+// ── patchManifest ────────────────────────────────────────────────────────────
+
+describe("patchManifest", () => {
+  beforeEach(() => {
+    seedManifest(tmpRoot, {
+      indigo: { status: "active", existing_field: "kept" },
+      other: { status: "active", cloud_uid: "cmp_other" },
+    });
+  });
+
+  it("writes cloud_uid + bucket_name under the target slug", () => {
+    patchManifest(tmpRoot, "indigo", "cmp_01H", "hq-vault-cmp-01H");
+    const after = yaml.load(
+      fs.readFileSync(manifestPath(tmpRoot), "utf-8"),
+    ) as { companies: Record<string, Record<string, unknown>> };
+    expect(after.companies.indigo.cloud_uid).toBe("cmp_01H");
+    expect(after.companies.indigo.bucket_name).toBe("hq-vault-cmp-01H");
+  });
+
+  it("preserves sibling fields on the target entry", () => {
+    patchManifest(tmpRoot, "indigo", "cmp_01H", "hq-vault-cmp-01H");
+    const after = yaml.load(
+      fs.readFileSync(manifestPath(tmpRoot), "utf-8"),
+    ) as { companies: Record<string, Record<string, unknown>> };
+    expect(after.companies.indigo.status).toBe("active");
+    expect(after.companies.indigo.existing_field).toBe("kept");
+  });
+
+  it("preserves other companies untouched", () => {
+    patchManifest(tmpRoot, "indigo", "cmp_01H", "hq-vault-cmp-01H");
+    const after = yaml.load(
+      fs.readFileSync(manifestPath(tmpRoot), "utf-8"),
+    ) as { companies: Record<string, Record<string, unknown>> };
+    expect(after.companies.other).toEqual({
+      status: "active",
+      cloud_uid: "cmp_other",
+    });
+  });
+
+  it("is idempotent — same inputs produce identical bytes", () => {
+    patchManifest(tmpRoot, "indigo", "cmp_01H", "hq-vault-cmp-01H");
+    const first = fs.readFileSync(manifestPath(tmpRoot), "utf-8");
+    patchManifest(tmpRoot, "indigo", "cmp_01H", "hq-vault-cmp-01H");
+    const second = fs.readFileSync(manifestPath(tmpRoot), "utf-8");
+    expect(second).toBe(first);
+  });
+
+  it("does not leave a .tmp file behind on success", () => {
+    patchManifest(tmpRoot, "indigo", "cmp_01H", "hq-vault-cmp-01H");
+    const dir = fs.readdirSync(path.dirname(manifestPath(tmpRoot)));
+    expect(dir.filter((f) => f.includes(".tmp."))).toEqual([]);
+  });
+
+  it("creates the .companies entry if the slug had a null value", () => {
+    seedManifest(tmpRoot, { newco: null });
+    patchManifest(tmpRoot, "newco", "cmp_NEW", "hq-vault-cmp-NEW");
+    const after = yaml.load(
+      fs.readFileSync(manifestPath(tmpRoot), "utf-8"),
+    ) as { companies: Record<string, Record<string, unknown>> };
+    expect(after.companies.newco).toEqual({
+      cloud_uid: "cmp_NEW",
+      bucket_name: "hq-vault-cmp-NEW",
+    });
+  });
+});
+
+// ── writeCompanyConfig ───────────────────────────────────────────────────────
+
+describe("writeCompanyConfig", () => {
+  beforeEach(() => {
+    seedCompanyDir(tmpRoot, "indigo");
+  });
+
+  it("writes valid JSON with all four fields", () => {
+    writeCompanyConfig(tmpRoot, "indigo", {
+      companyUid: "cmp_01H",
+      companySlug: "indigo",
+      bucketName: "hq-vault-cmp-01H",
+      vaultApiUrl: "https://vault.example.com",
+    });
+    const cPath = companyConfigPath(tmpRoot, "indigo");
+    const parsed = JSON.parse(fs.readFileSync(cPath, "utf-8"));
+    expect(parsed).toEqual({
+      companyUid: "cmp_01H",
+      companySlug: "indigo",
+      bucketName: "hq-vault-cmp-01H",
+      vaultApiUrl: "https://vault.example.com",
+    });
+  });
+
+  it("creates the parent .hq/ directory if missing", () => {
+    const hqDir = path.join(companyDirPath(tmpRoot, "indigo"), ".hq");
+    expect(fs.existsSync(hqDir)).toBe(false);
+    writeCompanyConfig(tmpRoot, "indigo", {
+      companyUid: "cmp_01H",
+      companySlug: "indigo",
+      bucketName: "b",
+      vaultApiUrl: "u",
+    });
+    expect(fs.existsSync(hqDir)).toBe(true);
+  });
+
+  it("is idempotent — same inputs produce identical bytes", () => {
+    const config = {
+      companyUid: "cmp_01H",
+      companySlug: "indigo",
+      bucketName: "b",
+      vaultApiUrl: "u",
+    };
+    writeCompanyConfig(tmpRoot, "indigo", config);
+    const first = fs.readFileSync(companyConfigPath(tmpRoot, "indigo"), "utf-8");
+    writeCompanyConfig(tmpRoot, "indigo", config);
+    const second = fs.readFileSync(companyConfigPath(tmpRoot, "indigo"), "utf-8");
+    expect(second).toBe(first);
+  });
+
+  it("does not leave a .tmp file behind on success", () => {
+    writeCompanyConfig(tmpRoot, "indigo", {
+      companyUid: "cmp_01H",
+      companySlug: "indigo",
+      bucketName: "b",
+      vaultApiUrl: "u",
+    });
+    const hqDir = path.join(companyDirPath(tmpRoot, "indigo"), ".hq");
+    const entries = fs.readdirSync(hqDir);
+    expect(entries.filter((f) => f.includes(".tmp."))).toEqual([]);
+  });
+});
+
+// ── createDefaultVaultClient ─────────────────────────────────────────────────
+
+describe("createDefaultVaultClient", () => {
+  const apiUrl = "https://vault.example.com";
+  const token = "test-token";
+
+  it("findCompanyBySlug returns the entity on 200", async () => {
+    const entity: VaultEntity = {
+      uid: "cmp_01H",
+      type: "company",
+      slug: "indigo",
+      name: "Indigo",
+      bucketName: "hq-vault-cmp-01H",
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({ entity }), { status: 200 }),
+    );
+    const client = createDefaultVaultClient(apiUrl, token);
+    const out = await client.findCompanyBySlug("indigo");
+    expect(out).toEqual(entity);
+  });
+
+  it("findCompanyBySlug returns null on 404", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("not found", { status: 404 }),
+    );
+    const client = createDefaultVaultClient(apiUrl, token);
+    expect(await client.findCompanyBySlug("missing")).toBeNull();
+  });
+
+  it("findCompanyBySlug throws ProvisionError code 1 on 500", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("kaboom", { status: 500, statusText: "Server Error" }),
+    );
+    const client = createDefaultVaultClient(apiUrl, token);
+    try {
+      await client.findCompanyBySlug("indigo");
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProvisionError);
+      expect((e as ProvisionError).code).toBe(1);
+      expect((e as ProvisionError).message).toMatch(/500/);
+    }
+  });
+
+  it("findCompanyBySlug throws code 1 if 200 has no entity body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    const client = createDefaultVaultClient(apiUrl, token);
+    await expect(client.findCompanyBySlug("indigo")).rejects.toThrowError(
+      /no entity body/,
+    );
+  });
+
+  it("createCompanyEntity returns the entity on 201", async () => {
+    const entity: VaultEntity = {
+      uid: "cmp_01H",
+      type: "company",
+      slug: "indigo",
+      name: "Indigo",
+      bucketName: "hq-vault-cmp-01H",
+    };
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ entity }), { status: 201 }),
+      );
+    const client = createDefaultVaultClient(apiUrl, token);
+    const out = await client.createCompanyEntity({
+      slug: "indigo",
+      name: "Indigo",
+    });
+    expect(out).toEqual(entity);
+    // Verify request shape
+    const call = fetchSpy.mock.calls[0];
+    expect(call[0]).toBe(`${apiUrl}/v1/entities`);
+    expect((call[1] as RequestInit)?.method).toBe("POST");
+    const body = JSON.parse(((call[1] as RequestInit)?.body as string) ?? "{}");
+    expect(body).toEqual({ type: "company", slug: "indigo", name: "Indigo" });
+  });
+
+  it("createCompanyEntity throws code 1 on 409 conflict", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("conflict", { status: 409, statusText: "Conflict" }),
+    );
+    const client = createDefaultVaultClient(apiUrl, token);
+    try {
+      await client.createCompanyEntity({ slug: "indigo", name: "Indigo" });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as ProvisionError).code).toBe(1);
+      expect((e as ProvisionError).message).toMatch(/409/);
+    }
+  });
+
+  it("createCompanyEntity sends ownerUid when provided", async () => {
+    const entity: VaultEntity = {
+      uid: "cmp_01H",
+      type: "company",
+      slug: "indigo",
+      name: "Indigo",
+      bucketName: "b",
+    };
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ entity }), { status: 201 }),
+      );
+    const client = createDefaultVaultClient(apiUrl, token);
+    await client.createCompanyEntity({
+      slug: "indigo",
+      name: "Indigo",
+      ownerUid: "person_01H",
+    });
+    const body = JSON.parse(
+      ((fetchSpy.mock.calls[0]?.[1] as RequestInit)?.body as string) ?? "{}",
+    );
+    expect(body.ownerUid).toBe("person_01H");
+  });
+});
+
+// ── provisionCompany (orchestrator) ──────────────────────────────────────────
+
+describe("provisionCompany", () => {
+  const vaultApiUrl = "https://vault.example.com";
+  const accessToken = "test-token";
+
+  function setupValid(): void {
+    seedManifest(tmpRoot, { indigo: { status: "active" } });
+    seedCompanyDir(tmpRoot, "indigo");
+  }
+
+  function makeVaultClient(overrides: Partial<VaultClient> = {}): VaultClient {
+    return {
+      findCompanyBySlug: vi.fn().mockResolvedValue(null),
+      createCompanyEntity: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it("happy path — entity not found → POST → manifest + config + sync", async () => {
+    setupValid();
+    const entity: VaultEntity = {
+      uid: "cmp_01H",
+      type: "company",
+      slug: "indigo",
+      name: "Indigo",
+      bucketName: "hq-vault-cmp-01H",
+      kmsKeyId: "key-123",
+    };
+    const vaultClient = makeVaultClient({
+      findCompanyBySlug: vi.fn().mockResolvedValue(null),
+      createCompanyEntity: vi.fn().mockResolvedValue(entity),
+    });
+    const runInitialSync = vi
+      .fn()
+      .mockResolvedValue({ filesUploaded: 7, bytesUploaded: 1024 });
+
+    const result = await provisionCompany({
+      slug: "indigo",
+      name: "Indigo",
+      hqRoot: tmpRoot,
+      vaultApiUrl,
+      vaultClient,
+      resolveAccessToken: async () => accessToken,
+      runInitialSync,
+      log: () => {},
+    });
+
+    expect(result).toEqual<ProvisionResult>({
+      ok: true,
+      company_slug: "indigo",
+      cloud_uid: "cmp_01H",
+      bucket_name: "hq-vault-cmp-01H",
+      vault_api_url: vaultApiUrl,
+      kms_key_id: "key-123",
+      created_entity: true,
+      manifest_patched: true,
+      config_written: true,
+      initial_sync: { ok: true, files_uploaded: 7, bytes_uploaded: 1024 },
+    });
+    // Manifest was actually patched on disk
+    const m = yaml.load(fs.readFileSync(manifestPath(tmpRoot), "utf-8")) as {
+      companies: Record<string, Record<string, unknown>>;
+    };
+    expect(m.companies.indigo.cloud_uid).toBe("cmp_01H");
+    expect(m.companies.indigo.bucket_name).toBe("hq-vault-cmp-01H");
+    // Config was written
+    const c = JSON.parse(
+      fs.readFileSync(companyConfigPath(tmpRoot, "indigo"), "utf-8"),
+    );
+    expect(c.companyUid).toBe("cmp_01H");
+    // POST happened
+    expect(vaultClient.createCompanyEntity).toHaveBeenCalledOnce();
+  });
+
+  it("idempotent path — entity found → no POST → still patches + syncs → created_entity=false", async () => {
+    setupValid();
+    const entity: VaultEntity = {
+      uid: "cmp_01H",
+      type: "company",
+      slug: "indigo",
+      name: "Indigo",
+      bucketName: "hq-vault-cmp-01H",
+      kmsKeyId: null,
+    };
+    const vaultClient = makeVaultClient({
+      findCompanyBySlug: vi.fn().mockResolvedValue(entity),
+      createCompanyEntity: vi.fn(),
+    });
+    const result = await provisionCompany({
+      slug: "indigo",
+      hqRoot: tmpRoot,
+      vaultApiUrl,
+      vaultClient,
+      resolveAccessToken: async () => accessToken,
+      runInitialSync: async () => ({ filesUploaded: 0, bytesUploaded: 0 }),
+      log: () => {},
+    });
+    expect(result.created_entity).toBe(false);
+    expect(result.kms_key_id).toBeNull();
+    expect(vaultClient.createCompanyEntity).not.toHaveBeenCalled();
+  });
+
+  it("throws code 1 when entity has no bucketName (incomplete provisioning)", async () => {
+    setupValid();
+    const entity: VaultEntity = {
+      uid: "cmp_01H",
+      type: "company",
+      slug: "indigo",
+      name: "Indigo",
+      // bucketName intentionally absent
+    };
+    const vaultClient = makeVaultClient({
+      findCompanyBySlug: vi.fn().mockResolvedValue(entity),
+    });
+    try {
+      await provisionCompany({
+        slug: "indigo",
+        hqRoot: tmpRoot,
+        vaultApiUrl,
+        vaultClient,
+        resolveAccessToken: async () => accessToken,
+        runInitialSync: async () => ({ filesUploaded: 0, bytesUploaded: 0 }),
+        log: () => {},
+      });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProvisionError);
+      expect((e as ProvisionError).code).toBe(1);
+      expect((e as ProvisionError).partial?.cloud_uid).toBe("cmp_01H");
+      expect((e as ProvisionError).partial?.manifest_patched).toBe(false);
+    }
+  });
+
+  it("throws code 3 when initial sync fails — manifest + config STILL written", async () => {
+    setupValid();
+    const entity: VaultEntity = {
+      uid: "cmp_01H",
+      type: "company",
+      slug: "indigo",
+      name: "Indigo",
+      bucketName: "hq-vault-cmp-01H",
+    };
+    const vaultClient = makeVaultClient({
+      findCompanyBySlug: vi.fn().mockResolvedValue(null),
+      createCompanyEntity: vi.fn().mockResolvedValue(entity),
+    });
+    const runInitialSync = vi
+      .fn()
+      .mockRejectedValue(new Error("S3 timeout"));
+
+    try {
+      await provisionCompany({
+        slug: "indigo",
+        hqRoot: tmpRoot,
+        vaultApiUrl,
+        vaultClient,
+        resolveAccessToken: async () => accessToken,
+        runInitialSync,
+        log: () => {},
+      });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ProvisionError);
+      expect((e as ProvisionError).code).toBe(3);
+      expect((e as ProvisionError).partial?.manifest_patched).toBe(true);
+      expect((e as ProvisionError).partial?.config_written).toBe(true);
+      expect((e as ProvisionError).partial?.initial_sync?.ok).toBe(false);
+      expect((e as ProvisionError).partial?.initial_sync?.error).toMatch(
+        /S3 timeout/,
+      );
+    }
+    // Manifest WAS written despite the sync failure (matches partial=true)
+    const m = yaml.load(fs.readFileSync(manifestPath(tmpRoot), "utf-8")) as {
+      companies: Record<string, Record<string, unknown>>;
+    };
+    expect(m.companies.indigo.cloud_uid).toBe("cmp_01H");
+  });
+
+  it("throws code 2 on invalid slug before any vault call", async () => {
+    seedCompanyDir(tmpRoot, "indigo"); // dir exists but slug is invalid
+    const vaultClient = makeVaultClient();
+    try {
+      await provisionCompany({
+        slug: "personal",
+        hqRoot: tmpRoot,
+        vaultApiUrl,
+        vaultClient,
+        resolveAccessToken: async () => accessToken,
+        runInitialSync: async () => ({ filesUploaded: 0, bytesUploaded: 0 }),
+        log: () => {},
+      });
+      expect.fail("should have thrown");
+    } catch (e) {
+      expect((e as ProvisionError).code).toBe(2);
+      expect(vaultClient.findCompanyBySlug).not.toHaveBeenCalled();
+    }
+  });
+
+  it("uses slug as the entity name when --name is omitted", async () => {
+    setupValid();
+    const entity: VaultEntity = {
+      uid: "cmp_01H",
+      type: "company",
+      slug: "indigo",
+      name: "indigo",
+      bucketName: "b",
+    };
+    const createSpy = vi.fn().mockResolvedValue(entity);
+    const vaultClient = makeVaultClient({
+      findCompanyBySlug: vi.fn().mockResolvedValue(null),
+      createCompanyEntity: createSpy,
+    });
+    await provisionCompany({
+      slug: "indigo",
+      // name omitted on purpose
+      hqRoot: tmpRoot,
+      vaultApiUrl,
+      vaultClient,
+      resolveAccessToken: async () => accessToken,
+      runInitialSync: async () => ({ filesUploaded: 0, bytesUploaded: 0 }),
+      log: () => {},
+    });
+    expect(createSpy).toHaveBeenCalledWith({
+      slug: "indigo",
+      name: "indigo",
+      ownerUid: undefined,
+    });
+  });
+});

--- a/packages/hq-cli/src/commands/cloud-provision.ts
+++ b/packages/hq-cli/src/commands/cloud-provision.ts
@@ -1,0 +1,638 @@
+/**
+ * `hq cloud provision company <slug>` — canonical cloud-promotion subcommand.
+ *
+ * Promotes a local company directory (`companies/<slug>/`) to a cloud-backed
+ * entity by:
+ *   1. Validating the slug, manifest membership, and local company directory
+ *   2. Resolving a Cognito access token (refresh as needed)
+ *   3. Idempotently provisioning the vault entity:
+ *        GET /v1/entities/by-slug/company/<slug> → 200 reuse, 404 → POST /v1/entities
+ *   4. Atomically patching `companies/manifest.yaml` with `cloud_uid` + `bucket_name`
+ *   5. Atomically writing `companies/<slug>/.hq/config.json`
+ *   6. Triggering an initial sync via `share()` from `@indigoai-us/hq-cloud`
+ *   7. Emitting one structured JSON line to stdout (machine-readable result)
+ *
+ * Replaces three ad-hoc implementations:
+ *   - `designate-team` bash script (hq-core-staging)
+ *   - AppBar `provision.rs` (hq-sync, auto-provision on first sync)
+ *   - AppBar `workspaces.rs` Connect flow (hq-sync, manual Connect)
+ *
+ * Exit codes:
+ *   0 — success (and `initial_sync.ok=true`)
+ *   1 — vault auth/network/API error (no entity provisioned)
+ *   2 — invalid slug, company missing from manifest, or company dir missing
+ *   3 — sync failure after entity provisioned (cloud_uid in JSON;
+ *       `initial_sync.ok=false`). Manifest + config may have been written.
+ */
+
+import { Command } from "commander";
+import chalk from "chalk";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as yaml from "js-yaml";
+
+import { share } from "@indigoai-us/hq-cloud";
+
+import {
+  DEFAULT_HQ_ROOT,
+  DEFAULT_VAULT_API_URL,
+  ensureCognitoToken,
+  buildVaultConfig,
+} from "../utils/cognito-session.js";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Vault entity shape (subset we consume). Mirrors hq-pro entity types. */
+export interface VaultEntity {
+  uid: string;
+  type: string;
+  slug: string;
+  name: string;
+  bucketName?: string;
+  kmsKeyId?: string | null;
+  status?: string;
+  ownerUid?: string;
+}
+
+/** Per-company `.hq/config.json` schema (matches AppBar `provision.rs::CompanyConfig`). */
+export interface CompanyConfig {
+  companyUid: string;
+  companySlug: string;
+  bucketName: string;
+  vaultApiUrl: string;
+}
+
+/** Final stdout JSON shape. Consumers (designate-team, AppBar) parse this. */
+export interface ProvisionResult {
+  ok: boolean;
+  company_slug: string;
+  cloud_uid: string;
+  bucket_name: string;
+  vault_api_url: string;
+  kms_key_id: string | null;
+  created_entity: boolean;
+  manifest_patched: boolean;
+  config_written: boolean;
+  initial_sync: {
+    ok: boolean;
+    files_uploaded?: number;
+    bytes_uploaded?: number;
+    error?: string;
+  };
+}
+
+/** Options for the high-level `provisionCompany` orchestrator. */
+export interface ProvisionCompanyOptions {
+  slug: string;
+  name?: string;
+  ownerUid?: string;
+  hqRoot: string;
+  vaultApiUrl: string;
+  /** Injected vault HTTP client (override for tests). */
+  vaultClient?: VaultClient;
+  /** Injected access-token resolver (override for tests). */
+  resolveAccessToken?: () => Promise<string>;
+  /** Injected sync runner (override for tests). */
+  runInitialSync?: (args: InitialSyncArgs) => Promise<{
+    filesUploaded: number;
+    bytesUploaded: number;
+  }>;
+  /** Optional progress logger; defaults to stderr-prefixed `[hq cloud provision]`. */
+  log?: (msg: string) => void;
+}
+
+interface InitialSyncArgs {
+  slug: string;
+  hqRoot: string;
+  accessToken: string;
+  vaultApiUrl: string;
+}
+
+/** Vault HTTP client interface — minimal surface for entity ops. */
+export interface VaultClient {
+  findCompanyBySlug(slug: string): Promise<VaultEntity | null>;
+  createCompanyEntity(input: {
+    slug: string;
+    name: string;
+    ownerUid?: string;
+  }): Promise<VaultEntity>;
+}
+
+/** Custom error class so the CLI runner can map to exit codes. */
+export class ProvisionError extends Error {
+  constructor(
+    public readonly code: 1 | 2 | 3,
+    message: string,
+    public readonly partial?: Partial<ProvisionResult>,
+  ) {
+    super(message);
+    this.name = "ProvisionError";
+  }
+}
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+const SLUG_REGEX = /^[A-Za-z0-9._-]+$/;
+const FORBIDDEN_SLUGS = new Set(["personal"]);
+
+/**
+ * Validate a company slug per the contract: alphanumeric / dot / dash / underscore,
+ * non-empty, and never `"personal"` (which is auto-provisioned per-user, not
+ * promoted via this subcommand).
+ *
+ * Throws ProvisionError with code=2 on failure.
+ */
+export function validateSlug(slug: string): void {
+  if (!slug || slug.trim() === "") {
+    throw new ProvisionError(2, "Slug is required");
+  }
+  if (!SLUG_REGEX.test(slug)) {
+    throw new ProvisionError(
+      2,
+      `Invalid slug "${slug}" — must match ${SLUG_REGEX.source}`,
+    );
+  }
+  if (FORBIDDEN_SLUGS.has(slug)) {
+    throw new ProvisionError(
+      2,
+      `Slug "${slug}" is reserved (auto-provisioned per-user, not eligible for cloud promotion)`,
+    );
+  }
+}
+
+/** Path to the top-level companies manifest file. */
+export function manifestPath(hqRoot: string): string {
+  return path.join(hqRoot, "companies", "manifest.yaml");
+}
+
+/** Path to a company's directory inside the HQ tree. */
+export function companyDirPath(hqRoot: string, slug: string): string {
+  return path.join(hqRoot, "companies", slug);
+}
+
+/** Path to a company's `.hq/config.json`. */
+export function companyConfigPath(hqRoot: string, slug: string): string {
+  return path.join(companyDirPath(hqRoot, slug), ".hq", "config.json");
+}
+
+/**
+ * Validate that the company exists in the manifest and on disk.
+ *
+ * Throws ProvisionError with code=2 if:
+ *   - manifest file missing
+ *   - manifest is malformed (no `companies` map)
+ *   - slug not present under `.companies`
+ *   - company is `status: archived`
+ *   - `companies/<slug>/` does not exist
+ *
+ * Returns the parsed manifest (so the caller can re-use it for the patch step).
+ */
+export function validateManifestAndDir(
+  hqRoot: string,
+  slug: string,
+): { manifest: ManifestDoc } {
+  const mPath = manifestPath(hqRoot);
+  if (!fs.existsSync(mPath)) {
+    throw new ProvisionError(
+      2,
+      `companies/manifest.yaml not found at ${mPath}`,
+    );
+  }
+  const raw = fs.readFileSync(mPath, "utf-8");
+  const parsed = yaml.load(raw) as unknown;
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    !("companies" in parsed) ||
+    typeof (parsed as ManifestDoc).companies !== "object"
+  ) {
+    throw new ProvisionError(
+      2,
+      `companies/manifest.yaml is malformed — missing top-level .companies map`,
+    );
+  }
+  const manifest = parsed as ManifestDoc;
+  const entry = manifest.companies?.[slug];
+  if (entry === undefined) {
+    throw new ProvisionError(
+      2,
+      `Company "${slug}" not found under .companies in manifest.yaml`,
+    );
+  }
+  if (entry && typeof entry === "object" && entry.status === "archived") {
+    throw new ProvisionError(
+      2,
+      `Company "${slug}" is status=archived — refusing to promote`,
+    );
+  }
+  const dir = companyDirPath(hqRoot, slug);
+  if (!fs.existsSync(dir)) {
+    throw new ProvisionError(
+      2,
+      `Company directory ${dir} does not exist`,
+    );
+  }
+  return { manifest };
+}
+
+// ── Manifest patching (atomic) ───────────────────────────────────────────────
+
+/**
+ * Top-level manifest shape we touch. We preserve all unknown fields — only
+ * `cloud_uid` and `bucket_name` under the target slug are mutated.
+ */
+export interface ManifestDoc {
+  companies?: Record<string, ManifestCompanyEntry | null>;
+  [k: string]: unknown;
+}
+
+export interface ManifestCompanyEntry {
+  cloud_uid?: string;
+  bucket_name?: string;
+  status?: string;
+  [k: string]: unknown;
+}
+
+/**
+ * Atomically patch `companies/manifest.yaml` to set `cloud_uid` + `bucket_name`
+ * under the target slug. Read → mutate → temp-write → rename so concurrent
+ * readers never see a partially-written file.
+ *
+ * Idempotent: if the values already match, this is a no-op (still rewrites
+ * the file to canonical YAML, but the mutation is identical).
+ *
+ * Returns true if the file was written (always true in current impl —
+ * reserved for future "skip if unchanged" optimization).
+ */
+export function patchManifest(
+  hqRoot: string,
+  slug: string,
+  cloudUid: string,
+  bucketName: string,
+): boolean {
+  const mPath = manifestPath(hqRoot);
+  const raw = fs.readFileSync(mPath, "utf-8");
+  const parsed = (yaml.load(raw) as ManifestDoc) ?? { companies: {} };
+  if (!parsed.companies) parsed.companies = {};
+  const existing = parsed.companies[slug];
+  // Preserve null / object / unknown — promote null → {} so we can write keys.
+  const entry: ManifestCompanyEntry =
+    existing && typeof existing === "object" ? { ...existing } : {};
+  entry.cloud_uid = cloudUid;
+  entry.bucket_name = bucketName;
+  parsed.companies[slug] = entry;
+
+  const dump = yaml.dump(parsed, { lineWidth: -1, noRefs: true });
+  const tmp = `${mPath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, dump);
+  fs.renameSync(tmp, mPath);
+  return true;
+}
+
+// ── .hq/config.json writing (atomic) ─────────────────────────────────────────
+
+/**
+ * Atomically write `companies/<slug>/.hq/config.json` with the cloud-promotion
+ * config. Creates the parent `.hq/` directory if needed. Temp-write + rename
+ * so concurrent readers never see a partial file.
+ *
+ * Idempotent: a re-run with the same inputs writes byte-identical output.
+ */
+export function writeCompanyConfig(
+  hqRoot: string,
+  slug: string,
+  config: CompanyConfig,
+): boolean {
+  const cPath = companyConfigPath(hqRoot, slug);
+  const dir = path.dirname(cPath);
+  fs.mkdirSync(dir, { recursive: true });
+  const body = JSON.stringify(config, null, 2) + "\n";
+  const tmp = `${cPath}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, body);
+  fs.renameSync(tmp, cPath);
+  return true;
+}
+
+// ── Vault HTTP client (real impl) ────────────────────────────────────────────
+
+/**
+ * Default vault HTTP client backed by global `fetch`. Uses the `/v1/entities`
+ * route surface (matches AppBar `vault_client.rs` and hq-pro handler routes).
+ *
+ * Note: the hq-pro handler.ts uses `/entity` (singular, no `/v1/`); the API
+ * Gateway in front of it exposes the same handlers under `/v1/entities/*`
+ * (plural) — the deployed surface is the prefixed form, which is what
+ * AppBar (`vault_client.rs`) and the architecture audit document. We use
+ * the deployed `/v1/entities/*` form here.
+ */
+export function createDefaultVaultClient(
+  apiUrl: string,
+  accessToken: string,
+): VaultClient {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+  };
+  return {
+    async findCompanyBySlug(slug: string): Promise<VaultEntity | null> {
+      const url = `${apiUrl.replace(/\/$/, "")}/v1/entities/by-slug/company/${encodeURIComponent(
+        slug,
+      )}`;
+      const res = await fetch(url, { method: "GET", headers });
+      if (res.status === 404) return null;
+      if (!res.ok) {
+        const body = await safeBody(res);
+        throw new ProvisionError(
+          1,
+          `Vault GET by-slug failed: ${res.status} ${res.statusText} — ${body}`,
+        );
+      }
+      const data = (await res.json()) as { entity?: VaultEntity };
+      if (!data.entity) {
+        throw new ProvisionError(
+          1,
+          `Vault GET by-slug returned 200 with no entity body`,
+        );
+      }
+      return data.entity;
+    },
+    async createCompanyEntity(input: {
+      slug: string;
+      name: string;
+      ownerUid?: string;
+    }): Promise<VaultEntity> {
+      const url = `${apiUrl.replace(/\/$/, "")}/v1/entities`;
+      const body: Record<string, unknown> = {
+        type: "company",
+        slug: input.slug,
+        name: input.name,
+      };
+      if (input.ownerUid) body.ownerUid = input.ownerUid;
+      const res = await fetch(url, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await safeBody(res);
+        // 409 means a concurrent client created it between our GET and POST —
+        // surface it as a vault error. The orchestrator is responsible for
+        // retrying GET if it wants idempotency on collisions.
+        throw new ProvisionError(
+          1,
+          `Vault POST /v1/entities failed: ${res.status} ${res.statusText} — ${text}`,
+        );
+      }
+      const data = (await res.json()) as { entity?: VaultEntity };
+      if (!data.entity) {
+        throw new ProvisionError(
+          1,
+          `Vault POST /v1/entities returned ${res.status} with no entity body`,
+        );
+      }
+      return data.entity;
+    },
+  };
+}
+
+async function safeBody(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return "<no body>";
+  }
+}
+
+// ── Default initial-sync runner (wraps share()) ──────────────────────────────
+
+async function defaultRunInitialSync(args: InitialSyncArgs): Promise<{
+  filesUploaded: number;
+  bytesUploaded: number;
+}> {
+  const result = await share({
+    paths: [companyDirPath(args.hqRoot, args.slug)],
+    company: args.slug,
+    message: `hq cloud provision:${args.slug}`,
+    onConflict: "keep",
+    vaultConfig: buildVaultConfig(args.accessToken),
+    hqRoot: args.hqRoot,
+  });
+  return {
+    filesUploaded: result.filesUploaded,
+    bytesUploaded: result.bytesUploaded,
+  };
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────────────
+
+/**
+ * Run the full 9-step provision flow. Returns a `ProvisionResult` on success
+ * (including partial success — sync failure after entity provisioned).
+ *
+ * Throws `ProvisionError` for terminal failures with the right exit code.
+ *
+ * All side effects (HTTP calls, file writes, sync) flow through injected
+ * helpers so unit tests can fully exercise the flow without network or disk.
+ */
+export async function provisionCompany(
+  options: ProvisionCompanyOptions,
+): Promise<ProvisionResult> {
+  const log = options.log ?? ((msg: string) => process.stderr.write(`[hq cloud provision] ${msg}\n`));
+
+  // Step 1+2+3: validate slug, manifest, dir
+  validateSlug(options.slug);
+  validateManifestAndDir(options.hqRoot, options.slug);
+  log(`validated slug=${options.slug}`);
+
+  // Step 4: auth — defer to injected resolver (default: ensureCognitoToken)
+  const accessToken = options.resolveAccessToken
+    ? await options.resolveAccessToken()
+    : await ensureCognitoToken();
+  log(`acquired Cognito access token`);
+
+  // Step 5: GET-then-POST for idempotency
+  const vaultClient =
+    options.vaultClient ??
+    createDefaultVaultClient(options.vaultApiUrl, accessToken);
+
+  let entity = await vaultClient.findCompanyBySlug(options.slug);
+  let createdEntity = false;
+  if (entity) {
+    log(`reusing existing vault entity uid=${entity.uid}`);
+  } else {
+    log(`vault entity not found — creating`);
+    entity = await vaultClient.createCompanyEntity({
+      slug: options.slug,
+      name: options.name ?? options.slug,
+      ownerUid: options.ownerUid,
+    });
+    createdEntity = true;
+    log(`created vault entity uid=${entity.uid}`);
+  }
+
+  if (!entity.bucketName) {
+    // Vault returned an entity without a bucket — this would happen if the
+    // provisioning Lambda asynchronously failed. We have a `cloud_uid` but
+    // no `bucket_name` to write to disk. Surface as a vault error since the
+    // entity exists but is incomplete.
+    throw new ProvisionError(
+      1,
+      `Vault entity ${entity.uid} has no bucketName — provisioning incomplete`,
+      {
+        ok: false,
+        company_slug: options.slug,
+        cloud_uid: entity.uid,
+        bucket_name: "",
+        vault_api_url: options.vaultApiUrl,
+        kms_key_id: entity.kmsKeyId ?? null,
+        created_entity: createdEntity,
+        manifest_patched: false,
+        config_written: false,
+        initial_sync: { ok: false, error: "entity has no bucketName" },
+      },
+    );
+  }
+
+  const cloudUid = entity.uid;
+  const bucketName = entity.bucketName;
+  const kmsKeyId = entity.kmsKeyId ?? null;
+
+  // Step 6: patch manifest atomically
+  patchManifest(options.hqRoot, options.slug, cloudUid, bucketName);
+  log(`patched companies/manifest.yaml`);
+
+  // Step 7: write .hq/config.json atomically
+  writeCompanyConfig(options.hqRoot, options.slug, {
+    companyUid: cloudUid,
+    companySlug: options.slug,
+    bucketName,
+    vaultApiUrl: options.vaultApiUrl,
+  });
+  log(`wrote companies/${options.slug}/.hq/config.json`);
+
+  // Step 8: trigger initial sync (failure ⇒ exit 3 with cloud_uid populated)
+  const runner = options.runInitialSync ?? defaultRunInitialSync;
+  let initialSync: ProvisionResult["initial_sync"];
+  try {
+    log(`triggering initial sync via share()`);
+    const sync = await runner({
+      slug: options.slug,
+      hqRoot: options.hqRoot,
+      accessToken,
+      vaultApiUrl: options.vaultApiUrl,
+    });
+    initialSync = {
+      ok: true,
+      files_uploaded: sync.filesUploaded,
+      bytes_uploaded: sync.bytesUploaded,
+    };
+    log(
+      `initial sync complete — files=${sync.filesUploaded} bytes=${sync.bytesUploaded}`,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log(`initial sync failed: ${msg}`);
+    throw new ProvisionError(3, `Initial sync failed: ${msg}`, {
+      ok: false,
+      company_slug: options.slug,
+      cloud_uid: cloudUid,
+      bucket_name: bucketName,
+      vault_api_url: options.vaultApiUrl,
+      kms_key_id: kmsKeyId,
+      created_entity: createdEntity,
+      manifest_patched: true,
+      config_written: true,
+      initial_sync: { ok: false, error: msg },
+    });
+  }
+
+  return {
+    ok: true,
+    company_slug: options.slug,
+    cloud_uid: cloudUid,
+    bucket_name: bucketName,
+    vault_api_url: options.vaultApiUrl,
+    kms_key_id: kmsKeyId,
+    created_entity: createdEntity,
+    manifest_patched: true,
+    config_written: true,
+    initial_sync: initialSync,
+  };
+}
+
+// ── Commander wiring ─────────────────────────────────────────────────────────
+
+/**
+ * Register `provision company <slug>` under a `cloud` subcommand group.
+ *
+ * Wired in `src/index.ts` via `registerCloudProvisionCommands(cloudCmd)` where
+ * `cloudCmd` is the top-level `hq cloud` command group.
+ */
+export function registerCloudProvisionCommands(program: Command): void {
+  const provisionCmd = program
+    .command("provision")
+    .description("Provision a cloud-backed entity (entity + bucket + initial sync)");
+
+  provisionCmd
+    .command("company")
+    .description(
+      "Promote a local company to a cloud-backed entity (idempotent). " +
+        "Provisions the vault entity if missing, patches manifest.yaml, " +
+        "writes .hq/config.json, and triggers an initial sync.",
+    )
+    .argument("<slug>", "Company slug (must match a top-level key in companies/manifest.yaml)")
+    .option("--name <name>", "Display name for the entity (default: slug)")
+    .option("--owner <uid>", "Owner person UID (default: current Cognito user sub)")
+    .option(
+      "--hq-root <path>",
+      `Local HQ tree root (default: ${DEFAULT_HQ_ROOT})`,
+      DEFAULT_HQ_ROOT,
+    )
+    .option(
+      "--vault-api-url <url>",
+      `Vault API URL (default: ${DEFAULT_VAULT_API_URL})`,
+      DEFAULT_VAULT_API_URL,
+    )
+    .action(
+      async (
+        slug: string,
+        options: {
+          name?: string;
+          owner?: string;
+          hqRoot: string;
+          vaultApiUrl: string;
+        },
+      ) => {
+        try {
+          const result = await provisionCompany({
+            slug,
+            name: options.name,
+            ownerUid: options.owner,
+            hqRoot: options.hqRoot,
+            vaultApiUrl: options.vaultApiUrl,
+          });
+          // Final stdout line — single JSON document for downstream consumers
+          process.stdout.write(JSON.stringify(result) + "\n");
+          process.exit(0);
+        } catch (err) {
+          if (err instanceof ProvisionError) {
+            // Partial-success path (code 3): cloud_uid is known; emit JSON to stdout
+            // so downstream consumers can capture it for retry.
+            if (err.partial) {
+              process.stdout.write(JSON.stringify(err.partial) + "\n");
+            }
+            process.stderr.write(
+              chalk.red(`[hq cloud provision] ${err.message}\n`),
+            );
+            process.exit(err.code);
+          }
+          process.stderr.write(
+            chalk.red(
+              `[hq cloud provision] Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
+            ),
+          );
+          process.exit(1);
+        }
+      },
+    );
+}

--- a/packages/hq-cli/src/index.ts
+++ b/packages/hq-cli/src/index.ts
@@ -11,6 +11,7 @@ import { registerSyncCommand } from "./commands/sync.js";
 import { registerListCommand } from "./commands/list.js";
 import { registerUpdateCommand } from "./commands/update.js";
 import { registerCloudCommands } from "./commands/cloud.js";
+import { registerCloudProvisionCommands } from "./commands/cloud-provision.js";
 import { registerLoginCommand } from "./commands/login.js";
 import { registerLogoutCommand } from "./commands/logout.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
@@ -65,6 +66,16 @@ const syncCmd = program
   .description("Cloud sync commands — sync HQ to S3 for mobile access");
 
 registerCloudCommands(syncCmd);
+
+// Cloud provisioning subcommand group (entity + bucket + initial sync)
+// Distinct from `hq sync` which assumes provisioning has already happened.
+const cloudCmd = program
+  .command("cloud")
+  .description(
+    "Cloud commands — provision entities and manage cloud-backed companies",
+  );
+
+registerCloudProvisionCommands(cloudCmd);
 
 // Team commands (top-level)
 registerTeamSyncCommand(program);


### PR DESCRIPTION
## Summary

New `hq cloud provision company <slug>` subcommand that becomes the canonical implementation for promoting a local company directory to a cloud-backed entity. Replaces three ad-hoc paths that today re-implement the same operations:

- `/designate-team` bash script (in `hq-core-staging`)
- AppBar HQ Sync `provision_missing_companies()` (Rust, auto-provision on first sync)
- AppBar HQ Sync `connect_workspace_to_cloud()` (Rust, manual Connect)

Behavior (idempotent):
1. Validate slug + `companies/manifest.yaml` membership + `companies/<slug>/` exists
2. Auth via existing `ensureCognitoToken` (refresh if expired)
3. `GET /v1/entities/by-slug/company/<slug>` → reuse if found, `POST /v1/entities` if not (404)
4. Atomically patch `companies/manifest.yaml` (`.companies.<slug>.cloud_uid` + `.bucket_name`)
5. Atomically write `companies/<slug>/.hq/config.json`
6. Trigger initial sync via `share()` from `@indigoai-us/hq-cloud`
7. Emit single-line JSON to stdout (machine-readable for downstream consumers)

Architecture for testability:
- Injectable `VaultClient` + `runInitialSync` on the orchestrator
- Custom `ProvisionError` class with structured exit codes (1=auth/network, 2=validation, 3=partial-success-on-sync-fail)
- Pure helpers (`validateSlug`, `patchManifest`, `writeCompanyConfig`, `validateManifestAndDir`) individually exportable + tested
- Wires into a NEW top-level `hq cloud` command group, distinct from `hq sync` (which assumes provisioning has already happened)

## Diff

3 files, +1301 lines:
- `packages/hq-cli/src/commands/cloud-provision.ts` (+638) — implementation
- `packages/hq-cli/src/commands/cloud-provision.test.ts` (+652) — 35 unit tests
- `packages/hq-cli/src/index.ts` (+11) — command-tree wiring

## Test plan

- [x] **Local: 100/100 vitest tests pass** in the package (35 new + 65 pre-existing). The 1 unrelated `sentry.test.ts` import failure is a pre-existing missing `@sentry/node` install.
- [ ] Manual: `hq cloud provision company <test-slug>` against staging vault — verify entity creation, manifest patch, config write, initial sync, and JSON output shape.
- [ ] Verify `hq cloud --help` and `hq cloud provision --help` render correctly.

## Downstream

After this lands, two consumer PRs will follow:
1. `hq-core-staging` — refactor `/designate-team` to a thin bash wrapper (~85 lines vs the current 204) calling this subcommand
2. `hq-sync` — refactor AppBar's `provision.rs` and `workspaces.rs` to shell out via a new `run_cli_provision.rs` Tauri helper

Both consumer branches are already implemented locally; landing them after this PR + after a new hq-cli npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)