### PR TITLE
release: hq-cli@5.6.0 — cloud provision company subcommand

### DIFF
--- a/packages/hq-cli/package.json
+++ b/packages/hq-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cli",
-  "version": "5.5.5",
+  "version": "5.6.0",
   "description": "HQ by Indigo management CLI — modules and cloud sync",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Minor version bump (`5.5.5` → `5.6.0`) for the new `hq cloud provision company <slug>` subcommand that landed in #99. Tag `v5.6.0` will trigger `publish.yml` to ship to npm via OIDC trusted publishing.

## Diff

1 file, +1/-1: `packages/hq-cli/package.json` version bump.

## Test plan

- [x] Subcommand implementation, tests (35 passing), and command-tree wiring all landed in #99.
- [ ] After merge: tag `v5.6.0` on merge commit, push tag, confirm `publish.yml` job succeeds and `npm view @indigoai-us/hq-cli version` returns `5.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)