### PR TITLE
release: hq-cli@5.6.1 — --skip-initial-sync flag

### DIFF
--- a/packages/hq-cli/package.json
+++ b/packages/hq-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cli",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "description": "HQ by Indigo management CLI — modules and cloud sync",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Bumps hq-cli to 5.6.1 to release the --skip-initial-sync flag from #101. Tag v5.6.1 will trigger publish.yml.