### PR TITLE
feat(hq-cloud): emit Stage-1 plan event before transfers

### DIFF
--- a/packages/hq-cloud/src/bin/sync-runner.test.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.test.ts
@@ -575,6 +575,49 @@ describe("per-company fanout", () => {
     ]);
   });
 
+  it("tags Stage-1 plan events with the company slug", async () => {
+    const deps = makeDeps({
+      createVaultClient: () =>
+        makeVaultStub({
+          memberships: [{ companyUid: "cmp_a" }],
+          entityGet: (uid: string) =>
+            Promise.resolve({ uid, slug: "acme" } as unknown as EntityInfo),
+        }),
+      sync: vi.fn().mockImplementation(async (opts: SyncOptions) => {
+        opts.onEvent?.({
+          type: "plan",
+          filesToDownload: 7,
+          bytesToDownload: 4096,
+          filesToUpload: 0,
+          bytesToUpload: 0,
+          filesToSkip: 3,
+          filesToConflict: 1,
+        });
+        return defaultSyncResult({ filesDownloaded: 7, bytesDownloaded: 4096 });
+      }),
+    });
+
+    const code = await runRunner(["--companies"], deps);
+    expect(code).toBe(0);
+    const planEvents = deps.stdout
+      .events()
+      .filter((e): e is Extract<RunnerEvent, { type: "plan" }> =>
+        e.type === "plan",
+      );
+    expect(planEvents).toEqual([
+      {
+        type: "plan",
+        company: "acme",
+        filesToDownload: 7,
+        bytesToDownload: 4096,
+        filesToUpload: 0,
+        bytesToUpload: 0,
+        filesToSkip: 3,
+        filesToConflict: 1,
+      },
+    ]);
+  });
+
   it("tags per-file error events with the company slug", async () => {
     const deps = makeDeps({
       createVaultClient: () =>

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -125,6 +125,18 @@ export type RunnerEvent =
       type: "fanout-plan";
       companies: Array<{ uid: string; slug: string; name?: string }>;
     }
+  | ({
+      /**
+       * Stage-1 results for a single company's sync/share pass. Emitted once
+       * before any `progress` events for that company arrive — once for the
+       * pull phase (download counts) and once for the push phase (upload
+       * counts) when `--direction both`. Consumers (the menubar) sum the
+       * non-zero fields across all `plan` events seen for a fanout to render
+       * an accurate "X of Y files" denominator before transfers begin.
+       */
+      type: "plan";
+      company: string;
+    } & Omit<Extract<SyncProgressEvent, { type: "plan" }>, "type">)
   | ({ type: "progress"; company: string } & Omit<Extract<SyncProgressEvent, { type: "progress" }>, "type">)
   | ({ type: "error"; company?: string } & Omit<Extract<SyncProgressEvent, { type: "error" }>, "type">)
   | ({ type: "conflict"; company: string } & Omit<Extract<SyncProgressEvent, { type: "conflict" }>, "type">)
@@ -534,7 +546,18 @@ export async function runRunner(
     // Per-company event tagger — shared by push and pull phases so progress
     // rows land on the right company regardless of which phase emitted them.
     const tagAndEmit = (event: SyncProgressEvent): void => {
-      if (event.type === "progress") {
+      if (event.type === "plan") {
+        emit({
+          type: "plan",
+          company: companyLabel,
+          filesToDownload: event.filesToDownload,
+          bytesToDownload: event.bytesToDownload,
+          filesToUpload: event.filesToUpload,
+          bytesToUpload: event.bytesToUpload,
+          filesToSkip: event.filesToSkip,
+          filesToConflict: event.filesToConflict,
+        });
+      } else if (event.type === "progress") {
         emit({
           type: "progress",
           company: companyLabel,
@@ -550,7 +573,7 @@ export async function runRunner(
           direction: event.direction,
           resolution: event.resolution,
         });
-      } else {
+      } else if (event.type === "error") {
         emit({
           type: "error",
           company: companyLabel,

--- a/packages/hq-cloud/src/cli/share.test.ts
+++ b/packages/hq-cloud/src/cli/share.test.ts
@@ -508,6 +508,9 @@ describe("share", () => {
       vaultConfig: mockConfig,
       hqRoot: tmpDir,
       onEvent: (e) => {
+        // Only file-level events carry `.path`. The Stage-1 `plan` event is
+        // surfaced separately and tested in its own block.
+        if (e.type === "plan") return;
         events.push({
           type: e.type,
           path: e.path,
@@ -520,5 +523,127 @@ describe("share", () => {
     expect(events).toHaveLength(2);
     expect(events.every((e) => e.type === "progress")).toBe(true);
     expect(events.map((e) => e.path).sort()).toEqual(["a.md", "b.md"]);
+  });
+
+  // ── Stage-1 plan event ─────────────────────────────────────────────────
+
+  it("emits a plan event before any progress events", async () => {
+    const companyRoot = path.join(tmpDir, "companies", "acme");
+    fs.mkdirSync(companyRoot, { recursive: true });
+    fs.writeFileSync(path.join(companyRoot, "a.md"), "alpha");
+    fs.writeFileSync(path.join(companyRoot, "b.md"), "beta");
+
+    const events: { type: string }[] = [];
+    await share({
+      paths: [companyRoot],
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onEvent: (e) => events.push({ type: e.type }),
+    });
+
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0].type).toBe("plan");
+    const planIndex = events.findIndex((e) => e.type === "plan");
+    const firstProgressIndex = events.findIndex((e) => e.type === "progress");
+    expect(firstProgressIndex).toBeGreaterThan(planIndex);
+  });
+
+  it("plan event reports filesToUpload = candidates and bytesToUpload = sum of file sizes", async () => {
+    const companyRoot = path.join(tmpDir, "companies", "acme");
+    fs.mkdirSync(companyRoot, { recursive: true });
+    fs.writeFileSync(path.join(companyRoot, "a.md"), "alpha"); // 5 bytes
+    fs.writeFileSync(path.join(companyRoot, "b.md"), "beta!"); // 5 bytes
+
+    const planEvents: Array<{
+      type: string;
+      filesToUpload?: number;
+      bytesToUpload?: number;
+      filesToDownload?: number;
+      bytesToDownload?: number;
+      filesToSkip?: number;
+      filesToConflict?: number;
+    }> = [];
+    await share({
+      paths: [companyRoot],
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onEvent: (e) => {
+        if (e.type === "plan") planEvents.push(e);
+      },
+    });
+
+    expect(planEvents).toHaveLength(1);
+    expect(planEvents[0]).toMatchObject({
+      type: "plan",
+      filesToUpload: 2,
+      bytesToUpload: 10,
+      filesToDownload: 0, // share() is push-only
+      bytesToDownload: 0,
+      filesToSkip: 0,
+      // Push conflicts can't be classified pre-HEAD (V1 limitation);
+      // the complete event reports the authoritative count.
+      filesToConflict: 0,
+    });
+  });
+
+  it("plan event filesToSkip reflects skip-unchanged hits when journal hash matches", async () => {
+    const companyRoot = path.join(tmpDir, "companies", "acme");
+    fs.mkdirSync(companyRoot, { recursive: true });
+    fs.writeFileSync(path.join(companyRoot, "unchanged.md"), "stable content");
+    fs.writeFileSync(path.join(companyRoot, "changed.md"), "newer content");
+
+    // Pre-seed the journal so unchanged.md matches its hash but
+    // changed.md does not.
+    const crypto = await import("crypto");
+    const unchangedHash = crypto
+      .createHash("sha256")
+      .update("stable content")
+      .digest("hex");
+    const journalPath = path.join(stateDir, "sync-journal.acme.json");
+    fs.writeFileSync(
+      journalPath,
+      JSON.stringify({
+        version: "1",
+        lastSync: new Date().toISOString(),
+        files: {
+          "unchanged.md": {
+            hash: unchangedHash,
+            size: 14,
+            syncedAt: new Date().toISOString(),
+            direction: "up",
+          },
+          "changed.md": {
+            hash: "stale-hash",
+            size: 13,
+            syncedAt: new Date().toISOString(),
+            direction: "up",
+          },
+        },
+      }),
+    );
+
+    const planEvents: Array<{
+      type: string;
+      filesToUpload?: number;
+      filesToSkip?: number;
+    }> = [];
+    await share({
+      paths: [companyRoot],
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      skipUnchanged: true,
+      onEvent: (e) => {
+        if (e.type === "plan") planEvents.push(e);
+      },
+    });
+
+    expect(planEvents).toHaveLength(1);
+    expect(planEvents[0]).toMatchObject({
+      filesToUpload: 1,
+      filesToSkip: 1,
+    });
   });
 });

--- a/packages/hq-cloud/src/cli/share.ts
+++ b/packages/hq-cloud/src/cli/share.ts
@@ -7,7 +7,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import type { VaultServiceConfig } from "../types.js";
+import type { VaultServiceConfig, SyncJournal } from "../types.js";
 import { resolveEntityContext, isExpiringSoon, refreshEntityContext } from "../context.js";
 import { uploadFile, headRemoteFile } from "../s3.js";
 import { readJournal, writeJournal, hashFile, updateEntry, normalizeEtag } from "../journal.js";
@@ -15,6 +15,100 @@ import { createIgnoreFilter, isWithinSizeLimit } from "../ignore.js";
 import { resolveConflict } from "./conflict.js";
 import type { ConflictStrategy } from "./conflict.js";
 import type { SyncProgressEvent } from "./sync.js";
+
+/**
+ * Stage-1 classification for a single local file in a push run. Pre-HEAD —
+ * only inputs we can evaluate locally (size limit, journal hash, optional
+ * skip-unchanged) determine the action. Files that pass classification as
+ * `upload` are still subject to a per-file HEAD + 3-way conflict check in
+ * Stage 2 before the actual PUT, so the `filesToUpload` count in the plan
+ * event is an upper bound: it includes files that may turn out to be
+ * conflicts. V1.5 follow-up: replace per-file HEAD with a single LIST so
+ * conflicts can be classified up-front and reported in the plan.
+ */
+type PushPlanItem =
+  | {
+      action: "upload";
+      absolutePath: string;
+      relativePath: string;
+      localHash: string;
+      size: number;
+    }
+  | {
+      action: "skip-size-limit";
+      absolutePath: string;
+      relativePath: string;
+    }
+  | {
+      action: "skip-unchanged";
+      absolutePath: string;
+      relativePath: string;
+    };
+
+interface PushPlan {
+  items: PushPlanItem[];
+  filesToUpload: number;
+  bytesToUpload: number;
+  filesToSkip: number;
+}
+
+/**
+ * Pure Stage-1 pass for push: walk the candidate file list, hash each one,
+ * apply the size-limit and skip-unchanged gates, and return a classified
+ * plan plus aggregate counts. No S3 calls, no journal writes, no event
+ * emission.
+ *
+ * The conflict count is intentionally absent from the returned `PushPlan` —
+ * detecting a push conflict requires a remote HEAD that we defer to Stage 2.
+ * Consumers that want a conflict count get it from the `complete` event.
+ */
+function computePushPlan(
+  filesToShare: { absolutePath: string; relativePath: string }[],
+  journal: SyncJournal,
+  skipUnchanged: boolean,
+): PushPlan {
+  const items: PushPlanItem[] = [];
+
+  for (const { absolutePath, relativePath } of filesToShare) {
+    if (!isWithinSizeLimit(absolutePath)) {
+      items.push({ action: "skip-size-limit", absolutePath, relativePath });
+      continue;
+    }
+
+    const localHash = hashFile(absolutePath);
+
+    if (skipUnchanged) {
+      const existing = journal.files[relativePath];
+      if (existing && existing.hash === localHash) {
+        items.push({ action: "skip-unchanged", absolutePath, relativePath });
+        continue;
+      }
+    }
+
+    const size = fs.statSync(absolutePath).size;
+    items.push({
+      action: "upload",
+      absolutePath,
+      relativePath,
+      localHash,
+      size,
+    });
+  }
+
+  let filesToUpload = 0;
+  let bytesToUpload = 0;
+  let filesToSkip = 0;
+  for (const item of items) {
+    if (item.action === "upload") {
+      filesToUpload++;
+      bytesToUpload += item.size;
+    } else {
+      filesToSkip++;
+    }
+  }
+
+  return { items, filesToUpload, bytesToUpload, filesToSkip };
+}
 
 export interface ShareOptions {
   /** Path(s) to share (files or directories) */
@@ -94,29 +188,44 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
   // Collect all files to share
   const filesToShare = collectFiles(paths, hqRoot, syncRoot, shouldSync);
 
-  for (const { absolutePath, relativePath } of filesToShare) {
-    if (!isWithinSizeLimit(absolutePath)) {
+  // Stage 1: classify each file. Pre-HEAD — only inputs we can evaluate
+  // locally (size limit, journal hash, optional skip-unchanged) are
+  // considered. The plan event below carries an upper-bound `filesToUpload`
+  // (true conflicts emerge from the per-file HEAD in Stage 2 and aren't
+  // knowable here). The final `complete` event reports authoritative counts.
+  const plan = computePushPlan(filesToShare, journal, skipUnchanged === true);
+
+  emit({
+    type: "plan",
+    // share() is push-only; pull counts are sourced from sync()'s plan event.
+    filesToDownload: 0,
+    bytesToDownload: 0,
+    filesToUpload: plan.filesToUpload,
+    bytesToUpload: plan.bytesToUpload,
+    filesToSkip: plan.filesToSkip,
+    // Push conflicts require a remote HEAD; we don't yet do that in Stage 1,
+    // so this stays 0. V1.5 (single LIST) will let us classify them up-front.
+    filesToConflict: 0,
+  });
+
+  // Stage 2: execute. Skip items pre-classified as no-ops, then for each
+  // upload candidate run the HEAD + 3-way conflict check + actual PUT.
+  for (const item of plan.items) {
+    if (item.action === "skip-size-limit") {
       emit({
         type: "error",
-        path: relativePath,
+        path: item.relativePath,
         message: "file exceeds size limit",
       });
       filesSkipped++;
       continue;
     }
-
-    // Skip-if-unchanged gate: the hot path for bidirectional Sync Now. When
-    // walking an entire company folder, this is what keeps us from re-uploading
-    // every file every tick. Off by default so `hq share <file>` keeps its
-    // explicit-intent semantics (user named it, user wants it sent).
-    const localHash = hashFile(absolutePath);
-    if (skipUnchanged) {
-      const existing = journal.files[relativePath];
-      if (existing && existing.hash === localHash) {
-        filesSkipped++;
-        continue;
-      }
+    if (item.action === "skip-unchanged") {
+      filesSkipped++;
+      continue;
     }
+
+    const { absolutePath, relativePath, localHash } = item;
 
     // Auto-refresh context if credentials expiring
     if (isExpiringSoon(ctx.expiresAt)) {
@@ -225,7 +334,13 @@ export async function share(options: ShareOptions): Promise<ShareResult> {
  * emitted before `onEvent` was added — tty users see no change.
  */
 function defaultConsoleLogger(event: SyncProgressEvent): void {
-  if (event.type === "progress") {
+  if (event.type === "plan") {
+    if (event.filesToUpload > 0) {
+      console.log(
+        `Plan: ${event.filesToUpload} to upload (${event.bytesToUpload} bytes), ${event.filesToSkip} unchanged`,
+      );
+    }
+  } else if (event.type === "progress") {
     if (event.message) {
       console.log(`  ✓ ${event.path} — "${event.message}"`);
     } else {
@@ -235,7 +350,7 @@ function defaultConsoleLogger(event: SyncProgressEvent): void {
     console.error(
       `  ⚠ conflict (${event.direction}): ${event.path} — ${event.resolution}`,
     );
-  } else {
+  } else if (event.type === "error") {
     console.error(`  ✗ ${event.path} — ${event.message}`);
   }
 }

--- a/packages/hq-cloud/src/cli/sync.test.ts
+++ b/packages/hq-cloud/src/cli/sync.test.ts
@@ -384,4 +384,101 @@ describe("sync", () => {
     expect(journal.files["docs/handoff.md"].remoteEtag).toBe("abc123");
     expect(journal.files["knowledge/readme.md"].remoteEtag).toBe("def456");
   });
+
+  // ── Stage-1 plan event ─────────────────────────────────────────────────
+
+  it("emits a plan event before any progress events", async () => {
+    const events: { type: string }[] = [];
+    await sync({
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onEvent: (e) => events.push({ type: e.type }),
+    });
+
+    // Plan must be the first event so consumers can use its totals as
+    // the progress denominator before any per-file events arrive.
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0].type).toBe("plan");
+    const planIndex = events.findIndex((e) => e.type === "plan");
+    const firstProgressIndex = events.findIndex((e) => e.type === "progress");
+    expect(firstProgressIndex).toBeGreaterThan(planIndex);
+  });
+
+  it("plan event totals reflect the upcoming Stage-2 work (all-new case)", async () => {
+    // Both mock remote files are new locally → both counted as downloads,
+    // bytes summed from listRemoteFiles, no conflicts, no skips.
+    const planEvents: unknown[] = [];
+    await sync({
+      company: "acme",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onEvent: (e) => {
+        if (e.type === "plan") {
+          planEvents.push(e);
+        }
+      },
+    });
+
+    expect(planEvents).toHaveLength(1);
+    expect(planEvents[0]).toMatchObject({
+      type: "plan",
+      filesToDownload: 2,
+      bytesToDownload: 142, // 42 + 100 from the s3 mock
+      filesToUpload: 0, // sync() never plans uploads
+      bytesToUpload: 0,
+      filesToSkip: 0,
+      filesToConflict: 0,
+    });
+  });
+
+  it("plan event counts a 3-way conflict separately from downloads", async () => {
+    // Local edit + journal-tracked + remote ETag drifted → conflict.
+    const companyDocs = path.join(tmpDir, "companies", "acme", "docs");
+    fs.mkdirSync(companyDocs, { recursive: true });
+    fs.writeFileSync(path.join(companyDocs, "handoff.md"), "local edit");
+
+    fs.writeFileSync(
+      journalPath,
+      JSON.stringify({
+        version: "1",
+        lastSync: new Date().toISOString(),
+        files: {
+          "docs/handoff.md": {
+            hash: "stale-hash-from-pre-edit",
+            size: 20,
+            syncedAt: new Date(Date.now() - 3600000).toISOString(),
+            direction: "down",
+            // Mismatched ETag — listRemoteFiles mock returns "abc123",
+            // we record a stale one so remoteChanged is true.
+            remoteEtag: "stale-remote-etag",
+          },
+        },
+      }),
+    );
+
+    const planEvents: Array<{
+      type: string;
+      filesToDownload?: number;
+      filesToConflict?: number;
+      filesToSkip?: number;
+    }> = [];
+    await sync({
+      company: "acme",
+      onConflict: "keep",
+      vaultConfig: mockConfig,
+      hqRoot: tmpDir,
+      onEvent: (e) => {
+        if (e.type === "plan") planEvents.push(e);
+      },
+    });
+
+    expect(planEvents).toHaveLength(1);
+    // Conflict is counted separately; only the new file is in toDownload.
+    expect(planEvents[0]).toMatchObject({
+      filesToDownload: 1,
+      filesToConflict: 1,
+      filesToSkip: 0,
+    });
+  });
 });

--- a/packages/hq-cloud/src/cli/sync.ts
+++ b/packages/hq-cloud/src/cli/sync.ts
@@ -7,9 +7,10 @@
 
 import * as fs from "fs";
 import * as path from "path";
-import type { VaultServiceConfig } from "../types.js";
+import type { VaultServiceConfig, SyncJournal } from "../types.js";
 import { resolveEntityContext, isExpiringSoon, refreshEntityContext } from "../context.js";
 import { downloadFile, listRemoteFiles } from "../s3.js";
+import type { RemoteFile } from "../s3.js";
 import { readJournal, writeJournal, hashFile, updateEntry, getEntry, normalizeEtag } from "../journal.js";
 import { createIgnoreFilter } from "../ignore.js";
 import { resolveConflict } from "./conflict.js";
@@ -25,8 +26,31 @@ import type { ConflictStrategy, ConflictResolution } from "./conflict.js";
  *
  * The human CLI (`hq sync`) leaves `onEvent` undefined and falls through to
  * `defaultConsoleLogger` below, which preserves the existing tty output.
+ *
+ * A single `plan` event is emitted once at the start of every run, before
+ * any `progress`/`conflict`/`error` events. It carries the totals derived
+ * from a Stage-1 classification pass so consumers can render an accurate
+ * progress denominator before transfers begin (the menubar's "Preparing
+ * sync…" pre-pass becomes obsolete once the runner forwards this).
  */
 export type SyncProgressEvent =
+  | {
+      type: "plan";
+      /** Files this run intends to download (pull-only; 0 from share). */
+      filesToDownload: number;
+      bytesToDownload: number;
+      /** Files this run intends to upload (push-only; 0 from sync). */
+      filesToUpload: number;
+      bytesToUpload: number;
+      /** Files classified as no-op (ignored, unchanged, local-only on pull). */
+      filesToSkip: number;
+      /**
+       * Files known up-front to be conflicts. Pull-side fills this from the
+       * 3-way merge against the journal; push-side leaves it 0 because
+       * conflict detection requires a remote HEAD that runs in Stage 2.
+       */
+      filesToConflict: number;
+    }
   | { type: "progress"; path: string; bytes: number; message?: string }
   | { type: "error"; path: string; message: string }
   | {
@@ -123,90 +147,91 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
   // List all remote files (IAM session policy filters at the AWS layer)
   const remoteFiles = await listRemoteFiles(ctx);
 
-  for (const remoteFile of remoteFiles) {
-    const localPath = path.join(companyRoot, remoteFile.key);
+  // Stage 1: classify every remote file against the journal + local disk.
+  // Hashing happens here (not in the transfer loop) so the plan event below
+  // carries an accurate denominator before any progress events fire.
+  const plan = computePullPlan(
+    remoteFiles,
+    journal,
+    companyRoot,
+    shouldSync,
+    options.personalMode === true,
+  );
 
-    if (options.personalMode === true && remoteFile.key.startsWith("companies/")) {
+  emit({
+    type: "plan",
+    filesToDownload: plan.filesToDownload,
+    bytesToDownload: plan.bytesToDownload,
+    // sync() is pull-only; push counts are sourced from share()'s plan event.
+    filesToUpload: 0,
+    bytesToUpload: 0,
+    filesToSkip: plan.filesToSkip,
+    filesToConflict: plan.filesToConflict,
+  });
+
+  // Stage 2: execute the plan. Per-item branching mirrors the pre-refactor
+  // inline loop; the only structural change is that classification has
+  // already happened (so `localHash` is reused instead of re-hashing).
+  for (const item of plan.items) {
+    if (
+      item.action === "skip-ignored" ||
+      item.action === "skip-personal-mode" ||
+      item.action === "skip-unchanged" ||
+      item.action === "skip-local-only"
+    ) {
       filesSkipped++;
       continue;
     }
 
-    // Apply ignore rules
-    if (!shouldSync(localPath)) {
-      filesSkipped++;
-      continue;
-    }
+    const { remoteFile, localPath } = item;
 
-    // Auto-refresh context if credentials expiring
+    // Auto-refresh context if credentials expiring (kept in execute phase
+    // because Stage 1 is fast — no need to refresh just to classify).
     if (isExpiringSoon(ctx.expiresAt)) {
       ctx = await refreshEntityContext(companyRef, vaultConfig);
     }
 
-    // Check for local conflict
-    const journalEntry = getEntry(journal, remoteFile.key);
+    if (item.action === "conflict") {
+      conflicts++;
+      conflictPaths.push(remoteFile.key);
 
-    if (fs.existsSync(localPath)) {
-      const localHash = hashFile(localPath);
-      const localChanged = !!journalEntry && journalEntry.hash !== localHash;
-      const remoteChanged = !!journalEntry && hasRemoteChanged(remoteFile, journalEntry);
-
-      // A real conflict requires BOTH sides to have moved since the last
-      // sync. If only local changed, push will handle it; pulling here would
-      // clobber the local edit. If only remote changed, fall through to
-      // download. If neither moved, skip.
-      if (localChanged && remoteChanged) {
-        conflicts++;
-        conflictPaths.push(remoteFile.key);
-
-        const resolution = await resolveConflict(
-          {
-            path: remoteFile.key,
-            localHash,
-            remoteModified: remoteFile.lastModified,
-            localModified: fs.statSync(localPath).mtime,
-            direction: "pull",
-          },
-          onConflict,
-        );
-
-        emit({
-          type: "conflict",
+      const resolution = await resolveConflict(
+        {
           path: remoteFile.key,
+          localHash: item.localHash,
+          remoteModified: remoteFile.lastModified,
+          localModified: fs.statSync(localPath).mtime,
           direction: "pull",
-          resolution,
-        });
+        },
+        onConflict,
+      );
 
-        if (resolution === "abort") {
-          writeJournal(journalSlug, journal);
-          return {
-            filesDownloaded,
-            bytesDownloaded,
-            filesSkipped,
-            conflicts,
-            conflictPaths,
-            aborted: true,
-          };
-        }
-        if (resolution === "keep" || resolution === "skip") {
-          filesSkipped++;
-          continue;
-        }
-        // "overwrite" falls through to download
-      } else if (journalEntry && localChanged && !remoteChanged) {
-        // Local-only edit: leave it for the push phase to upload. Pulling
-        // would silently overwrite the user's work.
-        filesSkipped++;
-        continue;
-      } else if (journalEntry && !localChanged && !remoteChanged) {
-        // Neither side moved — nothing to do.
+      emit({
+        type: "conflict",
+        path: remoteFile.key,
+        direction: "pull",
+        resolution,
+      });
+
+      if (resolution === "abort") {
+        writeJournal(journalSlug, journal);
+        return {
+          filesDownloaded,
+          bytesDownloaded,
+          filesSkipped,
+          conflicts,
+          conflictPaths,
+          aborted: true,
+        };
+      }
+      if (resolution === "keep" || resolution === "skip") {
         filesSkipped++;
         continue;
       }
-      // Otherwise (no journal entry, or remote-only changed) fall through
-      // to download.
+      // "overwrite" falls through to download
     }
 
-    // Download
+    // Download (action === "download" or conflict resolved to "overwrite")
     try {
       await downloadFile(ctx, remoteFile.key, localPath);
 
@@ -216,8 +241,10 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
       // drift independently of mtime drift.
       updateEntry(journal, remoteFile.key, hash, stat.size, "down", remoteFile.etag);
 
-      // Attach message from journal entry if present
-      const remoteJournalMessage = (journalEntry as { message?: string } | undefined)?.message;
+      // Attach message from the prior journal entry if present (set by a
+      // previous `share` operation that included a --message).
+      const priorEntry = getEntry(journal, remoteFile.key);
+      const remoteJournalMessage = (priorEntry as { message?: string } | undefined)?.message;
       emit({
         type: "progress",
         path: remoteFile.key,
@@ -288,6 +315,124 @@ function hasRemoteChanged(
 }
 
 /**
+ * Stage-1 classification for a single remote object. Each remote file falls
+ * into exactly one bucket; the executor in `sync()` switches on `action` to
+ * decide what to do. `localHash` is carried on `conflict` items so the
+ * executor can hand it to `resolveConflict` without re-hashing.
+ */
+type PullPlanItem =
+  | { action: "download"; remoteFile: RemoteFile; localPath: string }
+  | { action: "skip-ignored"; remoteFile: RemoteFile; localPath: string }
+  | { action: "skip-personal-mode"; remoteFile: RemoteFile; localPath: string }
+  | { action: "skip-unchanged"; remoteFile: RemoteFile; localPath: string }
+  | { action: "skip-local-only"; remoteFile: RemoteFile; localPath: string }
+  | {
+      action: "conflict";
+      remoteFile: RemoteFile;
+      localPath: string;
+      localHash: string;
+    };
+
+interface PullPlan {
+  items: PullPlanItem[];
+  filesToDownload: number;
+  bytesToDownload: number;
+  filesToSkip: number;
+  filesToConflict: number;
+}
+
+/**
+ * Stage-1 planning pass: classify every remote file into download / skip /
+ * conflict buckets without performing any S3 transfers. Local hashes are
+ * computed here (not in the transfer loop) so the totals returned reflect
+ * the real outcome of the upcoming Stage-2 execution rather than an
+ * upper-bound guess.
+ *
+ * Pure function: no S3 calls, no journal writes, no event emission. The
+ * caller (`sync()`) is responsible for emitting the resulting plan event
+ * before iterating `items`.
+ */
+function computePullPlan(
+  remoteFiles: RemoteFile[],
+  journal: SyncJournal,
+  companyRoot: string,
+  shouldSync: (filePath: string) => boolean,
+  personalMode: boolean,
+): PullPlan {
+  const items: PullPlanItem[] = [];
+
+  for (const remoteFile of remoteFiles) {
+    const localPath = path.join(companyRoot, remoteFile.key);
+
+    if (personalMode && remoteFile.key.startsWith("companies/")) {
+      items.push({ action: "skip-personal-mode", remoteFile, localPath });
+      continue;
+    }
+
+    if (!shouldSync(localPath)) {
+      items.push({ action: "skip-ignored", remoteFile, localPath });
+      continue;
+    }
+
+    const journalEntry = getEntry(journal, remoteFile.key);
+
+    if (fs.existsSync(localPath)) {
+      const localHash = hashFile(localPath);
+      const localChanged = !!journalEntry && journalEntry.hash !== localHash;
+      const remoteChanged =
+        !!journalEntry && hasRemoteChanged(remoteFile, journalEntry);
+
+      // Mirror the original 3-way merge from the inline loop. Tested by
+      // `does NOT flag a pull conflict when only local changed since last
+      // sync` and `detects conflicts with local changes…`.
+      if (localChanged && remoteChanged) {
+        items.push({
+          action: "conflict",
+          remoteFile,
+          localPath,
+          localHash,
+        });
+        continue;
+      }
+      if (journalEntry && localChanged && !remoteChanged) {
+        items.push({ action: "skip-local-only", remoteFile, localPath });
+        continue;
+      }
+      if (journalEntry && !localChanged && !remoteChanged) {
+        items.push({ action: "skip-unchanged", remoteFile, localPath });
+        continue;
+      }
+      // No journal entry, or remote-only changed → fall through to download.
+    }
+
+    items.push({ action: "download", remoteFile, localPath });
+  }
+
+  let filesToDownload = 0;
+  let bytesToDownload = 0;
+  let filesToSkip = 0;
+  let filesToConflict = 0;
+  for (const item of items) {
+    if (item.action === "download") {
+      filesToDownload++;
+      bytesToDownload += item.remoteFile.size;
+    } else if (item.action === "conflict") {
+      filesToConflict++;
+    } else {
+      filesToSkip++;
+    }
+  }
+
+  return {
+    items,
+    filesToDownload,
+    bytesToDownload,
+    filesToSkip,
+    filesToConflict,
+  };
+}
+
+/**
  * Check if an error is an S3 access denied (expected for filtered guests).
  */
 function isAccessDenied(err: unknown): boolean {
@@ -303,7 +448,26 @@ function isAccessDenied(err: unknown): boolean {
  * without an `onEvent` see no behavioral change.
  */
 function defaultConsoleLogger(event: SyncProgressEvent): void {
-  if (event.type === "progress") {
+  if (event.type === "plan") {
+    // Terse single line so humans see what's about to happen without
+    // drowning the per-file output that follows. Skip when there's
+    // nothing to do — no signal, no noise.
+    const movement = event.filesToDownload + event.filesToUpload + event.filesToConflict;
+    if (movement > 0) {
+      const parts: string[] = [];
+      if (event.filesToDownload > 0) {
+        parts.push(`${event.filesToDownload} to download (${event.bytesToDownload} bytes)`);
+      }
+      if (event.filesToUpload > 0) {
+        parts.push(`${event.filesToUpload} to upload (${event.bytesToUpload} bytes)`);
+      }
+      if (event.filesToConflict > 0) {
+        parts.push(`${event.filesToConflict} conflict(s)`);
+      }
+      parts.push(`${event.filesToSkip} unchanged`);
+      console.log(`Plan: ${parts.join(", ")}`);
+    }
+  } else if (event.type === "progress") {
     if (event.message) {
       console.log(`  ✓ ${event.path} — "${event.message}"`);
     } else {


### PR DESCRIPTION
## Summary

- Adds a `plan` event to `SyncProgressEvent`, emitted once per direction (push/pull) before any per-file `progress` events. Carries `filesToDownload` / `bytesToDownload` / `filesToUpload` / `bytesToUpload` / `filesToSkip` / `filesToConflict`.
- Splits `sync()` and `share()` into a pure Stage-1 classification pass (`computePullPlan` / `computePushPlan`) and a Stage-2 execute loop. Behavior unchanged; the structural split lets us emit accurate totals up-front.
- Runner forwards `plan` events tagged with company slug. `tagAndEmit`'s former catch-all branch is now type-narrowed so a future event variant can't get silently mis-routed to the error channel.

## Why

The menubar's "Preparing sync…" pre-pass currently walks the HQ tree from Rust to compute a real progress denominator (see [hq-sync sync.rs:540-564](https://github.com/indigoai-us/hq-sync/blob/main/src-tauri/src/commands/sync.rs#L540)) — work that duplicates what the runner already classifies inline. Emitting a `plan` event lets the menubar drop that pre-pass and use authoritative numbers from the engine instead.

## Caveat — push-side conflict count

Pull-side `filesToConflict` is real (3-way merge against the journal happens in Stage 1). Push-side conflicts require a per-file `HeadObject` that today runs in Stage 2, so push plan events emit `filesToConflict: 0` and the authoritative count comes from the per-company `complete` event. V1.5 follow-up: replace the per-file HEAD with one paginated `ListObjectsV2` per company so push conflicts can be classified up-front too.

## Backwards compatibility

Purely additive on the protocol: existing event consumers don't see any change, and the `plan` event is optional from the consumer's perspective. The `--direction both` Sync Now flow now emits two plan events per company (push then pull); consumers should sum the non-zero fields to get total work.

## Test plan

- [x] Unit tests: 158 → 165 (+7 new — plan ordering, totals correctness, conflict counts, runner forwarding)
- [x] E2E tests: pass
- [x] Typecheck: clean
- [x] Lint: clean
- [ ] Coordinated PR in `indigoai-us/hq-sync` consumes the new event (PR-2)
- [ ] Manual verification with menubar after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)