### PR TITLE
release: hq-cloud@5.7.0 — Stage-1 plan event

### DIFF
--- a/packages/hq-cloud/package.json
+++ b/packages/hq-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cloud",
-  "version": "5.4.6",
+  "version": "5.7.0",
   "description": "HQ by Indigo cloud sync engine — bidirectional S3 sync for mobile access",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Cuts the release for [#103](https://github.com/indigoai-us/hq/pull/103) — `hq-sync-runner` now emits a `plan` event per company per direction (push/pull) before any per-file `progress` events. Consumers (hq-sync menubar) use the totals to render an accurate progress denominator before transfers begin.

## Version choice

Bumping to **5.7.0**, not 5.5.0 (taken by older monorepo-wide tags) and not 5.6.0/5.6.1 (taken by hq-cli releases). 5.7.0 is the next available `v*` tag.

## Trigger

Merge → tag `v5.7.0` → publish.yml fires → `@indigoai-us/hq-cloud@5.7.0` lands on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)