### PR TITLE
release: hq-cli@5.6.2 — fix vault URL paths

### DIFF
--- a/packages/hq-cli/package.json
+++ b/packages/hq-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cli",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "description": "HQ by Indigo management CLI — modules and cloud sync",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Bump for #105.