### PR TITLE
feat(hq-cli): default to Google IdP, skip Cognito Hosted UI

### DIFF
--- a/packages/hq-cli/src/utils/cognito-session.ts
+++ b/packages/hq-cli/src/utils/cognito-session.ts
@@ -38,6 +38,15 @@ export const DEFAULT_COGNITO: CognitoAuthConfig = {
   port: process.env.HQ_COGNITO_CALLBACK_PORT
     ? Number(process.env.HQ_COGNITO_CALLBACK_PORT)
     : 8765,
+  // Skip Cognito's Hosted UI — go straight to Google OAuth. The Cognito
+  // /oauth2/authorize endpoint honors `identity_provider` and performs an
+  // internal redirect, so the user never sees the (un-styleable) Hosted UI.
+  // Set HQ_COGNITO_IDENTITY_PROVIDER="" to fall back to the IdP picker for
+  // accounts that use email+password (admin-created users without Google).
+  identityProvider:
+    process.env.HQ_COGNITO_IDENTITY_PROVIDER !== undefined
+      ? process.env.HQ_COGNITO_IDENTITY_PROVIDER || undefined
+      : "Google",
 };
 
 export const DEFAULT_VAULT_API_URL =


### PR DESCRIPTION
Skips the Cognito Hosted UI by passing `identity_provider=Google` on /oauth2/authorize. Cognito performs internal redirect → Google OAuth. Escape hatch: `HQ_COGNITO_IDENTITY_PROVIDER=""` for email+password accounts.