### PR TITLE
release: hq-cli@5.6.3 — Google IdP default

### DIFF
--- a/packages/hq-cli/package.json
+++ b/packages/hq-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cli",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "description": "HQ by Indigo management CLI — modules and cloud sync",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Bump for #107.