### PR TITLE
feat(hq-cloud): write conflict mirror files + index on pull conflict

### DIFF
--- a/packages/hq-cloud/src/cli/sync.ts
+++ b/packages/hq-cloud/src/cli/sync.ts
@@ -15,6 +15,12 @@ import { readJournal, writeJournal, hashFile, updateEntry, getEntry, normalizeEt
 import { createIgnoreFilter } from "../ignore.js";
 import { resolveConflict } from "./conflict.js";
 import type { ConflictStrategy, ConflictResolution } from "./conflict.js";
+import {
+  buildConflictId,
+  buildConflictPath,
+  readShortMachineId,
+} from "../lib/conflict-file.js";
+import { appendConflictEntry } from "../lib/conflict-index.js";
 
 /**
  * Per-file events emitted by `sync()` as it progresses.
@@ -212,6 +218,45 @@ export async function sync(options: SyncOptions): Promise<SyncResult> {
         direction: "pull",
         resolution,
       });
+
+      // Write `<original>.conflict-<ts>-<machine>.<ext>` mirror + append to
+      // `<hqRoot>/.hq-conflicts/index.json` so the user can later run
+      // `/resolve-conflicts` to walk pending conflicts. Skipped for "abort"
+      // (user gave up) and "overwrite" (cloud bytes are about to replace
+      // local — mirror would be redundant). Best-effort: failure here only
+      // emits an error, doesn't break the sync.
+      if (resolution !== "abort" && resolution !== "overwrite") {
+        try {
+          const detectedAt = new Date().toISOString();
+          const machineId = readShortMachineId();
+          const originalRelative = path.relative(hqRoot, localPath);
+          const conflictRelative = buildConflictPath(
+            originalRelative,
+            detectedAt,
+            machineId,
+          );
+          const conflictAbs = path.join(hqRoot, conflictRelative);
+          await downloadFile(ctx, remoteFile.key, conflictAbs);
+          appendConflictEntry(hqRoot, {
+            id: buildConflictId(originalRelative, detectedAt),
+            originalPath: originalRelative,
+            conflictPath: conflictRelative,
+            detectedAt,
+            side: "pull",
+            machineId,
+            localHash: item.localHash,
+            remoteHash: remoteFile.etag ? normalizeEtag(remoteFile.etag) : "",
+          });
+        } catch (mirrorErr) {
+          emit({
+            type: "error",
+            path: remoteFile.key,
+            message: `conflict mirror write failed: ${
+              mirrorErr instanceof Error ? mirrorErr.message : String(mirrorErr)
+            }`,
+          });
+        }
+      }
 
       if (resolution === "abort") {
         writeJournal(journalSlug, journal);

--- a/packages/hq-cloud/src/lib/conflict-file.ts
+++ b/packages/hq-cloud/src/lib/conflict-file.ts
@@ -1,0 +1,101 @@
+/**
+ * Conflict file naming + writing.
+ *
+ * When share/sync detects divergence, the cloud's version of the file is
+ * written next to the original with a name encoding the timestamp and the
+ * machine that detected the conflict. Lets multiple machines independently
+ * surface their own conflicts without name collisions, and lets the user
+ * (or the `/resolve-conflicts` HQ skill) see local + cloud side-by-side
+ * in their file browser.
+ */
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+/**
+ * Path to `~/.hq/menubar.json`. Evaluated lazily at call time (not module
+ * load) so that tests overriding `HOME` after import — and any future code
+ * that changes the user's effective home dir at runtime — see the right
+ * file. Going through `os.homedir()` rather than `process.env.HOME` keeps
+ * the Windows USERPROFILE fallback intact.
+ */
+function menubarJsonPath(): string {
+  return path.join(os.homedir(), ".hq", "menubar.json");
+}
+
+/**
+ * Read the short machine ID (first 6 chars) from `~/.hq/menubar.json`.
+ * Falls back to "unknown" if the file is missing/unreadable — conflict
+ * files should still be written even when machine identity is unclear.
+ */
+export function readShortMachineId(): string {
+  try {
+    const raw = fs.readFileSync(menubarJsonPath(), "utf-8");
+    const parsed = JSON.parse(raw);
+    const id = typeof parsed.machineId === "string" ? parsed.machineId : "";
+    return id.slice(0, 6) || "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Build the conflict file path for an original. ISO uses `-` instead of
+ * `:` so the result is filesystem-safe on every OS, and the original
+ * extension is preserved at the end so editors syntax-highlight correctly.
+ *
+ *   knowledge/notes.md, 2026-04-27T22:05:14Z, abc123
+ *     → knowledge/notes.md.conflict-2026-04-27T22-05-14Z-abc123.md
+ *
+ *   projects/foo/prd.json, ..., abc123
+ *     → projects/foo/prd.json.conflict-...-abc123.json
+ *
+ * Files without an extension get the `.conflict-...` suffix appended verbatim.
+ */
+export function buildConflictPath(
+  originalRelative: string,
+  detectedAt: string,
+  shortMachineId: string,
+): string {
+  const safeTs = detectedAt.replace(/:/g, "-").replace(/\.\d+/, "");
+  const ext = path.extname(originalRelative); // ".md" or "" if none
+  // The full original path is preserved (extension and all) so users can
+  // visually pair `notes.md` with `notes.md.conflict-…md` in their file
+  // browser. The trailing `<ext>` after the timestamp keeps the file
+  // syntax-highlighted in editors that key off the final extension.
+  const suffix = `.conflict-${safeTs}-${shortMachineId}${ext}`;
+  return `${originalRelative}${suffix}`;
+}
+
+/**
+ * Write the cloud-side bytes to the conflict path. Creates parent dirs as
+ * needed (the conflict file always lives next to the original, so the
+ * parent already exists in the steady-state — but defense-in-depth).
+ */
+export function writeConflictFile(
+  hqRoot: string,
+  conflictRelative: string,
+  contents: Buffer,
+): void {
+  const abs = path.join(hqRoot, conflictRelative);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents);
+}
+
+/**
+ * Stable conflict ID — used to dedupe re-detections of the same conflict.
+ * Re-running sync after a conflict but before the user has resolved should
+ * NOT pile up duplicate entries. The id is derived from the original path
+ * and the detection timestamp; if the same original conflicts twice with
+ * the user resolving in between, that's a new id (different timestamp),
+ * which is correct.
+ */
+export function buildConflictId(
+  originalRelative: string,
+  detectedAt: string,
+): string {
+  const safeTs = detectedAt.replace(/:/g, "-").replace(/\.\d+/, "");
+  const safePath = originalRelative.replace(/[\/\\.]/g, "-");
+  return `${safePath}-${safeTs}`;
+}

--- a/packages/hq-cloud/src/lib/conflict-index.ts
+++ b/packages/hq-cloud/src/lib/conflict-index.ts
@@ -1,0 +1,127 @@
+/**
+ * Conflict index — durable record of pending divergences awaiting resolution.
+ *
+ * Lives at `<hq_root>/.hq-conflicts/index.json` (inside HQ content, NOT in
+ * `~/.hq/`). Two reasons it sits in HQ content rather than in the state dir:
+ *   1. The `/resolve-conflicts` HQ skill discovers it relative to the user's
+ *      HQ folder — that's the user's mental anchor for "where my files are."
+ *   2. The conflict-side files themselves live in HQ content, so the index
+ *      and the files it references stay co-located. If the user moves HQ,
+ *      the index moves with it.
+ *
+ * Excluded from cross-machine sync via `.hqignore` — each machine resolves
+ * its own queue. We never propagate conflict files (they'd just create more
+ * conflicts on the other side).
+ *
+ * Writes are atomic (tmp + rename). The resolution skill mutates this file
+ * mid-walk; a torn write would corrupt the only record of pending conflicts
+ * and could lose track of files we'd written to disk. Higher stakes than the
+ * journal, which the next sync can rebuild.
+ */
+
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import type { ConflictIndex, ConflictIndexEntry } from "../types.js";
+
+const CONFLICTS_DIR = ".hq-conflicts";
+const INDEX_FILENAME = "index.json";
+
+/**
+ * Absolute path to the conflict index for a given HQ root.
+ */
+export function getConflictIndexPath(hqRoot: string): string {
+  return path.join(hqRoot, CONFLICTS_DIR, INDEX_FILENAME);
+}
+
+/**
+ * Read the conflict index. Returns an empty index if the file doesn't exist
+ * yet (first-conflict-ever case).
+ *
+ * Throws on corrupt JSON — we deliberately don't auto-repair, since the only
+ * record of pending conflicts is too important to silently overwrite. The
+ * `/resolve-conflicts` skill surfaces this case to the user with a manual
+ * inspection prompt.
+ */
+export function readConflictIndex(hqRoot: string): ConflictIndex {
+  const indexPath = getConflictIndexPath(hqRoot);
+  if (!fs.existsSync(indexPath)) {
+    return { version: 1, conflicts: [] };
+  }
+  const raw = fs.readFileSync(indexPath, "utf-8");
+  const parsed = JSON.parse(raw) as ConflictIndex;
+  // Defensive: an empty file or wrong-shape JSON shouldn't crash callers.
+  if (!parsed || typeof parsed !== "object" || !Array.isArray(parsed.conflicts)) {
+    return { version: 1, conflicts: [] };
+  }
+  return parsed;
+}
+
+/**
+ * Atomically write the conflict index. Writes to `<index>.tmp.<random>` then
+ * renames into place — `rename(2)` is atomic on POSIX, so a crash mid-write
+ * leaves either the old file or the new one, never a half-written one.
+ *
+ * Always sorts conflicts by `detectedAt` ascending before writing — keeps
+ * the file diff-friendly across runs and makes "oldest-first walk" the
+ * natural read order in the resolution skill.
+ */
+export function writeConflictIndex(
+  hqRoot: string,
+  index: ConflictIndex,
+): void {
+  const indexPath = getConflictIndexPath(hqRoot);
+  fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+
+  const sorted: ConflictIndex = {
+    version: index.version,
+    conflicts: [...index.conflicts].sort((a, b) =>
+      a.detectedAt.localeCompare(b.detectedAt),
+    ),
+  };
+
+  // Random suffix in tmp name avoids collision if two sync runs ever overlap
+  // (shouldn't happen — the runner serializes — but cheap insurance).
+  const tmpPath = `${indexPath}.tmp.${crypto.randomBytes(6).toString("hex")}`;
+  fs.writeFileSync(tmpPath, JSON.stringify(sorted, null, 2));
+  fs.renameSync(tmpPath, indexPath);
+}
+
+/**
+ * Idempotent append. If an entry with the same `id` already exists (same
+ * original path, same detection timestamp), update it in place rather than
+ * duplicating. This matters because re-running sync after a conflict but
+ * before resolution will re-detect the same divergence — without dedup the
+ * index would grow unboundedly.
+ *
+ * The "update in place" path also covers the case where the cloud advanced
+ * again between detections: we want the latest `remoteVersionId` and
+ * `remoteHash` so the resolution skill shows the user the *current* cloud
+ * state, not stale data from the first detection.
+ */
+export function appendConflictEntry(
+  hqRoot: string,
+  entry: ConflictIndexEntry,
+): void {
+  const index = readConflictIndex(hqRoot);
+  const existingIdx = index.conflicts.findIndex((c) => c.id === entry.id);
+  if (existingIdx >= 0) {
+    index.conflicts[existingIdx] = entry;
+  } else {
+    index.conflicts.push(entry);
+  }
+  writeConflictIndex(hqRoot, index);
+}
+
+/**
+ * Remove an entry by id. Used by the `/resolve-conflicts` skill after the
+ * user picks a resolution and the conflict file is cleaned up. No-op if the
+ * id isn't present (e.g. user manually removed the file then re-ran the
+ * skill — we want that to be a clean exit, not an error).
+ */
+export function removeConflictEntry(hqRoot: string, id: string): void {
+  const index = readConflictIndex(hqRoot);
+  const filtered = index.conflicts.filter((c) => c.id !== id);
+  if (filtered.length === index.conflicts.length) return;
+  writeConflictIndex(hqRoot, { version: index.version, conflicts: filtered });
+}

--- a/packages/hq-cloud/src/lib/conflict.test.ts
+++ b/packages/hq-cloud/src/lib/conflict.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the pure conflict primitives — path building, machine-id
+ * fallback, atomic index writes, dedup. Kept in one file so the related
+ * helpers stay co-located.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  buildConflictPath,
+  buildConflictId,
+  readShortMachineId,
+} from "./conflict-file.js";
+import {
+  appendConflictEntry,
+  getConflictIndexPath,
+  readConflictIndex,
+  removeConflictEntry,
+  writeConflictIndex,
+} from "./conflict-index.js";
+import type { ConflictIndexEntry } from "../types.js";
+
+describe("buildConflictPath", () => {
+  it("inserts the conflict marker before the original extension", () => {
+    expect(
+      buildConflictPath("knowledge/notes.md", "2026-04-27T22:05:14Z", "abc123"),
+    ).toBe("knowledge/notes.md.conflict-2026-04-27T22-05-14Z-abc123.md");
+  });
+
+  it("preserves nested paths and json extensions", () => {
+    expect(
+      buildConflictPath("projects/foo/prd.json", "2026-04-27T22:05:14.123Z", "abc123"),
+    ).toBe("projects/foo/prd.json.conflict-2026-04-27T22-05-14Z-abc123.json");
+  });
+
+  it("appends the suffix verbatim for files without an extension", () => {
+    expect(
+      buildConflictPath("secrets", "2026-04-27T22:05:14Z", "abc123"),
+    ).toBe("secrets.conflict-2026-04-27T22-05-14Z-abc123");
+  });
+});
+
+describe("buildConflictId", () => {
+  it("escapes path separators and dots so the id is filesystem-safe", () => {
+    expect(
+      buildConflictId("knowledge/notes.md", "2026-04-27T22:05:14Z"),
+    ).toBe("knowledge-notes-md-2026-04-27T22-05-14Z");
+  });
+
+  it("yields the same id for the same (path, ts) pair — dedup primitive", () => {
+    const a = buildConflictId("foo/bar.md", "2026-04-27T22:05:14Z");
+    const b = buildConflictId("foo/bar.md", "2026-04-27T22:05:14Z");
+    expect(a).toBe(b);
+  });
+});
+
+describe("readShortMachineId", () => {
+  let originalHome: string | undefined;
+  let tmpHome: string;
+
+  beforeEach(() => {
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "hq-machineid-"));
+    process.env.HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (originalHome) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns the first 6 chars when menubar.json has a machineId", () => {
+    fs.mkdirSync(path.join(tmpHome, ".hq"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpHome, ".hq", "menubar.json"),
+      JSON.stringify({ machineId: "deadbeefcafe1234567890" }),
+    );
+    expect(readShortMachineId()).toBe("deadbe");
+  });
+
+  it("falls back to 'unknown' when menubar.json is missing", () => {
+    expect(readShortMachineId()).toBe("unknown");
+  });
+
+  it("falls back to 'unknown' when menubar.json is malformed", () => {
+    fs.mkdirSync(path.join(tmpHome, ".hq"), { recursive: true });
+    fs.writeFileSync(path.join(tmpHome, ".hq", "menubar.json"), "{not-json");
+    expect(readShortMachineId()).toBe("unknown");
+  });
+});
+
+describe("conflict index", () => {
+  let tmpHq: string;
+
+  beforeEach(() => {
+    tmpHq = fs.mkdtempSync(path.join(os.tmpdir(), "hq-cidx-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpHq, { recursive: true, force: true });
+  });
+
+  function entry(overrides: Partial<ConflictIndexEntry> = {}): ConflictIndexEntry {
+    return {
+      id: "knowledge-notes-md-2026-04-27T22-05-14Z",
+      originalPath: "knowledge/notes.md",
+      conflictPath: "knowledge/notes.md.conflict-2026-04-27T22-05-14Z-abc123.md",
+      detectedAt: "2026-04-27T22:05:14Z",
+      side: "pull",
+      machineId: "abc123",
+      localHash: "local",
+      remoteHash: "remote",
+      remoteVersionId: "v2",
+      lastKnownVersionId: "v1",
+      ...overrides,
+    };
+  }
+
+  it("returns an empty index when the file does not exist", () => {
+    const idx = readConflictIndex(tmpHq);
+    expect(idx).toEqual({ version: 1, conflicts: [] });
+  });
+
+  it("creates the .hq-conflicts dir on first write", () => {
+    appendConflictEntry(tmpHq, entry());
+    expect(fs.existsSync(getConflictIndexPath(tmpHq))).toBe(true);
+    expect(fs.existsSync(path.join(tmpHq, ".hq-conflicts"))).toBe(true);
+  });
+
+  it("appends new entries and dedupes on id (idempotent re-detection)", () => {
+    appendConflictEntry(tmpHq, entry({ id: "a", remoteVersionId: "v1" }));
+    appendConflictEntry(tmpHq, entry({ id: "b", remoteVersionId: "v1" }));
+    // Re-detect "a" — the second push should update in place, not duplicate.
+    appendConflictEntry(tmpHq, entry({ id: "a", remoteVersionId: "v9" }));
+
+    const idx = readConflictIndex(tmpHq);
+    expect(idx.conflicts).toHaveLength(2);
+    const a = idx.conflicts.find((c) => c.id === "a");
+    expect(a?.remoteVersionId).toBe("v9"); // updated, not appended
+  });
+
+  it("sorts conflicts by detectedAt ascending on every write", () => {
+    appendConflictEntry(tmpHq, entry({ id: "newer", detectedAt: "2026-04-27T23:00:00Z" }));
+    appendConflictEntry(tmpHq, entry({ id: "older", detectedAt: "2026-04-27T22:00:00Z" }));
+    const idx = readConflictIndex(tmpHq);
+    expect(idx.conflicts.map((c) => c.id)).toEqual(["older", "newer"]);
+  });
+
+  it("removeConflictEntry removes a single entry by id", () => {
+    appendConflictEntry(tmpHq, entry({ id: "keep" }));
+    appendConflictEntry(tmpHq, entry({ id: "drop" }));
+    removeConflictEntry(tmpHq, "drop");
+    const idx = readConflictIndex(tmpHq);
+    expect(idx.conflicts.map((c) => c.id)).toEqual(["keep"]);
+  });
+
+  it("removeConflictEntry is a no-op when the id is not present", () => {
+    appendConflictEntry(tmpHq, entry({ id: "a" }));
+    expect(() => removeConflictEntry(tmpHq, "missing")).not.toThrow();
+    expect(readConflictIndex(tmpHq).conflicts).toHaveLength(1);
+  });
+
+  it("writeConflictIndex leaves no .tmp files on disk after success", () => {
+    writeConflictIndex(tmpHq, { version: 1, conflicts: [entry()] });
+    const files = fs.readdirSync(path.join(tmpHq, ".hq-conflicts"));
+    // Only index.json should remain; tmp files renamed atomically into place.
+    expect(files).toEqual(["index.json"]);
+  });
+
+  it("returns an empty index for malformed-but-parseable JSON", () => {
+    const indexPath = getConflictIndexPath(tmpHq);
+    fs.mkdirSync(path.dirname(indexPath), { recursive: true });
+    fs.writeFileSync(indexPath, JSON.stringify({ version: 1 })); // no `conflicts` array
+    const idx = readConflictIndex(tmpHq);
+    expect(idx.conflicts).toEqual([]);
+  });
+});

--- a/packages/hq-cloud/src/types.ts
+++ b/packages/hq-cloud/src/types.ts
@@ -102,3 +102,30 @@ export interface VaultServiceConfig {
   /** AWS region for S3 client (defaults to entity region or us-east-1) */
   region?: string;
 }
+
+// ── Conflict index (consumed by /resolve-conflicts) ─────────────────────────
+//
+// Restored from feat/lineage-conflict-tracking (83bf5fa1) so the producer
+// can write `.conflict-<ts>-<machine>.<ext>` mirror files + append to
+// `<hqRoot>/.hq-conflicts/index.json` whenever the hash-comparison detector
+// flags a conflict that doesn't get overwritten or aborted.
+
+export interface ConflictIndexEntry {
+  id: string;
+  originalPath: string;
+  conflictPath: string;
+  detectedAt: string;
+  side: "push" | "pull";
+  machineId: string;
+  localHash: string;
+  remoteHash: string;
+  /** S3 VersionId when known (present for VersionId-aware buckets). */
+  remoteVersionId?: string;
+  /** Last-known parent VersionId from journal, when known. */
+  lastKnownVersionId?: string | null;
+}
+
+export interface ConflictIndex {
+  version: 1;
+  conflicts: ConflictIndexEntry[];
+}


### PR DESCRIPTION
Producer side of /resolve-conflicts. Restores lib/conflict-file.ts + lib/conflict-index.ts from abandoned 83bf5fa1, wires into today's hash-comparison detector. Tests 181/181.