### PR TITLE
release: hq-cloud@5.8.0 + hq-cli@5.7.0 — pre-vended entityContext + push --creds-from-stdin/--json

### DIFF
--- a/packages/hq-cli/package.json
+++ b/packages/hq-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cli",
-  "version": "5.6.3",
+  "version": "5.7.0",
   "description": "HQ by Indigo management CLI — modules and cloud sync",
   "main": "dist/index.js",
   "bin": {

--- a/packages/hq-cloud/package.json
+++ b/packages/hq-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cloud",
-  "version": "5.7.2",
+  "version": "5.8.0",
   "description": "HQ by Indigo cloud sync engine — bidirectional S3 sync for mobile access",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Releases the foundation for AppBar HQ Sync first-push consolidation (Option C3) — feat changes landed in #113.

- **hq-cloud@5.8.0** — \`share()\` accepts an optional pre-resolved \`EntityContext\` that bypasses internal STS vending (mutually exclusive with \`vaultConfig\`)
- **hq-cli@5.7.0** — \`hq sync push\` gains \`--creds-from-stdin\` and \`--json\` flags (subprocess contract for AppBar)

Backwards-compatible: existing CLI usage and existing share() callers see no change. Tag \`v5.8.0\` will trigger the publish workflow for both packages; \`create-hq\` is unchanged and will be skipped.

## Test plan
- [x] hq-cloud: 186 tests pass (181 original + 5 new entityContext)
- [x] hq-cli: 103 tests pass; smoke test confirms both new flags appear in \`--help\`
- [ ] After merge: push \`v5.8.0\` tag → publish workflow ships both packages to npm
- [ ] After publish: AppBar PR (indigoai-us/hq-sync#48) consumes the new flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)