### PR TITLE
fix(create-hq): restore smoke tests after template/ removal

### DIFF
--- a/packages/create-hq/test/container.test.ts
+++ b/packages/create-hq/test/container.test.ts
@@ -1,13 +1,14 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { execSync } from "child_process";
 import * as path from "path";
 import * as fs from "fs";
+import * as os from "os";
+import { fetchTemplate } from "../src/fetch-template.js";
 
 const TEST_DIR = path.resolve(__dirname);
 const REPO_ROOT = path.resolve(TEST_DIR, "../../..");
 const PKG_DIR = path.resolve(REPO_ROOT, "packages/create-hq");
 const DOCKER_DIR = path.join(TEST_DIR, "docker");
-const TEMPLATE_DIR = path.join(REPO_ROOT, "template");
 const SMOKE_SCRIPT = path.join(TEST_DIR, "smoke-test.sh");
 
 function exec(cmd: string, opts?: { cwd?: string; timeout?: number }): string {
@@ -37,15 +38,38 @@ function execSafe(
 }
 
 let tarballPath = "";
+let templateDir = "";
 
 describe("container smoke tests", () => {
-  beforeAll(() => {
+  beforeAll(async () => {
     // Build create-hq and pack tarball
     exec("npm run build", { cwd: PKG_DIR });
     const packOutput = exec("npm pack", { cwd: PKG_DIR }).trim();
     const tarballName = packOutput.split("\n").pop()!;
     tarballPath = path.join(PKG_DIR, tarballName);
     expect(fs.existsSync(tarballPath)).toBe(true);
+
+    // Fetch the hq-core scaffold to a host-side temp dir for `--local-template`.
+    // The repo's old `template/` subdirectory was removed when the scaffold was
+    // split into its own repo (indigoai-us/hq-core). Fetching once on the host
+    // lets blank-slate containers run without GitHub auth, and dogfoods the
+    // real fetchTemplate path that end users hit on `npx create-hq`.
+    templateDir = fs.mkdtempSync(path.join(os.tmpdir(), "create-hq-smoke-template-"));
+    await fetchTemplate(templateDir);
+
+    // Pre-flight regression guard: refuse to run smoke tests against an empty
+    // or malformed scaffold. Without this, a missing/empty template dir causes
+    // every `dir-exists:*` assertion inside the container to fail with the
+    // unhelpful "Assertion failed" message — exactly the silent regression
+    // that hit CI when `template/` was deleted.
+    expect(
+      fs.existsSync(path.join(templateDir, "core.yaml")),
+      "Fetched hq-core template missing core.yaml — fetchTemplate likely failed"
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(templateDir, ".claude", "CLAUDE.md")),
+      "Fetched hq-core template missing .claude/CLAUDE.md"
+    ).toBe(true);
 
     // Build Docker images (use cache)
     exec(
@@ -56,7 +80,7 @@ describe("container smoke tests", () => {
       `docker build -f ${DOCKER_DIR}/Dockerfile.pre-deps -t create-hq-test:pre-deps ${DOCKER_DIR}`,
       { timeout: 120_000 }
     );
-  }, 180_000); // 3 min for build + docker
+  }, 240_000); // 4 min: build + tarball fetch + docker
 
   it(
     "smoke-test.sh passes in blank-slate container",
@@ -64,7 +88,7 @@ describe("container smoke tests", () => {
       const { stdout, stderr, exitCode } = execSafe(
         `docker run --rm ` +
           `-v "${tarballPath}:/opt/create-hq/create-hq.tgz:ro" ` +
-          `-v "${TEMPLATE_DIR}:/opt/create-hq/template:ro" ` +
+          `-v "${templateDir}:/opt/create-hq/template:ro" ` +
           `-v "${SMOKE_SCRIPT}:/opt/create-hq/smoke-test.sh:ro" ` +
           `create-hq-test:blank bash /opt/create-hq/smoke-test.sh --image blank-slate`
       );
@@ -98,7 +122,7 @@ describe("container smoke tests", () => {
       const { stdout, stderr, exitCode } = execSafe(
         `docker run --rm ` +
           `-v "${tarballPath}:/opt/create-hq/create-hq.tgz:ro" ` +
-          `-v "${TEMPLATE_DIR}:/opt/create-hq/template:ro" ` +
+          `-v "${templateDir}:/opt/create-hq/template:ro" ` +
           `-v "${SMOKE_SCRIPT}:/opt/create-hq/smoke-test.sh:ro" ` +
           `create-hq-test:pre-deps bash /opt/create-hq/smoke-test.sh --image pre-deps`
       );
@@ -126,10 +150,13 @@ describe("container smoke tests", () => {
     120_000
   );
 
-  // Cleanup tarball after all tests
+  // Cleanup tarball + fetched template dir after all tests
   afterAll(() => {
     if (tarballPath && fs.existsSync(tarballPath)) {
       fs.unlinkSync(tarballPath);
+    }
+    if (templateDir && fs.existsSync(templateDir)) {
+      fs.rmSync(templateDir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/create-hq/test/run-smoke-tests.sh
+++ b/packages/create-hq/test/run-smoke-tests.sh
@@ -15,7 +15,10 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 PKG_DIR="$REPO_ROOT/packages/create-hq"
 DOCKER_DIR="$SCRIPT_DIR/docker"
 RESULTS_DIR="$SCRIPT_DIR/results"
-TEMPLATE_DIR="$REPO_ROOT/template"
+
+# Allow override (e.g. for offline runs against a checked-out hq-core).
+# Default: fetched fresh per-run from indigoai-us/hq-core (see Step 1.5 below).
+TEMPLATE_DIR="${TEMPLATE_DIR:-}"
 
 IMAGES=("blank-slate" "pre-deps")
 IMAGE_RESULTS=()
@@ -36,6 +39,45 @@ TARBALL_NAME=$(npm pack 2>&1 | tail -1)
 TARBALL_PATH="$PKG_DIR/$TARBALL_NAME"
 echo "Packed: $TARBALL_NAME"
 echo ""
+
+# --- Step 1.5: Fetch hq-core scaffold for --local-template ---
+# The repo's old `template/` subdirectory was removed when the scaffold was
+# split into its own repo (indigoai-us/hq-core). Mounting a non-existent path
+# silently produces an empty container-side dir, which is what was breaking
+# CI before this fix. Fetch a fresh hq-core tarball into a host-side temp
+# dir each run so smoke tests exercise the actual current scaffold layout.
+TEMPLATE_FETCHED=false
+if [ -z "$TEMPLATE_DIR" ]; then
+  echo "=== Step 1.5: Fetching hq-core scaffold ==="
+  TEMPLATE_DIR="$(mktemp -d -t create-hq-smoke-template.XXXXXX)"
+  TEMPLATE_FETCHED=true
+  TMP_TAR="$(mktemp -t hq-core-tarball.XXXXXX)"
+  if ! gh api repos/indigoai-us/hq-core/tarball/HEAD > "$TMP_TAR"; then
+    echo "FATAL: failed to fetch hq-core tarball via gh CLI (set GH_TOKEN or run 'gh auth login')."
+    rm -f "$TMP_TAR"
+    rm -rf "$TEMPLATE_DIR"
+    exit 1
+  fi
+  tar -xzf "$TMP_TAR" -C "$TEMPLATE_DIR" --strip-components=1
+  rm -f "$TMP_TAR"
+  echo "Fetched scaffold to: $TEMPLATE_DIR"
+  echo ""
+fi
+
+# Pre-flight regression guard. Refuse to run smoke tests against an empty or
+# malformed scaffold directory — that is the failure mode that caused the
+# CI red after `template/` was deleted but the test paths weren't updated.
+if [ ! -f "$TEMPLATE_DIR/core.yaml" ] || [ ! -f "$TEMPLATE_DIR/.claude/CLAUDE.md" ]; then
+  echo "FATAL: TEMPLATE_DIR=$TEMPLATE_DIR is missing core.yaml or .claude/CLAUDE.md."
+  echo "       Either fetchTemplate produced an empty scaffold, or the hq-core layout has changed."
+  [ "$TEMPLATE_FETCHED" = true ] && rm -rf "$TEMPLATE_DIR"
+  exit 1
+fi
+
+# Cleanup fetched template on exit (do not delete a user-supplied dir)
+if [ "$TEMPLATE_FETCHED" = true ]; then
+  trap 'rm -rf "$TEMPLATE_DIR"' EXIT
+fi
 
 # --- Step 2: Build Docker images ---
 echo "=== Step 2: Building Docker images ==="

--- a/packages/create-hq/test/smoke-test.sh
+++ b/packages/create-hq/test/smoke-test.sh
@@ -83,6 +83,16 @@ if [ ! -f "$TARBALL" ]; then
   exit 1
 fi
 
+# Pre-flight guard for the mounted template. Docker silently auto-creates an
+# empty dir at the mount point if the host path does not exist, which would
+# cause every dir-exists/file-exists assertion below to fail with the unhelpful
+# "Assertion failed" message. Catch the empty-mount case explicitly here.
+if [ ! -f "$TEMPLATE_DIR/core.yaml" ] || [ ! -f "$TEMPLATE_DIR/.claude/CLAUDE.md" ]; then
+  echo "FATAL: Mounted template at ${TEMPLATE_DIR} is missing core.yaml or .claude/CLAUDE.md."
+  echo "The orchestrator must mount a populated hq-core scaffold (see run-smoke-tests.sh Step 1.5)."
+  exit 1
+fi
+
 echo "Installing create-hq from local tarball (user-local)..."
 # Install locally to a temp dir — non-root can't install globally
 INSTALL_DIR="/tmp/create-hq-install"


### PR DESCRIPTION
## Summary

`Test create-hq` has been red on every PR since 2026-04-24 (#115 deleted the in-repo `template/` folder). Both `container.test.ts` and `run-smoke-tests.sh` were still mounting `<repo-root>/template/` into the container as `--local-template`, and Docker silently auto-creates an empty dir at the mount point when the host path doesn't exist — so create-hq copied nothing into the target dir and every `dir-exists:*` / `file-exists:*` assertion failed downstream. (Hence #117 had to be admin-merged around it.)

## What changed

- **`test/container.test.ts`** — `beforeAll` now fetches the canonical hq-core tarball into a host-side temp dir via `fetchTemplate(...)` and mounts that as `--local-template`. Dogfoods the same fetch path real users hit on `npx create-hq`. Adds named regression-guard assertions (`core.yaml`, `.claude/CLAUDE.md`) so a future broken fetch fails loudly in `beforeAll` instead of producing 10 cryptic in-container assertion failures. Bumps timeout 180s → 240s for the extra fetch.
- **`test/run-smoke-tests.sh`** — Same conceptual fix in bash for the local-runner path. New Step 1.5 fetches via `gh api repos/indigoai-us/hq-core/tarball/HEAD`, with `TEMPLATE_DIR` env override for offline runs against a checked-out hq-core. `trap` cleans up the fetched dir on exit.
- **`test/smoke-test.sh`** — Defense-in-depth: refuses to run create-hq if the mounted template at `/opt/create-hq/template/` is missing `core.yaml` or `.claude/CLAUDE.md`. Even if both host-side guards are bypassed, the container surfaces a named error rather than a cascade of `Assertion failed`.

Total: 87 insertions, 8 deletions across 3 files. No production code touched.

## Why fetch instead of restoring `template/`

Restoring an in-repo `template/` mirror would re-introduce the duplication that #115 deleted on purpose — `indigoai-us/hq-core` is the source of truth for the scaffold post-split. Fetching at test time means the smoke test exercises the *actual current* hq-core layout users will receive, and the test stays correct as hq-core evolves without manual sync.

## Verified locally

```
npm test -w packages/create-hq
  Test Files  9 passed (9)
       Tests  104 passed (104)
✓ test/container.test.ts > smoke-test.sh passes in blank-slate container 3407ms
✓ test/container.test.ts > smoke-test.sh passes in pre-deps container (happy path) 4331ms
```

## Test plan

- [ ] CI `Test create-hq` workflow passes on this PR (was red on every recent PR)
- [ ] Pre-deps container reports `passed: true` with `fail_count: 0`
- [ ] Blank-slate container reports `passed: true` (git assertions skipped, not failed)
- [ ] No new TS or eslint warnings
- [ ] Re-confirm CI doesn't admin-bypass for the next create-hq PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)