### PR TITLE
fix(ci): record pagefind cross-platform binaries in lockfile

### DIFF
--- a/apps/teams-docs/package.json
+++ b/apps/teams-docs/package.json
@@ -12,5 +12,12 @@
     "@astrojs/starlight": "^0.38.2",
     "astro": "^6.0.1",
     "sharp": "^0.34.2"
+  },
+  "optionalDependencies": {
+    "@pagefind/darwin-arm64": "1.4.0",
+    "@pagefind/darwin-x64": "1.4.0",
+    "@pagefind/linux-arm64": "1.4.0",
+    "@pagefind/linux-x64": "1.4.0",
+    "@pagefind/windows-x64": "1.4.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,13 @@
         "@astrojs/starlight": "^0.38.2",
         "astro": "^6.0.1",
         "sharp": "^0.34.2"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.4.0",
+        "@pagefind/darwin-x64": "1.4.0",
+        "@pagefind/linux-arm64": "1.4.0",
+        "@pagefind/linux-x64": "1.4.0",
+        "@pagefind/windows-x64": "1.4.0"
       }
     },
     "apps/teams-docs/node_modules/@astrojs/compiler": {
@@ -4933,9 +4940,61 @@
         "darwin"
       ]
     },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.4.0.tgz",
+      "integrity": "sha512-e7JPIS6L9/cJfow+/IAqknsGqEPjJnVXGjpGm25bnq+NPdoD3c/7fAwr1OXkG4Ocjx6ZGSCijXEV4ryMcH2E3A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
     "node_modules/@pagefind/default-ui": {
       "version": "1.4.0",
       "license": "MIT"
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.4.0.tgz",
+      "integrity": "sha512-PIt8dkqt4W06KGmQjONw7EZbhDF+uXI7i0XtRLN1vjCUxM9vGPdtJc2mUyVPevjomrGz5M86M8bqTr6cgDp1Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.4.0.tgz",
+      "integrity": "sha512-z4oddcWwQ0UHrTHR8psLnVlz6USGJ/eOlDPTDYZ4cI8TK8PgwRUPQZp9D2iJPNIPcS6Qx/E4TebjuGJOyK8Mmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.4.0.tgz",
+      "integrity": "sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@prisma/instrumentation": {
       "version": "7.6.0",
@@ -18247,7 +18306,7 @@
       }
     },
     "packages/create-hq": {
-      "version": "10.11.0",
+      "version": "10.12.0",
       "license": "MIT",
       "dependencies": {
         "@indigoai-us/hq-cloud": "^5.1.9",
@@ -19377,7 +19436,7 @@
     },
     "packages/hq-cli": {
       "name": "@indigoai-us/hq-cli",
-      "version": "5.5.2-sentry-rc.0",
+      "version": "5.8.5",
       "license": "MIT",
       "dependencies": {
         "@indigoai-us/hq-cloud": "^5.1.0",
@@ -19414,7 +19473,7 @@
     },
     "packages/hq-cloud": {
       "name": "@indigoai-us/hq-cloud",
-      "version": "5.1.9",
+      "version": "5.9.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-cognito-identity": "^3.700.0",


### PR DESCRIPTION
## Summary

CI's `build` job was red on every PR because `npm ci` on `ubuntu-latest` couldn't install `@pagefind/linux-x64` — the existing `package-lock.json` only recorded the macOS-host optional binary entries ([npm/cli#4828](https://github.com/npm/cli/issues/4828)). Astro/Starlight's pagefind step then failed at build:done with `Failed to install either of [pagefind_extended, pagefind]. Most likely the platform linux-x64 is not yet a supported architecture.`

Root cause is the lockfile, not pagefind — pagefind 1.4.0 ships `@pagefind/linux-x64` just fine.

**Fix:** declare the platform binaries as explicit `optionalDependencies` in [apps/teams-docs/package.json](apps/teams-docs/package.json) so npm records all platforms in the lockfile regardless of where `npm install` runs. Pinned to `1.4.0` to match the pagefind already resolved transitively via `@astrojs/starlight@^0.38.2`, keeping the lockfile diff surgical (65 lines vs ~11k from a full regen).

## Verification

Ran the full CI flow in a `linux/amd64` Node 22 Docker container (matching `ubuntu-latest`):

| Step | Result |
|------|--------|
| `npm ci` | green |
| `npm run lint` | 0 errors, 227 pre-existing warnings |
| `npm run build -w packages/hq-cloud` | green |
| `npm run build -w packages/hq-onboarding` | green |
| `npm run build --workspaces --if-present` | green (was failing) |
| `npm run typecheck --workspaces --if-present` | green |

Pagefind log on Linux: `[starlight:pagefind] Finished building search index in 161ms.`

## Test plan

- [x] Build `apps/teams-docs` succeeds on `ubuntu-latest`-equivalent (verified in linux/amd64 container)
- [x] Build `apps/teams-docs` still succeeds on macOS arm64 host
- [x] Lockfile diff scope contained to `@pagefind/*` entries + 3 stale internal-package version stamps that any `npm install` would correct
- [ ] CI's `build` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)