### PR TITLE
fix(hq-cloud): resolve auth token per-request to survive long syncs

### DIFF
--- a/packages/hq-cloud/package.json
+++ b/packages/hq-cloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indigoai-us/hq-cloud",
-  "version": "5.9.1",
+  "version": "5.10.0",
   "description": "HQ by Indigo cloud sync engine — bidirectional S3 sync for mobile access",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hq-cloud/src/bin/sync-runner.ts
+++ b/packages/hq-cloud/src/bin/sync-runner.ts
@@ -459,12 +459,20 @@ export async function runRunner(
   }
 
   // ---- auth -------------------------------------------------------------
-  let accessToken: string;
+  // Resolve the access token up-front to surface auth-error early (before any
+  // protocol events). Long-running multi-company syncs can outlast Cognito's
+  // 60-min access token TTL, so the vaultConfig captures a *getter* — every
+  // vault request resolves the latest token via getValidAccessToken, which
+  // re-reads `~/.hq/cognito-tokens.json` and refreshes on demand. Without
+  // this, a captured string goes stale mid-fanout (e.g. personal sync runs
+  // last → STS expires after 13 min → refreshEntityContext → fetchEntity →
+  // 401 against API Gateway's JWT authorizer because the captured token
+  // expired while the menubar was happily rotating the on-disk token).
+  const getAccessToken =
+    deps.getAccessToken ??
+    (() => getValidAccessToken(DEFAULT_COGNITO, { interactive: false }));
   try {
-    const getAccessToken =
-      deps.getAccessToken ??
-      (() => getValidAccessToken(DEFAULT_COGNITO, { interactive: false }));
-    accessToken = await getAccessToken();
+    await getAccessToken();
   } catch (err) {
     emit({
       type: "auth-error",
@@ -476,7 +484,7 @@ export async function runRunner(
   // ---- vault client -----------------------------------------------------
   const vaultConfig: VaultServiceConfig = {
     apiUrl: DEFAULT_VAULT_API_URL,
-    authToken: accessToken,
+    authToken: getAccessToken,
     region: DEFAULT_COGNITO.region,
   };
   const client =

--- a/packages/hq-cloud/src/context.test.ts
+++ b/packages/hq-cloud/src/context.test.ts
@@ -303,3 +303,84 @@ describe("isExpiringSoon", () => {
     expect(isExpiringSoon(past)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Refreshable authToken getter
+//
+// Regression for the personal-sync 401: a long-running `hq-sync-runner` run
+// captures vaultConfig.authToken as a string at startup, then `refreshEntityContext`
+// fires ~13 min into the personal-company sync (STS expiry) and uses that
+// stale string against API Gateway's JWT authorizer → 401. The getter form
+// lets every fetchEntity / postVend call resolve the latest token from disk.
+// ---------------------------------------------------------------------------
+
+describe("authToken getter is invoked per-request (regression: personal-sync 401)", () => {
+  beforeEach(() => {
+    clearContextCache();
+    vi.restoreAllMocks();
+  });
+
+  it("calls the getter on entity fetch AND on vend (every request)", async () => {
+    setupFetchMock();
+    const getter = vi.fn(async () => "fresh-token");
+
+    await resolveEntityContext("cmp_01ABCDEF", {
+      apiUrl: "https://vault-api.test",
+      authToken: getter,
+    });
+
+    // Two upstream requests: fetchEntity (UID looks like a UID) + postVend.
+    expect(getter).toHaveBeenCalledTimes(2);
+  });
+
+  it("picks up a rotated token between resolveEntityContext and refreshEntityContext", async () => {
+    const fetchMock = setupFetchMock();
+    let current = "stale-token";
+    const cfg = {
+      apiUrl: "https://vault-api.test",
+      authToken: async () => current,
+    };
+
+    await resolveEntityContext("cmp_01ABCDEF", cfg);
+
+    // fetchEntity + vend during initial resolution — both used "stale-token"
+    const initialAuth = (fetchMock.mock.calls as [string, RequestInit][]).map(
+      ([, init]) =>
+        (init.headers as Record<string, string>).Authorization,
+    );
+    expect(initialAuth.every((a) => a === "Bearer stale-token")).toBe(true);
+
+    // Simulate the on-disk token rotating mid-flight.
+    current = "fresh-token";
+
+    await refreshEntityContext("cmp_01ABCDEF", cfg);
+
+    // The post-refresh calls must use the new token. Without the per-request
+    // getter, refreshEntityContext would still send "Bearer stale-token" and
+    // 401 against the gateway.
+    const allCalls = fetchMock.mock.calls as [string, RequestInit][];
+    const postRefreshCalls = allCalls.slice(initialAuth.length);
+    expect(postRefreshCalls.length).toBeGreaterThan(0);
+    for (const [, init] of postRefreshCalls) {
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer fresh-token",
+      );
+    }
+  });
+
+  it("static-string authToken still works (back-compat)", async () => {
+    const fetchMock = setupFetchMock();
+    await resolveEntityContext("cmp_01ABCDEF", {
+      apiUrl: "https://vault-api.test",
+      authToken: "static-token",
+    });
+
+    const calls = fetchMock.mock.calls as [string, RequestInit][];
+    expect(calls.length).toBeGreaterThan(0);
+    for (const [, init] of calls) {
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer static-token",
+      );
+    }
+  });
+});

--- a/packages/hq-cloud/src/context.ts
+++ b/packages/hq-cloud/src/context.ts
@@ -138,12 +138,25 @@ interface VendResponse {
   expiresAt: string;
 }
 
+/**
+ * Resolve the current bearer token from a VaultServiceConfig. Accepts either
+ * a static string (back-compat with short-lived tools) or an async getter
+ * (long-running callers like `hq-sync-runner` pass `() => getValidAccessToken(...)`
+ * so each request picks up token refreshes that landed in
+ * `~/.hq/cognito-tokens.json` since the run started).
+ */
+async function resolveAuthToken(config: VaultServiceConfig): Promise<string> {
+  return typeof config.authToken === "function"
+    ? config.authToken()
+    : config.authToken;
+}
+
 async function fetchEntity(
   uid: string,
   config: VaultServiceConfig,
 ): Promise<EntityResponse> {
   const res = await fetch(`${config.apiUrl}/entity/${uid}`, {
-    headers: { Authorization: `Bearer ${config.authToken}` },
+    headers: { Authorization: `Bearer ${await resolveAuthToken(config)}` },
   });
   if (!res.ok) {
     const body = await res.text();
@@ -159,7 +172,7 @@ async function fetchEntityBySlug(
   config: VaultServiceConfig,
 ): Promise<EntityResponse> {
   const res = await fetch(`${config.apiUrl}/entity/by-slug/${type}/${slug}`, {
-    headers: { Authorization: `Bearer ${config.authToken}` },
+    headers: { Authorization: `Bearer ${await resolveAuthToken(config)}` },
   });
   if (!res.ok) {
     const body = await res.text();
@@ -180,7 +193,7 @@ async function postVend(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${config.authToken}`,
+      Authorization: `Bearer ${await resolveAuthToken(config)}`,
     },
     body: JSON.stringify({ ...body, durationSeconds: DEFAULT_SESSION_DURATION_SECONDS }),
   });

--- a/packages/hq-cloud/src/types.ts
+++ b/packages/hq-cloud/src/types.ts
@@ -97,8 +97,17 @@ export interface VaultCredentials {
 export interface VaultServiceConfig {
   /** Vault API base URL (e.g. https://vault-api.example.com) */
   apiUrl: string;
-  /** Cognito JWT token for authentication */
-  authToken: string;
+  /**
+   * Cognito JWT token for authentication. Either a static string OR an async
+   * getter that returns the current token on every call. Long-running consumers
+   * (e.g. `hq-sync-runner`'s multi-company fanout) MUST pass a getter — a
+   * captured string can outlive the 60-min Cognito access token TTL, which
+   * causes mid-flight `refreshEntityContext` calls to 401 against
+   * API Gateway's JWT authorizer even though `~/.hq/cognito-tokens.json` was
+   * refreshed under them by another process (e.g. the menubar). The getter
+   * lets every request resolve the latest token via `getValidAccessToken`.
+   */
+  authToken: string | (() => string | Promise<string>);
   /** AWS region for S3 client (defaults to entity region or us-east-1) */
   region?: string;
 }

--- a/packages/hq-cloud/src/vault-client.test.ts
+++ b/packages/hq-cloud/src/vault-client.test.ts
@@ -693,3 +693,97 @@ describe("VaultClient identity bootstrap", () => {
     expect(JSON.parse(init.body as string)).toEqual({ personUid: "prs_x" });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Refreshable authToken getter
+//
+// Regression for the personal-sync 401: a captured `authToken` string can
+// outlive Cognito's 60-min access token TTL during long multi-company
+// fanouts, causing mid-flight `refreshEntityContext` calls to 401. The
+// getter form lets every request resolve the latest token from disk.
+// ---------------------------------------------------------------------------
+
+describe("authToken getter (refreshable token)", () => {
+  // Response bodies can only be read once, so each mock call needs a fresh
+  // Response. Using mockImplementation (not mockResolvedValue) ensures a new
+  // Response instance per request — same pattern as the retry tests above.
+  function alwaysOk(body: unknown): void {
+    fetchSpy.mockImplementation(() =>
+      Promise.resolve(jsonResponse(200, body)),
+    );
+  }
+
+  it("calls the getter on every request", async () => {
+    const getter = vi.fn(async () => "first-token");
+    const c = new VaultClient({
+      apiUrl: "https://vault.test.example.com",
+      authToken: getter,
+    });
+
+    alwaysOk({ members: [] });
+
+    await c.listMembersOfCompany("cmp_abc");
+    await c.listMembersOfCompany("cmp_abc");
+    await c.listMembersOfCompany("cmp_abc");
+
+    expect(getter).toHaveBeenCalledTimes(3);
+  });
+
+  it("picks up a rotated token without recreating the client", async () => {
+    let current = "stale-token";
+    const c = new VaultClient({
+      apiUrl: "https://vault.test.example.com",
+      authToken: async () => current,
+    });
+
+    alwaysOk({ members: [] });
+
+    await c.listMembersOfCompany("cmp_abc");
+    const [, firstInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((firstInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer stale-token",
+    );
+
+    // Simulate the menubar refreshing ~/.hq/cognito-tokens.json mid-flight.
+    current = "fresh-token";
+
+    await c.listMembersOfCompany("cmp_abc");
+    const [, secondInit] = fetchSpy.mock.calls[1] as [string, RequestInit];
+    expect((secondInit.headers as Record<string, string>).Authorization).toBe(
+      "Bearer fresh-token",
+    );
+  });
+
+  it("supports a sync getter (returns plain string, not a promise)", async () => {
+    const c = new VaultClient({
+      apiUrl: "https://vault.test.example.com",
+      authToken: () => "sync-token",
+    });
+
+    alwaysOk({ members: [] });
+    await c.listMembersOfCompany("cmp_abc");
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer sync-token",
+    );
+  });
+
+  it("static-string authToken still works (back-compat)", async () => {
+    const c = new VaultClient({
+      apiUrl: "https://vault.test.example.com",
+      authToken: "static-token",
+    });
+
+    alwaysOk({ members: [] });
+    await c.listMembersOfCompany("cmp_abc");
+    await c.listMembersOfCompany("cmp_abc");
+
+    const calls = fetchSpy.mock.calls as [string, RequestInit][];
+    for (const [, init] of calls) {
+      expect((init.headers as Record<string, string>).Authorization).toBe(
+        "Bearer static-token",
+      );
+    }
+  });
+});

--- a/packages/hq-cloud/src/vault-client.ts
+++ b/packages/hq-cloud/src/vault-client.ts
@@ -212,11 +212,21 @@ async function sleep(ms: number): Promise<void> {
 
 export class VaultClient {
   private readonly apiUrl: string;
-  private readonly authToken: string;
+  private readonly getAuthToken: () => Promise<string>;
 
   constructor(config: VaultServiceConfig) {
     this.apiUrl = config.apiUrl.replace(/\/+$/, "");
-    this.authToken = config.authToken;
+    // Normalize string|getter into a single async getter so the request path
+    // doesn't have to branch. Static strings still work — they just produce a
+    // getter that returns the same value forever (suitable for short-lived
+    // tools and tests). Long-running callers pass a getter that re-reads
+    // `~/.hq/cognito-tokens.json` via `getValidAccessToken`, which is what
+    // makes the request layer self-heal across token refreshes.
+    const tok = config.authToken;
+    this.getAuthToken =
+      typeof tok === "function"
+        ? async () => tok()
+        : async () => tok;
   }
 
   // -- Membership operations ------------------------------------------------
@@ -436,7 +446,7 @@ export class VaultClient {
       }
 
       const headers: Record<string, string> = {
-        Authorization: `Bearer ${this.authToken}`,
+        Authorization: `Bearer ${await this.getAuthToken()}`,
         Accept: "application/json",
       };
 


### PR DESCRIPTION
## Summary

Personal-company sync was 401'ing on entity fetch after thousands of files had already landed on disk. Root cause: `vaultConfig.authToken` was a static string captured once at sync-runner startup; multi-company fanouts can outlast Cognito's 60-min access token TTL, so by the time `refreshEntityContext` fires inside personal sync (STS expiring ~13 min in), the captured bearer token is dead and API Gateway 401s — even though `~/.hq/cognito-tokens.json` got refreshed under us by the menubar.

**Not a person-vs-company scope mismatch.** Verified directly:
- `hq-pro/src/vault-service/handlers/entity.ts:425-433` calls `repo.getEntity(uid)` with no membership filter and cannot return 401.
- `hq-pro/infra/vault-service.ts:135` sets `audiences: [userPoolClient.id]` with no per-route `authorizationScopes`.
- All three Cognito app clients share `["openid", "email", "profile"]`.

The 401 comes exclusively from API Gateway's JWT authorizer rejecting an expired token.

## Fix

Extend `VaultServiceConfig.authToken` to accept either a static string (back-compat) or an async getter. `VaultClient` and `context.ts` helpers normalize to an async getter and resolve the current token on every request. `bin/sync-runner.ts` passes `getValidAccessToken` directly so each fetch picks up token rotations that landed on disk during the run.

- 5.9.0 → **5.10.0** (additive API surface — minor bump)
- Workspace typecheck clean across all 7 packages
- 7 regression tests across `vault-client.test.ts` and `context.test.ts`
- `hq-cli` and `hq-onboarding` unchanged (back-compat preserved)

Per `prefer-systemic-fix-over-user-bandaid`: no env override / "ask user to re-login" workaround. Anyone on 5.10.0+ self-heals across token boundaries.

## Test plan

- [x] `bun run test` in `packages/hq-cloud` (203/203 passing)
- [x] `npm run typecheck --workspaces` (all 7 packages clean)
- [ ] Manual: run `hq sync` against a tree with 12 companies + a `personal` company; verify personal sync completes past the 13-min STS-refresh boundary
- [ ] Manual: confirm regression test `picks up a rotated token between resolveEntityContext and refreshEntityContext` covers the exact failure mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)