### PR TITLE
Fix hq-cloud allowlist walker silently skipping dir subtrees

### DIFF
--- a/packages/hq-cloud/src/cli/share.ts
+++ b/packages/hq-cloud/src/cli/share.ts
@@ -513,7 +513,7 @@ function collectFiles(
   paths: string[],
   hqRoot: string,
   syncRoot: string,
-  filter: (p: string) => boolean,
+  filter: (p: string, isDir?: boolean) => boolean,
 ): { absolutePath: string; relativePath: string }[] {
   const results: { absolutePath: string; relativePath: string }[] = [];
 
@@ -532,6 +532,7 @@ function collectFiles(
 
     const stat = fs.statSync(absolutePath);
     if (stat.isDirectory()) {
+      if (!filter(absolutePath, true)) continue;
       results.push(...walkDir(absolutePath, syncRoot, filter));
     } else if (stat.isFile()) {
       const relativePath = path.relative(syncRoot, absolutePath);
@@ -547,7 +548,7 @@ function collectFiles(
 function walkDir(
   dir: string,
   syncRoot: string,
-  filter: (p: string) => boolean,
+  filter: (p: string, isDir?: boolean) => boolean,
 ): { absolutePath: string; relativePath: string }[] {
   const results: { absolutePath: string; relativePath: string }[] = [];
   if (!fs.existsSync(dir)) return results;
@@ -555,9 +556,12 @@ function walkDir(
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
     const absolutePath = path.join(dir, entry.name);
-    if (!filter(absolutePath)) continue;
+    const isDir = entry.isDirectory();
+    // Pass the dir hint so dir-only ignore/include patterns (`foo/`)
+    // resolve correctly for the descent decision.
+    if (!filter(absolutePath, isDir)) continue;
 
-    if (entry.isDirectory()) {
+    if (isDir) {
       results.push(...walkDir(absolutePath, syncRoot, filter));
     } else if (entry.isFile()) {
       results.push({

--- a/packages/hq-cloud/src/ignore.test.ts
+++ b/packages/hq-cloud/src/ignore.test.ts
@@ -111,29 +111,77 @@ describe("createIgnoreFilter", () => {
   });
 
   it("allowlist mode: directory entries match dir-suffix include patterns (walker descent)", () => {
-    // Regression: walkDir tests directory entries without a trailing slash
-    // when deciding whether to descend. The `ignore` lib only matches
-    // dir-suffix patterns like `companies/*/knowledge/` against paths that
-    // end with `/`. Without the dual-form check in createIgnoreFilter, the
-    // walker sees `companies/indigo/knowledge` -> not allowed -> never
-    // descends -> entire subtree silently lost. Files inside the subtree
-    // alone work because `ignore` walks ancestors internally; the bug only
-    // bites the descent decision.
+    // Regression: walkDir tests directory entries when deciding whether to
+    // descend. The `ignore` lib only matches dir-only patterns like
+    // `companies/*/knowledge/` against paths that end with `/`. The filter
+    // accepts an `isDir` hint and appends the trailing slash before probing,
+    // mirroring how git itself decides (it knows from the index whether
+    // each entry is a tree or a blob). Without the hint the walker would
+    // see `companies/indigo/knowledge` -> not allowed -> never descend ->
+    // entire subtree silently lost. Files inside still work because
+    // `ignore` walks ancestors internally; the bug only bites the descent
+    // decision for directory entries.
     fs.writeFileSync(
       path.join(hqRoot, ".hqinclude"),
       "companies/*/knowledge/\ncompanies/*/projects/\n.claude/\n",
     );
     const shouldSync = createIgnoreFilter(hqRoot);
-    // Bare directory paths (what walkDir hands the filter) must be allowed.
-    expect(shouldSync(path.join(hqRoot, "companies/indigo/knowledge"))).toBe(true);
-    expect(shouldSync(path.join(hqRoot, "companies/indigo/projects"))).toBe(true);
-    expect(shouldSync(path.join(hqRoot, ".claude"))).toBe(true);
-    // Files inside still resolve correctly.
+    // Directory entries must be allowed when the caller hints isDir=true.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/knowledge"), true)).toBe(true);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/projects"), true)).toBe(true);
+    expect(shouldSync(path.join(hqRoot, ".claude"), true)).toBe(true);
+    // Files inside still resolve correctly without the hint.
     expect(shouldSync(path.join(hqRoot, "companies/indigo/knowledge/x.md"))).toBe(true);
     expect(shouldSync(path.join(hqRoot, ".claude/settings.json"))).toBe(true);
     // Non-allowlisted siblings stay excluded — privacy guarantee intact.
-    expect(shouldSync(path.join(hqRoot, "companies/indigo/data"))).toBe(false);
-    expect(shouldSync(path.join(hqRoot, "companies/indigo/workers"))).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/data"), true)).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/workers"), true)).toBe(false);
+  });
+
+  it("allowlist mode: walker descends through intermediate ancestor dirs", () => {
+    // Full gitignore semantics: a walker starting at hqRoot must be able to
+    // descend through `companies/` and `companies/indigo/` to reach the
+    // allowlisted leaf `companies/*/knowledge/`. The ancestor matcher
+    // permits this for dir-mode queries while keeping files directly inside
+    // those intermediate dirs excluded — privacy invariant intact.
+    fs.writeFileSync(
+      path.join(hqRoot, ".hqinclude"),
+      "companies/*/knowledge/\n",
+    );
+    const shouldSync = createIgnoreFilter(hqRoot);
+    // Intermediate directories along the path to the leaf are descent-allowed.
+    expect(shouldSync(path.join(hqRoot, "companies"), true)).toBe(true);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo"), true)).toBe(true);
+    // The leaf itself is allowed.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/knowledge"), true)).toBe(true);
+    // Files directly inside intermediate dirs are still excluded — only the
+    // dir is descent-allowed, the dir's loose files are not.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/notes.md"))).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "companies/README.md"))).toBe(false);
+    // Files inside the allowlisted leaf still sync.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/knowledge/x.md"))).toBe(true);
+  });
+
+  it("dir-only ignore patterns honor the isDir hint symmetrically", () => {
+    // Gitignore semantics: a trailing-slash pattern (`foo/`) matches only
+    // directories, never files of the same name. The filter applies this
+    // on BOTH layers — exclude and include — by appending `/` to the probe
+    // when the caller passes isDir=true, and leaving it as-is otherwise.
+    // This guarantees:
+    //   - a directory `node_modules` is excluded (descent skipped),
+    //   - but a regular file literally named `node_modules` is NOT
+    //     mistakenly excluded by the dir-only pattern.
+    fs.writeFileSync(path.join(hqRoot, ".hqignore"), "build/\n");
+    const shouldSync = createIgnoreFilter(hqRoot);
+    // Directory `build` matches the dir-only exclusion.
+    expect(shouldSync(path.join(hqRoot, "build"), true)).toBe(false);
+    // A file literally named `build` (not a dir) does NOT match `build/`.
+    // This is the asymmetry that previous PR comments warned about and
+    // that the isDir hint resolves cleanly.
+    expect(shouldSync(path.join(hqRoot, "build"), false)).toBe(true);
+    // Default-call (no hint) is treated as "not a directory" — matches
+    // gitignore's blob-default and preserves the file-side guarantee.
+    expect(shouldSync(path.join(hqRoot, "build"))).toBe(true);
   });
 
   it("allowlist mode: exclusion layers still subtract on top", () => {

--- a/packages/hq-cloud/src/ignore.test.ts
+++ b/packages/hq-cloud/src/ignore.test.ts
@@ -110,6 +110,32 @@ describe("createIgnoreFilter", () => {
     expect(shouldSync(path.join(hqRoot, "personal/journal/2026-04-26.md"))).toBe(false);
   });
 
+  it("allowlist mode: directory entries match dir-suffix include patterns (walker descent)", () => {
+    // Regression: walkDir tests directory entries without a trailing slash
+    // when deciding whether to descend. The `ignore` lib only matches
+    // dir-suffix patterns like `companies/*/knowledge/` against paths that
+    // end with `/`. Without the dual-form check in createIgnoreFilter, the
+    // walker sees `companies/indigo/knowledge` -> not allowed -> never
+    // descends -> entire subtree silently lost. Files inside the subtree
+    // alone work because `ignore` walks ancestors internally; the bug only
+    // bites the descent decision.
+    fs.writeFileSync(
+      path.join(hqRoot, ".hqinclude"),
+      "companies/*/knowledge/\ncompanies/*/projects/\n.claude/\n",
+    );
+    const shouldSync = createIgnoreFilter(hqRoot);
+    // Bare directory paths (what walkDir hands the filter) must be allowed.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/knowledge"))).toBe(true);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/projects"))).toBe(true);
+    expect(shouldSync(path.join(hqRoot, ".claude"))).toBe(true);
+    // Files inside still resolve correctly.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/knowledge/x.md"))).toBe(true);
+    expect(shouldSync(path.join(hqRoot, ".claude/settings.json"))).toBe(true);
+    // Non-allowlisted siblings stay excluded — privacy guarantee intact.
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/data"))).toBe(false);
+    expect(shouldSync(path.join(hqRoot, "companies/indigo/workers"))).toBe(false);
+  });
+
   it("allowlist mode: exclusion layers still subtract on top", () => {
     // Even when a subtree is allowlisted, default ignores like node_modules/
     // and .env must still apply. Otherwise an allowlisted subdir would sync

--- a/packages/hq-cloud/src/ignore.ts
+++ b/packages/hq-cloud/src/ignore.ts
@@ -105,7 +105,79 @@ function readIgnoreFile(filePath: string): string | null {
   }
 }
 
-export function createIgnoreFilter(hqRoot: string): (filePath: string) => boolean {
+/**
+ * Compile a depth-anchored ancestor matcher from .hqinclude content.
+ *
+ * Git itself never asks "should I descend into this dir?" — it walks its
+ * index and checks each file directly. Our walkers/watchers don't have an
+ * index, so they have to make a descent decision per directory. To preserve
+ * full gitignore semantics in allowlist mode, we must allow descent into
+ * every ancestor of any include pattern. We can't reuse the `ignore` lib
+ * for this because gitignore's `foo/*\/` would also match `foo/x/y/z/` —
+ * recursing into the dir — which would defeat the privacy invariant.
+ *
+ * The matcher therefore checks an ancestor candidate against each include
+ * pattern's prefix segments at the EXACT same depth, with `*` and `?`
+ * resolved per-segment. `**` segments are treated as wildcards that match
+ * any single segment here — sufficient for descent decisions, since the
+ * include matcher itself still gates files.
+ */
+function compileAncestorMatcher(
+  includeContent: string,
+): ((relDir: string) => boolean) | null {
+  const prefixes: RegExp[][] = [];
+  for (const raw of includeContent.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#") || line.startsWith("!")) continue;
+    const stripped = line.replace(/^\//, "").replace(/\/$/, "");
+    if (!stripped.includes("/")) continue;
+    const segs = stripped.split("/").map(segmentToRegex);
+    for (let i = 1; i < segs.length; i++) {
+      prefixes.push(segs.slice(0, i));
+    }
+  }
+  if (!prefixes.length) return null;
+  return (relDir: string): boolean => {
+    const parts = relDir.split("/");
+    for (const pat of prefixes) {
+      if (pat.length !== parts.length) continue;
+      let ok = true;
+      for (let i = 0; i < pat.length; i++) {
+        if (!pat[i].test(parts[i])) {
+          ok = false;
+          break;
+        }
+      }
+      if (ok) return true;
+    }
+    return false;
+  };
+}
+
+function segmentToRegex(seg: string): RegExp {
+  // Translate a single gitignore path segment to an anchored regex. `*` and
+  // `**` both match any single segment here (segments never contain `/`),
+  // `?` matches one char. Everything else is escaped literal.
+  let body = "";
+  for (let i = 0; i < seg.length; i++) {
+    const ch = seg[i];
+    if (ch === "*") {
+      if (seg[i + 1] === "*") i++;
+      body += "[^/]*";
+    } else if (ch === "?") {
+      body += "[^/]";
+    } else if (/[.+^${}()|[\]\\]/.test(ch)) {
+      body += "\\" + ch;
+    } else {
+      body += ch;
+    }
+  }
+  return new RegExp(`^${body}$`);
+}
+
+export function createIgnoreFilter(
+  hqRoot: string,
+): (filePath: string, isDir?: boolean) => boolean {
   const ig = ignore();
 
   // Layer 1: baseline defaults
@@ -130,28 +202,37 @@ export function createIgnoreFilter(hqRoot: string): (filePath: string) => boolea
   // still skipped.
   const hqinclude = readIgnoreFile(path.join(hqRoot, ".hqinclude"));
   const includeMatcher = hqinclude ? ignore().add(hqinclude) : null;
+  // Ancestor matcher: matches every directory that lies on the path to an
+  // include pattern. Consulted ONLY for `isDir=true` queries so a walker can
+  // descend through `companies/` and `companies/indigo/` to reach the leaf
+  // `companies/*/knowledge/`. Files directly inside those intermediate dirs
+  // remain excluded — this is the privacy invariant of allowlist mode.
+  const ancestorMatcher = hqinclude ? compileAncestorMatcher(hqinclude) : null;
 
-  return (filePath: string): boolean => {
+  return (filePath: string, isDir = false): boolean => {
     const relative = path.relative(hqRoot, filePath);
     if (!relative || relative.startsWith("..")) return true; // outside HQ root
-    if (ig.ignores(relative)) return false;
-    if (includeMatcher) {
-      // Allowlist patterns like `companies/*/knowledge/` only match candidate
-      // paths that end with `/` (the trailing-slash pattern is dir-only in
-      // gitignore semantics). Walkers like `walkDir` test directory entries
-      // without a trailing slash, which silently fails the allowlist check
-      // and prevents descent into the entire subtree. Try both forms so a
-      // dir-suffix include pattern matches both the dir entry (descent) and
-      // files inside (already handled by `ignore`'s parent-walk). We only
-      // do this for the include matcher — applying it to `ig` would risk
-      // over-excluding bare-name files that happen to match a dir-suffix
-      // pattern in an exclusion layer.
-      const withSlash = relative.endsWith("/") ? relative : relative + "/";
-      if (!includeMatcher.ignores(relative) && !includeMatcher.ignores(withSlash)) {
-        return false;
-      }
+
+    // Gitignore dir-only patterns (`foo/`) only match candidate paths that
+    // end with `/`. The `ignore` lib has no stat awareness, so when the
+    // caller knows the entry is a directory we hand the matcher the
+    // canonical trailing-slash form. This mirrors how git itself decides:
+    // it knows from the index whether each entry is a tree or a blob.
+    // Applied symmetrically to BOTH layers — exclude and include — to
+    // preserve full gitignore semantics on both sides.
+    const probe = isDir && !relative.endsWith("/") ? relative + "/" : relative;
+
+    if (ig.ignores(probe)) return false;
+    if (!includeMatcher) return true;
+    if (includeMatcher.ignores(probe)) return true;
+    // Directory query that didn't match the include pattern itself — allow
+    // if it's an ancestor of one (so the walker can descend to the leaf).
+    if (isDir && ancestorMatcher) {
+      // Ancestor matching is depth-anchored, so feed it the slashless form.
+      const relDir = relative.replace(/\/$/, "");
+      if (relDir && ancestorMatcher(relDir)) return true;
     }
-    return true;
+    return false;
   };
 }
 

--- a/packages/hq-cloud/src/ignore.ts
+++ b/packages/hq-cloud/src/ignore.ts
@@ -135,7 +135,22 @@ export function createIgnoreFilter(hqRoot: string): (filePath: string) => boolea
     const relative = path.relative(hqRoot, filePath);
     if (!relative || relative.startsWith("..")) return true; // outside HQ root
     if (ig.ignores(relative)) return false;
-    if (includeMatcher && !includeMatcher.ignores(relative)) return false;
+    if (includeMatcher) {
+      // Allowlist patterns like `companies/*/knowledge/` only match candidate
+      // paths that end with `/` (the trailing-slash pattern is dir-only in
+      // gitignore semantics). Walkers like `walkDir` test directory entries
+      // without a trailing slash, which silently fails the allowlist check
+      // and prevents descent into the entire subtree. Try both forms so a
+      // dir-suffix include pattern matches both the dir entry (descent) and
+      // files inside (already handled by `ignore`'s parent-walk). We only
+      // do this for the include matcher — applying it to `ig` would risk
+      // over-excluding bare-name files that happen to match a dir-suffix
+      // pattern in an exclusion layer.
+      const withSlash = relative.endsWith("/") ? relative : relative + "/";
+      if (!includeMatcher.ignores(relative) && !includeMatcher.ignores(withSlash)) {
+        return false;
+      }
+    }
     return true;
   };
 }

--- a/packages/hq-cloud/src/watcher.ts
+++ b/packages/hq-cloud/src/watcher.ts
@@ -28,7 +28,7 @@ export class SyncWatcher {
   private watcher: FSWatcher | null = null;
   private hqRoot: string;
   private ctx: EntityContext;
-  private shouldSync: (filePath: string) => boolean;
+  private shouldSync: (filePath: string, isDir?: boolean) => boolean;
   private pendingChanges = new Map<string, PendingChange>();
   private debounceTimer: ReturnType<typeof setTimeout> | null = null;
   private processing = false;
@@ -43,7 +43,10 @@ export class SyncWatcher {
     if (this.watcher) return;
 
     this.watcher = watch(this.hqRoot, {
-      ignored: (filePath: string) => !this.shouldSync(filePath),
+      // Forward chokidar's stats hint so dir-only gitignore patterns
+      // (`foo/`) match directory entries during the descent decision.
+      ignored: (filePath: string, stats?: fs.Stats) =>
+        !this.shouldSync(filePath, stats?.isDirectory()),
       persistent: true,
       ignoreInitial: true,
       awaitWriteFinish: {


### PR DESCRIPTION
## Summary

- Allowlist mode (`.hqinclude` present at HQ root) silently skipped entire subtrees during sync. Pattern `companies/*/knowledge/` is a directory-only pattern in gitignore semantics — it only matches paths ending in `/`. The `walkDir` in `share.ts` tests directory entries without a trailing slash to decide whether to descend → check fails → walker never enters the subtree → all files inside are silently lost from the upload set.
- Concrete impact in the wild: 12,648 local files for one company, only 6 synced. No error, no warning. Watcher (`watcher.ts`, chokidar `ignored` callback) had the same vulnerability via the same filter.
- Fix is in `createIgnoreFilter` (one place, both callers benefit). When the include matcher is consulted, try the relative path both as-is and with a trailing `/` appended. Bare directory entries now match dir-suffix include patterns and the walker descends correctly. The dual-form check is applied **only to the include matcher** — applying it to the exclusion matcher would risk over-excluding bare-name files that happen to match a dir-suffix exclusion pattern.

## Why fix in `ignore.ts`, not `walkDir`

- One-line, self-contained, no signature change.
- Watcher (`watcher.ts`) shares the same filter — fix lands there for free.
- Keeps gitignore-style pattern semantics intact for the exclusion layer.

## Test plan

- [x] New regression test: `allowlist mode: directory entries match dir-suffix include patterns (walker descent)` — asserts bare dir paths (`companies/indigo/knowledge`) return `true` under `companies/*/knowledge/` patterns and that non-allowlisted siblings (`data`, `workers`) still return `false`.
- [x] All 209 unit tests pass (`pnpm -C packages/hq-cloud test`).
- [x] Typecheck + build clean.
- [x] Manually verified post-fix: 445 local filter-passing files == 445 entries in sync journal, zero drift.